### PR TITLE
Fixing send/poll race

### DIFF
--- a/src/Microsoft.AspNetCore.SignalR.Common/InvocationMessage.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Common/InvocationMessage.cs
@@ -1,11 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
 namespace Microsoft.AspNetCore.SignalR
 {
     public abstract class InvocationMessage

--- a/src/Microsoft.AspNetCore.Sockets/ConnectionManager.cs
+++ b/src/Microsoft.AspNetCore.Sockets/ConnectionManager.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Concurrent;
-using System.Diagnostics;
 using System.IO.Pipelines;
 using System.Threading;
 
@@ -36,6 +35,7 @@ namespace Microsoft.AspNetCore.Sockets
             {
                 ConnectionId = id
             };
+
             return state;
         }
 
@@ -87,11 +87,8 @@ namespace Microsoft.AspNetCore.Sockets
                     ConnectionState s;
                     if (_connections.TryRemove(c.Key, out s))
                     {
-                        s?.Close();
-                    }
-                    else
-                    {
-
+                        s.CanSend.TrySetResult(false);
+                        s.Close?.Invoke();
                     }
                 }
             }

--- a/src/Microsoft.AspNetCore.Sockets/ConnectionState.cs
+++ b/src/Microsoft.AspNetCore.Sockets/ConnectionState.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Threading.Tasks;
 
 namespace Microsoft.AspNetCore.Sockets
 {
@@ -12,6 +13,8 @@ namespace Microsoft.AspNetCore.Sockets
         // These are used for long polling mostly
         public Action Close { get; set; }
         public DateTimeOffset LastSeen { get; set; }
-        public bool Active { get; set; } = true;
+        public bool Active { get; set; }
+        // This is for handling situations when send comes before poll or sse
+        public TaskCompletionSource<bool> CanSend { get; } = new TaskCompletionSource<bool>();
     }
 }

--- a/src/Microsoft.AspNetCore.Sockets/HttpConnectionDispatcher.cs
+++ b/src/Microsoft.AspNetCore.Sockets/HttpConnectionDispatcher.cs
@@ -191,7 +191,7 @@ namespace Microsoft.AspNetCore.Sockets
             return context.Response.Body.WriteAsync(connectionIdBuffer, 0, connectionIdBuffer.Length);
         }
 
-        private Task ProcessSend(HttpContext context)
+        private async Task ProcessSend(HttpContext context)
         {
             var connectionId = context.Request.Query["id"];
             if (StringValues.IsNullOrEmpty(connectionId))
@@ -202,16 +202,22 @@ namespace Microsoft.AspNetCore.Sockets
             ConnectionState state;
             if (_manager.TryGetConnection(connectionId, out state))
             {
+                // send received but the channel not established with poll or sse
+                // Wait for poll or sse or fail if channel not established within timeout
+                if (!await state.CanSend.Task)
+                {
+                    throw new InvalidOperationException("No channel");
+                }
                 // If we received an HTTP POST for the connection id and it's not an HttpChannel then fail.
                 // You can't write to a TCP channel directly from here.
                 var httpChannel = state.Connection.Channel as HttpConnection;
-
                 if (httpChannel == null)
                 {
                     throw new InvalidOperationException("No channel");
                 }
 
-                return context.Request.Body.CopyToAsync(httpChannel.Input);
+                await context.Request.Body.CopyToAsync(httpChannel.Input);
+                return;
             }
 
             throw new InvalidOperationException("Unknown connection id");
@@ -229,12 +235,13 @@ namespace Microsoft.AspNetCore.Sockets
             ConnectionState connectionState;
             isNewConnection = false;
 
-            // There's no connection id so this is a branch new connection
+            // There's no connection id so this is a brand new connection
             if (StringValues.IsNullOrEmpty(connectionId))
             {
                 isNewConnection = true;
                 var channel = new HttpConnection(_pipelineFactory);
                 connectionState = _manager.AddNewConnection(channel);
+                connectionState.CanSend.TrySetResult(true);
             }
             else
             {
@@ -253,6 +260,7 @@ namespace Microsoft.AspNetCore.Sockets
                     connectionState.Connection.Channel = new HttpConnection(_pipelineFactory);
                     connectionState.Active = true;
                     connectionState.LastSeen = DateTimeOffset.UtcNow;
+                    connectionState.CanSend.TrySetResult(true);
                 }
             }
 

--- a/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/HubConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/HubConnectionTests.cs
@@ -2,7 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.IO;
 using System.IO.Pipelines;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -10,6 +14,7 @@ using Microsoft.AspNetCore.Sockets.Client;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Moq;
 using Xunit;
 
 namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
@@ -46,8 +51,6 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
                 var transport = new LongPollingTransport(httpClient, loggerFactory);
                 using (var connection = await HubConnection.ConnectAsync(new Uri("http://test/hubs"), new JsonNetInvocationAdapter(), transport, httpClient, pipelineFactory, loggerFactory))
                 {
-                    //TODO: Get rid of this. This is to prevent "No channel" failures due to sends occuring before the first poll.
-                    await Task.Delay(500);
                     var result = await connection.Invoke<string>("HelloWorld");
 
                     Assert.Equal("Hello World!", result);
@@ -67,8 +70,6 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
                 var transport = new LongPollingTransport(httpClient, loggerFactory);
                 using (var connection = await HubConnection.ConnectAsync(new Uri("http://test/hubs"), new JsonNetInvocationAdapter(), transport, httpClient, pipelineFactory, loggerFactory))
                 {
-                    //TODO: Get rid of this. This is to prevent "No channel" failures due to sends occuring before the first poll.
-                    await Task.Delay(500);
                     var result = await connection.Invoke<string>("Echo", originalMessage);
 
                     Assert.Equal(originalMessage, result);
@@ -94,8 +95,6 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
                         tcs.TrySetResult((string)a[0]);
                     });
 
-                    //TODO: Get rid of this. This is to prevent "No channel" failures due to sends occuring before the first poll.
-                    await Task.Delay(500);
                     await connection.Invoke<Task>("CallEcho", originalMessage);
                     var completed = await Task.WhenAny(Task.Delay(2000), tcs.Task);
                     Assert.True(completed == tcs.Task, "Receive timed out!");
@@ -123,6 +122,74 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
 
                     Assert.Equal(ex.Message, "The hub method '!@#$%' could not be resolved.");
                 }
+            }
+        }
+
+        [Fact]
+        public async Task CanSendSendBeforePoll()
+        {
+            using (var httpClient = _testServer.CreateClient())
+            {
+                var resp = await httpClient.GetAsync("http://test/hubs/getid");
+                var connectionId = await resp.Content.ReadAsStringAsync();
+
+                var invocationAdapter = new JsonNetInvocationAdapter();
+                var request = new InvocationDescriptor
+                {
+                    Method = "Echo",
+                    Arguments = new object[] { "Hi" }
+                };
+
+                var stream = new MemoryStream();
+                await invocationAdapter.WriteMessageAsync(request, stream);
+                stream.Position = 0;
+
+                var sendTask = httpClient.PostAsync($"http://test/hubs/send?id={connectionId}",
+                    new StreamContent(stream));
+
+                await Task.Delay(100);
+                var pollTask = httpClient.PostAsync($"http://test/hubs/poll?id={connectionId}", null);
+                await Task.WhenAll(sendTask, pollTask);
+
+                var mockBinder = new Mock<IInvocationBinder>();
+                mockBinder.Setup(b => b.GetReturnType(It.IsAny<string>())).Returns(typeof(string));
+                var result = (InvocationResultDescriptor)await invocationAdapter.ReadMessageAsync(await pollTask.Result.Content.ReadAsStreamAsync(),
+                    mockBinder.Object, CancellationToken.None);
+
+                Assert.Null(result.Error);
+                Assert.Equal("Hi", result.Result);
+            }
+        }
+
+        [Fact]
+        public async Task PendingSendCancelledIfPollNotReceivedWithinTimeout()
+        {
+            using (var httpClient = _testServer.CreateClient())
+            {
+                var resp = await httpClient.GetAsync("http://test/hubs/getid");
+                var connectionId = await resp.Content.ReadAsStringAsync();
+
+                var invocationAdapter = new JsonNetInvocationAdapter();
+                var request = new InvocationDescriptor
+                {
+                    Method = "Echo",
+                    Arguments = new object[] { "Hi" }
+                };
+
+                var stream = new MemoryStream();
+                await invocationAdapter.WriteMessageAsync(request, stream);
+                stream.Position = 0;
+
+                var sendTask = httpClient.PostAsync($"http://test/hubs/send?id={connectionId}",
+                    new StreamContent(stream));
+
+                var timeoutTask = Task.Delay(10000);
+
+                var completedTask = await Task.WhenAny(sendTask, timeoutTask);
+                Assert.Same(sendTask, completedTask);
+                Assert.Equal(
+                    (await Assert.ThrowsAsync<InvalidOperationException>(async () => await sendTask)).Message,
+                    "No channel");
             }
         }
 

--- a/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/project.json
+++ b/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/project.json
@@ -12,7 +12,8 @@
     "Microsoft.AspNetCore.SignalR": "1.0.0-*",
     "Microsoft.AspNetCore.SignalR.Client": "1.0.0-*",
     "xunit": "2.2.0-*",
-    "Microsoft.AspNetCore.TestHost": "1.2.0-*"
+    "Microsoft.AspNetCore.TestHost": "1.2.0-*",
+    "Moq": "4.6.36-*"
   },
   "frameworks": {
     "netcoreapp1.1": {

--- a/test/Microsoft.AspNetCore.Sockets.Tests/ConnectionManagerTests.cs
+++ b/test/Microsoft.AspNetCore.Sockets.Tests/ConnectionManagerTests.cs
@@ -17,9 +17,10 @@ namespace Microsoft.AspNetCore.Sockets.Tests
 
             Assert.NotNull(state.Connection);
             Assert.NotNull(state.Connection.ConnectionId);
-            Assert.True(state.Active);
+            Assert.False(state.Active);
             Assert.Null(state.Close);
             Assert.Null(state.Connection.Channel);
+            Assert.NotNull(state.CanSend);
         }
 
         [Fact]


### PR DESCRIPTION
Fixing a bug where the server would throw if send request is received before the first poll or sse request (#57). We will now delay send until the first poll or sse is received or reject the send request if poll or sse not received within a timeout
Also making the connection not to be marked as Active upon reserving a connection. This enables cleaning up connections that were reserved but never used.