### PR TITLE
Removing type name from hub method name

### DIFF
--- a/src/Microsoft.AspNetCore.SignalR/HubEndPoint.cs
+++ b/src/Microsoft.AspNetCore.SignalR/HubEndPoint.cs
@@ -168,7 +168,7 @@ namespace Microsoft.AspNetCore.SignalR
 
             foreach (var methodInfo in type.GetTypeInfo().DeclaredMethods.Where(m => IsHubMethod(m)))
             {
-                var methodName = type.FullName + "." + methodInfo.Name;
+                var methodName = methodInfo.Name;
 
                 if (_callbacks.ContainsKey(methodName))
                 {


### PR DESCRIPTION
Since we have 1:1 mapping between endpoints and hubs we should not need the fully qualified function name. The difference on the client is the following:

`client.invoke('Microsoft.AspNetCore.SignalR.Test.Server.TestHub.InvokeWithString', message)`
vs. 
`client.invoke('InvokeWithString', message)`

or 

`var result = await connection.Invoke<string>($"{typeof(TestHub).FullName}.Echo", originalMessage); `
vs.
`var result = await connection.Invoke<string>($"Echo", originalMessage); `

if we wanted we could just include simple type name (albeit it may get ugly for nested/generic types)

This will get test coverage when we merge https://github.com/aspnet/SignalR/pull/52 and https://github.com/aspnet/SignalR/pull/61