### PR TITLE
Fixing Promise related compiler errors

### DIFF
--- a/src/Microsoft.AspNetCore.SignalR.Client.TS/Transports.ts
+++ b/src/Microsoft.AspNetCore.SignalR.Client.TS/Transports.ts
@@ -113,7 +113,7 @@ export class ServerSentEventsTransport implements ITransport {
     }
 
     send(data: any): Promise<void> {
-        return new HttpClient().post(this.url + "/send?" + this.queryString, data);
+        return new HttpClient().post(this.url + "/send?" + this.queryString, data).then(() => { });
     }
 
     stop(): void {
@@ -190,7 +190,7 @@ export class LongPollingTransport implements ITransport {
     }
 
     send(data: any): Promise<void> {
-        return new HttpClient().post(this.url + "/send?" + this.queryString, data);
+        return new HttpClient().post(this.url + "/send?" + this.queryString, data).then(() => { });
     }
 
     stop(): void {


### PR DESCRIPTION
We don't expect any content for `ITransport.send` methods so the `.ITransportsend` method just returns `Promise<void>`. However LongPolling and ServerSentEvents transport use the standard HttpClient to send send requests whose return type is `Promise<string>`. This causes:

error TS2322: Type `Promise<string>` is not assignable to type `Promise<void>`.