### PR TITLE
Pawelka/api

### DIFF
--- a/samples/ClientSample/HubSample.cs
+++ b/samples/ClientSample/HubSample.cs
@@ -30,7 +30,7 @@ namespace ClientSample
             using (var httpClient = new HttpClient(new LoggingMessageHandler(loggerFactory, new HttpClientHandler())))
             {
                 logger.LogInformation("Connecting to {0}", baseUrl);
-                var transport = new LongPollingTransport(httpClient, loggerFactory);
+                var transport = new LongPollingTransport(loggerFactory, httpClient);
                 using (var connection = await HubConnection.ConnectAsync(new Uri(baseUrl),
                     new JsonNetInvocationAdapter(), transport, httpClient, loggerFactory))
                 {

--- a/src/Microsoft.AspNetCore.SignalR.Client/HubConnection.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client/HubConnection.cs
@@ -129,9 +129,9 @@ namespace Microsoft.AspNetCore.SignalR.Client
         public static async Task<HubConnection> ConnectAsync(Uri url, IInvocationAdapter adapter, ITransport transport, HttpClient httpClient, ILoggerFactory loggerFactory)
         {
             // Connect the underlying connection
-            var connection = await Connection.ConnectAsync(url, transport, httpClient, loggerFactory);
+            var connection = new Connection(url, loggerFactory);
+            await connection.StartAsync(transport, httpClient);
 
-            // Create the RPC connection wrapper
             return new HubConnection(connection, adapter, loggerFactory.CreateLogger<HubConnection>());
         }
 

--- a/src/Microsoft.AspNetCore.Sockets.Client/Connection.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client/Connection.cs
@@ -23,6 +23,7 @@ namespace Microsoft.AspNetCore.Sockets.Client
         private int _connectionState;
         private IChannelConnection<Message> _transportChannel;
         private ITransport _transport;
+        private bool _ownsTransport;
         private readonly ILogger _logger;
         private readonly ILoggerFactory _loggerFactory;
 
@@ -82,7 +83,8 @@ namespace Microsoft.AspNetCore.Sockets.Client
             try
             {
                 // Start the transport, giving it one end of the pipeline
-                _transport = transport ?? new LongPollingTransport(httpClient, _loggerFactory);
+                _transport = transport ?? new LongPollingTransport(_loggerFactory, httpClient);
+                _ownsTransport = transport == null;
                 await _transport.StartAsync(connectedUrl, applicationSide);
             }
             catch (Exception ex)
@@ -129,7 +131,7 @@ namespace Microsoft.AspNetCore.Sockets.Client
 
         public void Dispose()
         {
-            if (_transport != null)
+            if (_ownsTransport && _transport != null)
             {
                 _transport.Dispose();
             }

--- a/src/Microsoft.AspNetCore.Sockets.Client/ITransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client/ITransport.cs
@@ -9,5 +9,7 @@ namespace Microsoft.AspNetCore.Sockets.Client
     public interface ITransport : IDisposable
     {
         Task StartAsync(Uri url, IChannelConnection<Message> application);
+
+        Task StopAsync();
     }
 }

--- a/src/Microsoft.AspNetCore.Sockets.Client/LongPollingTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client/LongPollingTransport.cs
@@ -28,14 +28,23 @@ namespace Microsoft.AspNetCore.Sockets.Client
 
         public Task Running { get; private set; }
 
+        public LongPollingTransport()
+            : this(null)
+        { }
+
+        public LongPollingTransport(ILoggerFactory loggerFactory)
+            : this(null, loggerFactory)
+        { }
+
         public LongPollingTransport(HttpClient httpClient, ILoggerFactory loggerFactory)
         {
-            _httpClient = httpClient;
-            _logger = loggerFactory.CreateLogger<LongPollingTransport>();
+            _httpClient = httpClient ?? new HttpClient();
+            _logger = (loggerFactory ?? NullLoggerFactory.Instance).CreateLogger<LongPollingTransport>();
         }
 
         public void Dispose()
         {
+            // dispose client?
             _transportCts.Cancel();
         }
 

--- a/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/HubConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/HubConnectionTests.cs
@@ -49,7 +49,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
 
             using (var httpClient = _testServer.CreateClient())
             {
-                var transport = new LongPollingTransport(httpClient, loggerFactory);
+                var transport = new LongPollingTransport(loggerFactory, httpClient);
                 using (var connection = await HubConnection.ConnectAsync(new Uri("http://test/hubs"),
                     new JsonNetInvocationAdapter(), transport, httpClient, loggerFactory))
                 {
@@ -70,7 +70,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
 
             using (var httpClient = _testServer.CreateClient())
             {
-                var transport = new LongPollingTransport(httpClient, loggerFactory);
+                var transport = new LongPollingTransport(loggerFactory, httpClient);
                 using (var connection = await HubConnection.ConnectAsync(new Uri("http://test/hubs"),
                     new JsonNetInvocationAdapter(), transport, httpClient, loggerFactory))
                 {
@@ -91,7 +91,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
 
             using (var httpClient = _testServer.CreateClient())
             {
-                var transport = new LongPollingTransport(httpClient, loggerFactory);
+                var transport = new LongPollingTransport(loggerFactory, httpClient);
                 using (var connection = await HubConnection.ConnectAsync(new Uri("http://test/hubs"),
                     new JsonNetInvocationAdapter(), transport, httpClient, loggerFactory))
                 {
@@ -112,7 +112,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
 
             using (var httpClient = _testServer.CreateClient())
             {
-                var transport = new LongPollingTransport(httpClient, loggerFactory);
+                var transport = new LongPollingTransport(loggerFactory, httpClient);
                 using (var connection = await HubConnection.ConnectAsync(new Uri("http://test/hubs"),
                     new JsonNetInvocationAdapter(), transport, httpClient, loggerFactory))
                 {
@@ -139,7 +139,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
 
             using (var httpClient = _testServer.CreateClient())
             {
-                var transport = new LongPollingTransport(httpClient, loggerFactory);
+                var transport = new LongPollingTransport(loggerFactory, httpClient);
                 using (var connection = await HubConnection.ConnectAsync(new Uri("http://test/hubs"),
                     new JsonNetInvocationAdapter(), transport, httpClient, loggerFactory))
                 {

--- a/test/Microsoft.AspNetCore.SignalR.Tests/EndToEndTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/EndToEndTests.cs
@@ -54,24 +54,23 @@ namespace Microsoft.AspNetCore.SignalR.Tests
         }
 
         [Fact]
+        // TODO: run for all transports
         public async Task ConnectionCanSendAndReceiveMessages()
         {
             const string message = "Major Key";
             var baseUrl = _serverFixture.BaseUrl;
             var loggerFactory = new LoggerFactory();
 
-            using (var httpClient = new HttpClient())
+            using (var connection = new ClientConnection(new Uri(baseUrl + "/echo"), loggerFactory))
             {
-                var transport = new LongPollingTransport(httpClient, loggerFactory);
-                using (var connection = await ClientConnection.ConnectAsync(new Uri(baseUrl + "/echo"), transport, httpClient, loggerFactory))
-                {
-                    await connection.Output.WriteAsync(new Message(
-                        ReadableBuffer.Create(Encoding.UTF8.GetBytes(message)).Preserve(),
-                        Format.Text));
+                await connection.StartAsync();
 
-                    var received = await ReceiveMessage(connection).OrTimeout();
-                    Assert.Equal(message, received);
-                }
+                await connection.Output.WriteAsync(new Message(
+                    ReadableBuffer.Create(Encoding.UTF8.GetBytes(message)).Preserve(),
+                    Format.Text));
+
+                var received = await ReceiveMessage(connection).OrTimeout();
+                Assert.Equal(message, received);
             }
         }
 

--- a/test/Microsoft.AspNetCore.Sockets.Client.Tests/ConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.Sockets.Client.Tests/ConnectionTests.cs
@@ -29,12 +29,14 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
                     return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(string.Empty) };
                 });
 
+            var loggerFactory = new LoggerFactory();
             var connectionUrl = new Uri("http://fakeuri.org/");
             using (var httpClient = new HttpClient(mockHttpHandler.Object))
             using (var longPollingTransport = new LongPollingTransport(httpClient, new LoggerFactory()))
             {
-                using (var connection = await Connection.ConnectAsync(connectionUrl, longPollingTransport, httpClient))
+                using (var connection = new Connection(connectionUrl, loggerFactory))
                 {
+                    await connection.StartAsync(longPollingTransport, httpClient);
                     Assert.Equal(connectionUrl, connection.Url);
                 }
 
@@ -57,8 +59,9 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
             using (var httpClient = new HttpClient(mockHttpHandler.Object))
             using (var longPollingTransport = new LongPollingTransport(httpClient, new LoggerFactory()))
             {
-                using (var connection = await Connection.ConnectAsync(new Uri("http://fakeuri.org/"), longPollingTransport, httpClient))
+                using (var connection = new Connection(new Uri("http://fakeuri.org/")))
                 {
+                    await connection.StartAsync(longPollingTransport, httpClient);
                     Assert.False(longPollingTransport.Running.IsCompleted);
                 }
 
@@ -84,9 +87,11 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
                 });
 
             using (var httpClient = new HttpClient(mockHttpHandler.Object))
+            using (var connection = new Connection(new Uri("http://fakeuri.org/")))
             using (var longPollingTransport = new LongPollingTransport(httpClient, new LoggerFactory()))
-            using (var connection = await Connection.ConnectAsync(new Uri("http://fakeuri.org/"), longPollingTransport, httpClient))
             {
+                await connection.StartAsync(longPollingTransport, httpClient);
+
                 Assert.False(connection.Input.Completion.IsCompleted);
 
                 var data = new byte[] { 1, 1, 2, 3, 5, 8 };
@@ -117,9 +122,11 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
                 });
 
             using (var httpClient = new HttpClient(mockHttpHandler.Object))
+            using (var connection = new Connection(new Uri("http://fakeuri.org/")))
             using (var longPollingTransport = new LongPollingTransport(httpClient, new LoggerFactory()))
-            using (var connection = await Connection.ConnectAsync(new Uri("http://fakeuri.org/"), longPollingTransport, httpClient))
             {
+                await connection.StartAsync(longPollingTransport, httpClient);
+
                 Assert.False(connection.Input.Completion.IsCompleted);
 
                 await connection.Input.WaitToReadAsync();
@@ -145,9 +152,11 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
                 });
 
             using (var httpClient = new HttpClient(mockHttpHandler.Object))
+            using (var connection = new Connection(new Uri("http://fakeuri.org/")))
             using (var longPollingTransport = new LongPollingTransport(httpClient, new LoggerFactory()))
-            using (var connection = await Connection.ConnectAsync(new Uri("http://fakeuri.org/"), longPollingTransport, httpClient))
             {
+                await connection.StartAsync(longPollingTransport, httpClient);
+
                 Assert.False(connection.Input.Completion.IsCompleted);
                 connection.Output.TryComplete();
 

--- a/test/Microsoft.AspNetCore.Sockets.Client.Tests/LongPollingTransportTests.cs
+++ b/test/Microsoft.AspNetCore.Sockets.Client.Tests/LongPollingTransportTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
             Task transportActiveTask;
 
             using (var httpClient = new HttpClient(mockHttpHandler.Object))
-            using (var longPollingTransport = new LongPollingTransport(httpClient, new LoggerFactory()))
+            using (var longPollingTransport = new LongPollingTransport(new LoggerFactory(), httpClient))
             {
                 var connectionToTransport = Channel.CreateUnbounded<Message>();
                 var transportToConnection = Channel.CreateUnbounded<Message>();
@@ -60,7 +60,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
                 });
 
             using (var httpClient = new HttpClient(mockHttpHandler.Object))
-            using (var longPollingTransport = new LongPollingTransport(httpClient, new LoggerFactory()))
+            using (var longPollingTransport = new LongPollingTransport(new LoggerFactory(), httpClient))
             {
                 var connectionToTransport = Channel.CreateUnbounded<Message>();
                 var transportToConnection = Channel.CreateUnbounded<Message>();
@@ -85,7 +85,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
                 });
 
             using (var httpClient = new HttpClient(mockHttpHandler.Object))
-            using (var longPollingTransport = new LongPollingTransport(httpClient, new LoggerFactory()))
+            using (var longPollingTransport = new LongPollingTransport(new LoggerFactory(), httpClient))
             {
                 var connectionToTransport = Channel.CreateUnbounded<Message>();
                 var transportToConnection = Channel.CreateUnbounded<Message>();
@@ -114,7 +114,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
                 });
 
             using (var httpClient = new HttpClient(mockHttpHandler.Object))
-            using (var longPollingTransport = new LongPollingTransport(httpClient, new LoggerFactory()))
+            using (var longPollingTransport = new LongPollingTransport(new LoggerFactory(), httpClient))
             {
                 var connectionToTransport = Channel.CreateUnbounded<Message>();
                 var transportToConnection = Channel.CreateUnbounded<Message>();
@@ -152,7 +152,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
                 });
 
             using (var httpClient = new HttpClient(mockHttpHandler.Object))
-            using (var longPollingTransport = new LongPollingTransport(httpClient, new LoggerFactory()))
+            using (var longPollingTransport = new LongPollingTransport(new LoggerFactory(), httpClient))
             {
                 var connectionToTransport = Channel.CreateUnbounded<Message>();
                 var transportToConnection = Channel.CreateUnbounded<Message>();
@@ -163,6 +163,29 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
 
                 Assert.Equal(longPollingTransport.Running, await Task.WhenAny(Task.Delay(1000), longPollingTransport.Running));
                 Assert.Equal(connectionToTransport.In.Completion, await Task.WhenAny(Task.Delay(1000), connectionToTransport.In.Completion));
+            }
+        }
+
+        [Fact]
+        public async Task CanStopNotStartedConnection()
+        {
+            await new LongPollingTransport().StopAsync();
+        }
+
+        [Fact]
+        public void CanDisposeNotStartedConnection()
+        {
+            new LongPollingTransport().Dispose();
+        }
+
+        [Fact]
+        public void LongPollingTransportDoesNotDisposeHttpClientItDoesntOwn()
+        {
+            using (var httpClient = new HttpClient())
+            {
+                new LongPollingTransport(/*loggerFactory*/ null, httpClient).Dispose();
+                // this fails with ObjectDisposedException if the client is disposed
+                httpClient.CancelPendingRequests();
             }
         }
     }


### PR DESCRIPTION
Preparation to changing to Connection to be event based
- Separating creating connection from starting connection (needed to be able to subscribe to DataReceived, Closed events before the connection is started)
- Enabling stopping connection without disposing connection
- Enabling stopping transports without disposing transports
- Fixing ownership issues 
   - LongPollingTransport will not dispose httpClient if it did not create one
   - Connection will not dispose transport if it did not create one
   - TODO: connection should dispose httpClient if it created one (easy to fix once LongPollingTransport is not the default transport)