### PR TITLE
some clean-up and refactoring

### DIFF
--- a/src/Microsoft.AspNetCore.Sockets/Transports/IHttpTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets/Transports/IHttpTransport.cs
@@ -8,6 +8,8 @@ namespace Microsoft.AspNetCore.Sockets.Transports
 {
     public interface IHttpTransport
     {
+        string Name { get; }
+
         /// <summary>
         /// Executes the transport
         /// </summary>

--- a/src/Microsoft.AspNetCore.Sockets/Transports/WebSocketsTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets/Transports/WebSocketsTransport.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.Sockets.Transports
 {
     public class WebSocketsTransport : IHttpTransport
     {
-        public static readonly string Name = "webSockets";
+        public static readonly string TransportName = "webSockets";
 
         private static readonly TimeSpan _closeTimeout = TimeSpan.FromSeconds(5);
         private static readonly WebSocketAcceptContext _emptyContext = new WebSocketAcceptContext();
@@ -24,6 +24,8 @@ namespace Microsoft.AspNetCore.Sockets.Transports
 
         private readonly ILogger _logger;
         private readonly IChannelConnection<Message> _application;
+
+        public string Name { get; } = TransportName;
 
         public WebSocketsTransport(IChannelConnection<Message> application, ILoggerFactory loggerFactory)
         {

--- a/test/Microsoft.AspNetCore.Sockets.Tests/ConnectionManagerTests.cs
+++ b/test/Microsoft.AspNetCore.Sockets.Tests/ConnectionManagerTests.cs
@@ -13,7 +13,6 @@ namespace Microsoft.AspNetCore.Sockets.Tests
         [Fact]
         public void NewConnectionsHaveConnectionId()
         {
-
             var connectionManager = new ConnectionManager();
             var state = connectionManager.CreateConnection();
 

--- a/test/Microsoft.AspNetCore.Sockets.Tests/HttpConnectionDispatcherTests.cs
+++ b/test/Microsoft.AspNetCore.Sockets.Tests/HttpConnectionDispatcherTests.cs
@@ -1,17 +1,11 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Internal;
 using Microsoft.AspNetCore.Sockets.Internal;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Primitives;
+using Microsoft.AspNetCore.Sockets.Transports;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Sockets.Tests
@@ -21,21 +15,13 @@ namespace Microsoft.AspNetCore.Sockets.Tests
         [Fact]
         public async Task NegotiateReservesConnectionIdAndReturnsIt()
         {
-            var manager = new ConnectionManager();
-            var dispatcher = new HttpConnectionDispatcher(manager, new LoggerFactory());
-            var context = new DefaultHttpContext();
-            var services = new ServiceCollection();
-            services.AddSingleton<TestEndPoint>();
-            context.RequestServices = services.BuildServiceProvider();
-            var ms = new MemoryStream();
-            context.Request.Path = "/negotiate";
-            context.Response.Body = ms;
-            await dispatcher.ExecuteAsync<TestEndPoint>("", context);
+            var host = SocketsTestHost.CreateWithDefaultEndPoint();
+            var result = await host.ExecuteRequestAsync("/negotiate");
 
-            var id = Encoding.UTF8.GetString(ms.ToArray());
+            var id = Encoding.UTF8.GetString(result.ResponseBody);
 
             ConnectionState state;
-            Assert.True(manager.TryGetConnection(id, out state));
+            Assert.True(host.ConnectionManager.TryGetConnection(id, out state));
             Assert.Equal(id, state.Connection.ConnectionId);
         }
 
@@ -46,29 +32,10 @@ namespace Microsoft.AspNetCore.Sockets.Tests
         [InlineData("/ws")]
         public async Task EndpointsThatAcceptConnectionId404WhenUnknownConnectionIdProvided(string path)
         {
-            var manager = new ConnectionManager();
-            var dispatcher = new HttpConnectionDispatcher(manager, new LoggerFactory());
-
-            using (var strm = new MemoryStream())
-            {
-                var context = new DefaultHttpContext();
-                context.Response.Body = strm;
-
-                var services = new ServiceCollection();
-                services.AddSingleton<TestEndPoint>();
-                context.RequestServices = services.BuildServiceProvider();
-                context.Request.Path = path;
-                var values = new Dictionary<string, StringValues>();
-                values["id"] = "unknown";
-                var qs = new QueryCollection(values);
-                context.Request.Query = qs;
-
-                await dispatcher.ExecuteAsync<TestEndPoint>("", context);
-
-                Assert.Equal(StatusCodes.Status404NotFound, context.Response.StatusCode);
-                await strm.FlushAsync();
-                Assert.Equal("No Connection with that ID", Encoding.UTF8.GetString(strm.ToArray()));
-            }
+            var host = SocketsTestHost.CreateWithDefaultEndPoint();
+            var result = await host.ExecuteRequestAsync(path, queryString: "?id=unknown");
+            Assert.Equal(StatusCodes.Status404NotFound, result.HttpContext.Response.StatusCode);
+            Assert.Equal("No Connection with that ID", Encoding.UTF8.GetString(result.ResponseBody));
         }
 
         [Theory]
@@ -77,31 +44,20 @@ namespace Microsoft.AspNetCore.Sockets.Tests
         [InlineData("/poll")]
         public async Task EndpointsThatRequireConnectionId400WhenNoConnectionIdProvided(string path)
         {
-            var manager = new ConnectionManager();
-            var dispatcher = new HttpConnectionDispatcher(manager, new LoggerFactory());
-            using (var strm = new MemoryStream())
-            {
-                var context = new DefaultHttpContext();
-                context.Response.Body = strm;
-                var services = new ServiceCollection();
-                services.AddSingleton<TestEndPoint>();
-                context.RequestServices = services.BuildServiceProvider();
-                context.Request.Path = path;
-
-                await dispatcher.ExecuteAsync<TestEndPoint>("", context);
-
-                Assert.Equal(StatusCodes.Status400BadRequest, context.Response.StatusCode);
-                await strm.FlushAsync();
-                Assert.Equal("Connection ID required", Encoding.UTF8.GetString(strm.ToArray()));
-            }
+            var host = SocketsTestHost.CreateWithDefaultEndPoint();
+            var result = await host.ExecuteRequestAsync(path);
+            Assert.Equal(StatusCodes.Status400BadRequest, result.HttpContext.Response.StatusCode);
+            Assert.Equal("Connection ID required", Encoding.UTF8.GetString(result.ResponseBody));
         }
-    }
 
-    public class TestEndPoint : EndPoint
-    {
-        public override Task OnConnectedAsync(Connection connection)
+        [Fact]
+        public async Task CannotUseSendEndpointWithWebSockets()
         {
-            throw new NotImplementedException();
+            var host = SocketsTestHost.CreateWithDefaultEndPoint();
+            var connectionState = host.CreateConnection(transportName: WebSocketsTransport.TransportName);
+            var result = await host.ExecuteRequestAsync("/send", queryString: $"?id={connectionState.Connection.ConnectionId}");
+            Assert.Equal(StatusCodes.Status400BadRequest, result.HttpContext.Response.StatusCode);
+            Assert.Equal("Cannot send to a WebSockets connection", Encoding.UTF8.GetString(result.ResponseBody));
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Sockets.Tests/HttpConnectionDispatcherTests.cs
+++ b/test/Microsoft.AspNetCore.Sockets.Tests/HttpConnectionDispatcherTests.cs
@@ -57,7 +57,7 @@ namespace Microsoft.AspNetCore.Sockets.Tests
             var connectionState = host.CreateConnection(transportName: WebSocketsTransport.TransportName);
             var result = await host.ExecuteRequestAsync("/send", queryString: $"?id={connectionState.Connection.ConnectionId}");
             Assert.Equal(StatusCodes.Status400BadRequest, result.HttpContext.Response.StatusCode);
-            Assert.Equal("Cannot send to a WebSockets connection", Encoding.UTF8.GetString(result.ResponseBody));
+            Assert.Equal("Cannot use '/send' to send messages to a WebSockets connection", Encoding.UTF8.GetString(result.ResponseBody));
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Sockets.Tests/LongPollingTests.cs
+++ b/test/Microsoft.AspNetCore.Sockets.Tests/LongPollingTests.cs
@@ -83,8 +83,7 @@ namespace Microsoft.AspNetCore.Sockets.Tests
             var expected = new InvalidOperationException("Failed!");
             channel.Out.Complete(expected);
 
-            var actual = await Assert.ThrowsAsync<InvalidOperationException>(async () => await transportTask.WithTimeout());
-            Assert.Equal(expected.Message, actual.Message);
+            await transportTask.WithTimeout();
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Sockets.Tests/LongPollingTests.cs
+++ b/test/Microsoft.AspNetCore.Sockets.Tests/LongPollingTests.cs
@@ -81,7 +81,7 @@ namespace Microsoft.AspNetCore.Sockets.Tests
             var transportTask = poll.ProcessRequestAsync(context);
 
             var expected = new InvalidOperationException("Failed!");
-            channel.Complete(expected);
+            channel.Out.Complete(expected);
 
             var actual = await Assert.ThrowsAsync<InvalidOperationException>(async () => await transportTask.WithTimeout());
             Assert.Equal(expected.Message, actual.Message);

--- a/test/Microsoft.AspNetCore.Sockets.Tests/ServerSentEventsTests.cs
+++ b/test/Microsoft.AspNetCore.Sockets.Tests/ServerSentEventsTests.cs
@@ -80,7 +80,7 @@ namespace Microsoft.AspNetCore.Sockets.Tests
             var transportTask = poll.ProcessRequestAsync(context);
 
             var expected = new InvalidOperationException("Failed!");
-            channel.Complete(expected);
+            channel.Out.Complete(expected);
 
             var actual = await Assert.ThrowsAsync<InvalidOperationException>(async () => await transportTask.WithTimeout());
             Assert.Equal(expected.Message, actual.Message);

--- a/test/Microsoft.AspNetCore.Sockets.Tests/ServerSentEventsTests.cs
+++ b/test/Microsoft.AspNetCore.Sockets.Tests/ServerSentEventsTests.cs
@@ -82,8 +82,7 @@ namespace Microsoft.AspNetCore.Sockets.Tests
             var expected = new InvalidOperationException("Failed!");
             channel.Out.Complete(expected);
 
-            var actual = await Assert.ThrowsAsync<InvalidOperationException>(async () => await transportTask.WithTimeout());
-            Assert.Equal(expected.Message, actual.Message);
+            await transportTask.WithTimeout();
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Sockets.Tests/SocketsRequestResult.cs
+++ b/test/Microsoft.AspNetCore.Sockets.Tests/SocketsRequestResult.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.AspNetCore.Sockets.Tests
+{
+    public class SocketsRequestResult
+    {
+        public byte[] ResponseBody { get; }
+        public DefaultHttpContext HttpContext { get; }
+
+        public SocketsRequestResult(DefaultHttpContext httpContext, byte[] responseBody)
+        {
+            HttpContext = httpContext;
+            ResponseBody = responseBody;
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Sockets.Tests/SocketsTestHost.cs
+++ b/test/Microsoft.AspNetCore.Sockets.Tests/SocketsTestHost.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Sockets.Internal;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Sockets.Tests
+{
+    public static class SocketsTestHost
+    {
+        public static SocketsTestHost<TestEndPoint> CreateWithDefaultEndPoint()
+        {
+            return new SocketsTestHost<TestEndPoint>();
+        }
+
+        public class TestEndPoint : EndPoint
+        {
+            public override Task OnConnectedAsync(Connection connection)
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+
+    public class SocketsTestHost<TEndPoint> where TEndPoint : EndPoint
+    {
+        public ConnectionManager ConnectionManager { get; }
+        public HttpConnectionDispatcher Dispatcher { get; }
+        public ServiceCollection Services { get; }
+
+        public SocketsTestHost()
+        {
+            ConnectionManager = new ConnectionManager();
+            Dispatcher = new HttpConnectionDispatcher(ConnectionManager, new LoggerFactory());
+            Services = new ServiceCollection();
+            Services.AddSingleton<TEndPoint>();
+        }
+
+        public ConnectionState CreateConnection(string transportName = null)
+        {
+            var connectionState = ConnectionManager.CreateConnection();
+            if (!string.IsNullOrEmpty(transportName))
+            {
+                connectionState.Connection.Metadata["transport"] = transportName;
+            }
+            return connectionState;
+        }
+
+        public async Task<SocketsRequestResult> ExecuteRequestAsync(string path, string queryString = null, Action<HttpContext> contextConfigurator = null)
+        {
+            var context = new DefaultHttpContext();
+            using (var stream = new MemoryStream())
+            {
+                context.RequestServices = Services.BuildServiceProvider();
+                context.Response.Body = stream;
+                context.Request.Path = path;
+                if (!string.IsNullOrEmpty(queryString))
+                {
+                    context.Request.QueryString = new QueryString(queryString);
+                }
+
+                contextConfigurator?.Invoke(context);
+
+                await Dispatcher.ExecuteAsync<TEndPoint>("", context);
+
+                await stream.FlushAsync();
+                var body = stream.ToArray();
+
+                return new SocketsRequestResult(context, body);
+            }
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Sockets.Tests/TestTaskExtensions.cs
+++ b/test/Microsoft.AspNetCore.Sockets.Tests/TestTaskExtensions.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.Sockets.Tests
+{
+    public static class TestTaskExtensions
+    {
+        public static Task<T> WithTimeout<T>(this Task<T> self) => WithTimeout(self, TimeSpan.FromSeconds(5));
+
+        public static Task<T> WithTimeout<T>(this Task<T> self, int millisecondsTimeout) => WithTimeout(self, TimeSpan.FromMilliseconds(millisecondsTimeout));
+
+        public static async Task<T> WithTimeout<T>(this Task<T> self, TimeSpan timeout)
+        {
+            var task = WithTimeout((Task)self, timeout);
+            await task;
+
+            // If we got here, it means the cancellation task didn't fire.
+            return self.GetAwaiter().GetResult();
+        }
+
+        public static Task WithTimeout(this Task self) => WithTimeout(self, TimeSpan.FromSeconds(5));
+
+        public static Task WithTimeout(this Task self, int millisecondsTimeout) => WithTimeout(self, TimeSpan.FromMilliseconds(millisecondsTimeout));
+
+        public static async Task WithTimeout(this Task self, TimeSpan timeout)
+        {
+            var cts = new CancellationTokenSource();
+            var tcs = new TaskCompletionSource<object>();
+
+            using (cts.Token.Register(() => tcs.TrySetCanceled()))
+            {
+                var tasks = Task.WhenAny(self, tcs.Task);
+                cts.CancelAfter(timeout);
+                var completed = await tasks;
+                try
+                {
+                    completed.GetAwaiter().GetResult();
+                }
+                catch (OperationCanceledException)
+                {
+                    throw new TimeoutException("Task timed out");
+                }
+            }
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Sockets.Tests/WebSocketsTests.cs
+++ b/test/Microsoft.AspNetCore.Sockets.Tests/WebSocketsTests.cs
@@ -175,7 +175,7 @@ namespace Microsoft.AspNetCore.Sockets.Tests
         [Theory]
         [InlineData(Format.Text, WebSocketOpcode.Text)]
         [InlineData(Format.Binary, WebSocketOpcode.Binary)]
-        public async Task DataWrittenToOutputPipelineAreSentAsFrames(Format format, WebSocketOpcode opcode)
+        public async Task DataWrittenToChannelAreSentAsFrames(Format format, WebSocketOpcode opcode)
         {
             var transportToApplication = Channel.CreateUnbounded<Message>();
             var applicationToTransport = Channel.CreateUnbounded<Message>();


### PR DESCRIPTION
* treat `/send` like a transport and run it closer to when the transports run
* refactor code to allow us to share one code path when looking up connection state, without funky behavior like having the `GetConnectionAsync` method write to the response
* refactor tests and add additional disconnect/error test cases.

No functional changes here, just some refactoring.

/cc @davidfowl 