### PR TITLE
 #courage #prototype

### DIFF
--- a/src/Microsoft.AspNetCore.Sockets/ConnectionManager.cs
+++ b/src/Microsoft.AspNetCore.Sockets/ConnectionManager.cs
@@ -6,6 +6,7 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.IO.Pipelines;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Microsoft.AspNetCore.Sockets
 {
@@ -36,6 +37,10 @@ namespace Microsoft.AspNetCore.Sockets
             {
                 ConnectionId = id
             };
+
+            // TODO: Cancel if connection closed?
+            Task.Delay(5000).ContinueWith(_ => state.CanSend.TrySetResult(false));
+
             return state;
         }
 
@@ -88,10 +93,6 @@ namespace Microsoft.AspNetCore.Sockets
                     if (_connections.TryRemove(c.Key, out s))
                     {
                         s?.Close();
-                    }
-                    else
-                    {
-
                     }
                 }
             }

--- a/src/Microsoft.AspNetCore.Sockets/ConnectionState.cs
+++ b/src/Microsoft.AspNetCore.Sockets/ConnectionState.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Threading.Tasks;
 
 namespace Microsoft.AspNetCore.Sockets
 {
@@ -13,5 +14,7 @@ namespace Microsoft.AspNetCore.Sockets
         public Action Close { get; set; }
         public DateTimeOffset LastSeen { get; set; }
         public bool Active { get; set; } = true;
+        // This is for handling situation when send comes before poll or sse
+        public TaskCompletionSource<bool> CanSend { get; } = new TaskCompletionSource<bool>();
     }
 }


### PR DESCRIPTION
Fixing a bug where the server would throw if send request is received before the first poll or sse request (#57). We will now delay send until the first poll or sse is received or reject the send request if poll or sse not received within a timeout