### PR TITLE
Use TryRead and TryWrite

### DIFF
--- a/src/Microsoft.AspNetCore.SignalR/HubEndPoint.cs
+++ b/src/Microsoft.AspNetCore.SignalR/HubEndPoint.cs
@@ -146,57 +146,55 @@ namespace Microsoft.AspNetCore.SignalR
             while (await connection.Transport.Input.WaitToReadAsync())
             {
                 Message message;
-                if (!connection.Transport.Input.TryRead(out message))
+                while (connection.Transport.Input.TryRead(out message))
                 {
-                    continue;
-                }
-
-                InvocationDescriptor invocationDescriptor;
-                using (message)
-                {
-                    var inputStream = new MemoryStream(message.Payload.Buffer.ToArray());
-
-                    // TODO: Handle receiving InvocationResultDescriptor
-                    invocationDescriptor = await invocationAdapter.ReadMessageAsync(inputStream, this) as InvocationDescriptor;
-                }
-
-                // Is there a better way of detecting that a connection was closed?
-                if (invocationDescriptor == null)
-                {
-                    break;
-                }
-
-                if (_logger.IsEnabled(LogLevel.Debug))
-                {
-                    _logger.LogDebug("Received hub invocation: {invocation}", invocationDescriptor);
-                }
-
-                InvocationResultDescriptor result;
-                Func<Connection, InvocationDescriptor, Task<InvocationResultDescriptor>> callback;
-                if (_callbacks.TryGetValue(invocationDescriptor.Method, out callback))
-                {
-                    result = await callback(connection, invocationDescriptor);
-                }
-                else
-                {
-                    // If there's no method then return a failed response for this request
-                    result = new InvocationResultDescriptor
+                    InvocationDescriptor invocationDescriptor;
+                    using (message)
                     {
-                        Id = invocationDescriptor.Id,
-                        Error = $"Unknown hub method '{invocationDescriptor.Method}'"
-                    };
+                        var inputStream = new MemoryStream(message.Payload.Buffer.ToArray());
 
-                    _logger.LogError("Unknown hub method '{method}'", invocationDescriptor.Method);
-                }
+                        // TODO: Handle receiving InvocationResultDescriptor
+                        invocationDescriptor = await invocationAdapter.ReadMessageAsync(inputStream, this) as InvocationDescriptor;
+                    }
 
-                // TODO: Pool memory
-                var outStream = new MemoryStream();
-                await invocationAdapter.WriteMessageAsync(result, outStream);
+                    // Is there a better way of detecting that a connection was closed?
+                    if (invocationDescriptor == null)
+                    {
+                        break;
+                    }
 
-                var buffer = ReadableBuffer.Create(outStream.ToArray()).Preserve();
-                if (await connection.Transport.Output.WaitToWriteAsync())
-                {
-                    connection.Transport.Output.TryWrite(new Message(buffer, connection.Metadata.Format, endOfMessage: true));
+                    if (_logger.IsEnabled(LogLevel.Debug))
+                    {
+                        _logger.LogDebug("Received hub invocation: {invocation}", invocationDescriptor);
+                    }
+
+                    InvocationResultDescriptor result;
+                    Func<Connection, InvocationDescriptor, Task<InvocationResultDescriptor>> callback;
+                    if (_callbacks.TryGetValue(invocationDescriptor.Method, out callback))
+                    {
+                        result = await callback(connection, invocationDescriptor);
+                    }
+                    else
+                    {
+                        // If there's no method then return a failed response for this request
+                        result = new InvocationResultDescriptor
+                        {
+                            Id = invocationDescriptor.Id,
+                            Error = $"Unknown hub method '{invocationDescriptor.Method}'"
+                        };
+
+                        _logger.LogError("Unknown hub method '{method}'", invocationDescriptor.Method);
+                    }
+
+                    // TODO: Pool memory
+                    var outStream = new MemoryStream();
+                    await invocationAdapter.WriteMessageAsync(result, outStream);
+
+                    var buffer = ReadableBuffer.Create(outStream.ToArray()).Preserve();
+                    if (await connection.Transport.Output.WaitToWriteAsync())
+                    {
+                        connection.Transport.Output.TryWrite(new Message(buffer, connection.Metadata.Format, endOfMessage: true));
+                    }
                 }
             }
         }

--- a/src/Microsoft.AspNetCore.Sockets/HttpConnectionDispatcher.cs
+++ b/src/Microsoft.AspNetCore.Sockets/HttpConnectionDispatcher.cs
@@ -226,9 +226,12 @@ namespace Microsoft.AspNetCore.Sockets
                     endOfMessage: true);
 
                 // REVIEW: Do we want to return a specific status code here if the connection has ended?
-                if (await state.Application.Output.WaitToWriteAsync())
+                while (await state.Application.Output.WaitToWriteAsync())
                 {
-                    state.Application.Output.TryWrite(message);
+                    if (state.Application.Output.TryWrite(message))
+                    {
+                        break;
+                    }
                 }
             }
             else

--- a/src/Microsoft.AspNetCore.Sockets/HttpConnectionDispatcher.cs
+++ b/src/Microsoft.AspNetCore.Sockets/HttpConnectionDispatcher.cs
@@ -225,8 +225,11 @@ namespace Microsoft.AspNetCore.Sockets
                     format,
                     endOfMessage: true);
 
-                await state.Application.Output.WriteAsync(message);
-
+                // REVIEW: Do we want to return a specific status code here if the connection has ended?
+                if (await state.Application.Output.WaitToWriteAsync())
+                {
+                    state.Application.Output.TryWrite(message);
+                }
             }
             else
             {

--- a/src/Microsoft.AspNetCore.Sockets/Transports/ServerSentEventsTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets/Transports/ServerSentEventsTransport.cs
@@ -33,7 +33,7 @@ namespace Microsoft.AspNetCore.Sockets.Transports
                 while (await _application.WaitToReadAsync(context.RequestAborted))
                 {
                     Message message;
-                    if (_application.TryRead(out message))
+                    while (_application.TryRead(out message))
                     {
                         using (message)
                         {

--- a/src/Microsoft.AspNetCore.Sockets/Transports/WebSocketsTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets/Transports/WebSocketsTransport.cs
@@ -156,7 +156,7 @@ namespace Microsoft.AspNetCore.Sockets.Transports
             {
                 // Get a frame from the application
                 Message message;
-                if (_application.Input.TryRead(out message))
+                while (_application.Input.TryRead(out message))
                 {
                     using (message)
                     {


### PR DESCRIPTION
- Use TryWrite to avoid errors on channel close for /send requests
- Use TryRead until it returns false for all transports but long polling