### PR TITLE
Clean up disposal of connection state

### DIFF
--- a/test/Microsoft.AspNetCore.Sockets.Tests/ConnectionManagerTests.cs
+++ b/test/Microsoft.AspNetCore.Sockets.Tests/ConnectionManagerTests.cs
@@ -83,17 +83,19 @@ namespace Microsoft.AspNetCore.Sockets.Tests
             var connectionManager = new ConnectionManager();
             var state = connectionManager.CreateConnection();
 
-            var task = Task.Run(async () =>
+            state.ApplicationTask = Task.Run(async () =>
             {
-                var connection = state.Connection;
+                Assert.False(await state.Connection.Transport.Input.WaitToReadAsync());
+            });
 
-                Assert.False(await connection.Transport.Input.WaitToReadAsync());
-                Assert.True(connection.Transport.Input.Completion.IsCompleted);
+            state.TransportTask = Task.Run(async () =>
+            {
+                Assert.False(await state.Application.Input.WaitToReadAsync());
             });
 
             connectionManager.CloseConnections();
 
-            await task;
+            await state.DisposeAsync();
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Sockets.Tests/ConnectionManagerTests.cs
+++ b/test/Microsoft.AspNetCore.Sockets.Tests/ConnectionManagerTests.cs
@@ -13,14 +13,14 @@ namespace Microsoft.AspNetCore.Sockets.Tests
         [Fact]
         public void NewConnectionsHaveConnectionId()
         {
-
             var connectionManager = new ConnectionManager();
             var state = connectionManager.CreateConnection();
 
             Assert.NotNull(state.Connection);
             Assert.NotNull(state.Connection.ConnectionId);
             Assert.True(state.Active);
-            Assert.Null(state.Close);
+            Assert.Null(state.ApplicationTask);
+            Assert.Null(state.TransportTask);
             Assert.NotNull(state.Connection.Transport);
         }
 


### PR DESCRIPTION
- Removed IDisposable and added a DisposeAsync method to ConnectionState
- Added ApplicationTask and TransportTask to ConnectionState as first class
properties so that it is easy to see (in a process dump or debugger) the
outstanding tasks that Sockets is keeping track of on a per connection basis.
- Swapped transport and application initialization to enable https://github.com/aspnet/SignalR/issues/123 

Sorry @anurse 😄 