### PR TITLE
Pawelka/events

### DIFF
--- a/SignalR.sln
+++ b/SignalR.sln
@@ -47,7 +47,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebSocketSample", "samples\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.AspNetCore.Sockets.Client", "src\Microsoft.AspNetCore.Sockets.Client\Microsoft.AspNetCore.Sockets.Client.csproj", "{623FD372-36DE-41A9-A564-F6040D570DBD}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.AspNetCore.Sockets.Client.Tests", "test\Microsoft.AspNetCore.Sockets.Client.Tests\Microsoft.AspNetCore.Sockets.Client.Tests.csproj", "{B19C15A5-F5EA-4CA7-936B-1166ABEE35C4}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.AspNetCore.Client.Tests", "test\Microsoft.AspNetCore.Sockets.Client.Tests\Microsoft.AspNetCore.Client.Tests.csproj", "{B19C15A5-F5EA-4CA7-936B-1166ABEE35C4}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.AspNetCore.SignalR.Common", "src\Microsoft.AspNetCore.SignalR.Common\Microsoft.AspNetCore.SignalR.Common.csproj", "{E37324FF-6BAF-4243-BA80-7C024CF5F29D}"
 EndProject

--- a/samples/ClientSample/HubSample.cs
+++ b/samples/ClientSample/HubSample.cs
@@ -30,9 +30,9 @@ namespace ClientSample
             {
                 logger.LogInformation("Connecting to {0}", baseUrl);
                 var transport = new LongPollingTransport(httpClient, loggerFactory);
-                using (var connection = await HubConnection.ConnectAsync(new Uri(baseUrl),
-                    new JsonNetInvocationAdapter(), transport, httpClient, loggerFactory))
+                using (var connection = new HubConnection(new Uri(baseUrl), new JsonNetInvocationAdapter(), loggerFactory))
                 {
+                    await connection.StartAsync(transport, httpClient);
                     logger.LogInformation("Connected to {0}", baseUrl);
 
                     var cts = new CancellationTokenSource();

--- a/samples/ClientSample/RawSample.cs
+++ b/samples/ClientSample/RawSample.cs
@@ -30,8 +30,10 @@ namespace ClientSample
             {
                 logger.LogInformation("Connecting to {0}", baseUrl);
                 var transport = new LongPollingTransport(httpClient, loggerFactory);
-                using (var connection = await Connection.ConnectAsync(new Uri(baseUrl), transport, httpClient, loggerFactory))
+                using (var connection = new Connection(new Uri(baseUrl), loggerFactory))
                 {
+                    await connection.StartAsync(transport, httpClient);
+
                     logger.LogInformation("Connected to {0}", baseUrl);
 
                     var cts = new CancellationTokenSource();
@@ -49,6 +51,7 @@ namespace ClientSample
                         StartSending(loggerFactory.CreateLogger("SendLoop"), connection, cts.Token).ContinueWith(_ => cts.Cancel());
 
                     await Task.WhenAll(receive, send);
+                    await connection.StopAsync();
                 }
             }
         }

--- a/src/Microsoft.AspNetCore.SignalR.Client/HubConnection.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client/HubConnection.cs
@@ -118,9 +118,9 @@ namespace Microsoft.AspNetCore.SignalR.Client
         public static async Task<HubConnection> ConnectAsync(Uri url, IInvocationAdapter adapter, ITransport transport, HttpClient httpClient, ILoggerFactory loggerFactory)
         {
             // Connect the underlying connection
-            var connection = await Connection.ConnectAsync(url, transport, httpClient, loggerFactory);
+            var connection = new Connection(url, loggerFactory);
+            await connection.StartAsync(transport, httpClient);
 
-            // Create the RPC connection wrapper
             return new HubConnection(connection, adapter, loggerFactory.CreateLogger<HubConnection>());
         }
 

--- a/src/Microsoft.AspNetCore.Sockets.Client/NullLoggerFactory.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client/NullLoggerFactory.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 

--- a/src/Microsoft.AspNetCore.Sockets.Client/WebSocketsTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client/WebSocketsTransport.cs
@@ -30,8 +30,8 @@ namespace Microsoft.AspNetCore.Sockets.Client
         }
 
         public Task Running { get; private set; }
-                                                
-        public async Task StartAsync(Uri url, IChannelConnection<Message> application)  
+
+        public async Task StartAsync(Uri url, IChannelConnection<Message> application)
         {
             if (url == null)
             {

--- a/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/HubConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/HubConnectionTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.SignalR.Tests.Common;
@@ -10,6 +8,8 @@ using Microsoft.AspNetCore.Sockets.Client;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using System;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
@@ -51,9 +51,10 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
             using (var httpClient = _testServer.CreateClient())
             {
                 var transport = new LongPollingTransport(httpClient, loggerFactory);
-                using (var connection = await HubConnection.ConnectAsync(new Uri("http://test/hubs"),
-                    new JsonNetInvocationAdapter(), transport, httpClient, loggerFactory))
+                using (var connection = new HubConnection(new Uri("http://test/hubs"), new JsonNetInvocationAdapter(), loggerFactory))
                 {
+                    await connection.StartAsync(transport, httpClient);
+
                     var result = await connection.Invoke<string>("HelloWorld");
 
                     Assert.Equal("Hello World!", result);
@@ -70,9 +71,10 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
             using (var httpClient = _testServer.CreateClient())
             {
                 var transport = new LongPollingTransport(httpClient, loggerFactory);
-                using (var connection = await HubConnection.ConnectAsync(new Uri("http://test/hubs"),
-                    new JsonNetInvocationAdapter(), transport, httpClient, loggerFactory))
+                using (var connection = new HubConnection(new Uri("http://test/hubs"), new JsonNetInvocationAdapter(), loggerFactory))
                 {
+                    await connection.StartAsync(transport, httpClient);
+
                     var result = await connection.Invoke<string>("Echo", originalMessage);
 
                     Assert.Equal(originalMessage, result);
@@ -89,9 +91,10 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
             using (var httpClient = _testServer.CreateClient())
             {
                 var transport = new LongPollingTransport(httpClient, loggerFactory);
-                using (var connection = await HubConnection.ConnectAsync(new Uri("http://test/hubs"),
-                    new JsonNetInvocationAdapter(), transport, httpClient, loggerFactory))
+                using (var connection = new HubConnection(new Uri("http://test/hubs"), new JsonNetInvocationAdapter(), loggerFactory))
                 {
+                    await connection.StartAsync(transport, httpClient);
+
                     var result = await connection.Invoke<string>("echo", originalMessage);
 
                     Assert.Equal(originalMessage, result);
@@ -108,9 +111,10 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
             using (var httpClient = _testServer.CreateClient())
             {
                 var transport = new LongPollingTransport(httpClient, loggerFactory);
-                using (var connection = await HubConnection.ConnectAsync(new Uri("http://test/hubs"),
-                    new JsonNetInvocationAdapter(), transport, httpClient, loggerFactory))
+                using (var connection = new HubConnection(new Uri("http://test/hubs"), new JsonNetInvocationAdapter(), loggerFactory))
                 {
+                    await connection.StartAsync(transport, httpClient);
+
                     var tcs = new TaskCompletionSource<string>();
                     connection.On("Echo", new[] { typeof(string) }, a =>
                     {
@@ -132,9 +136,10 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
             using (var httpClient = _testServer.CreateClient())
             {
                 var transport = new LongPollingTransport(httpClient, loggerFactory);
-                using (var connection = await HubConnection.ConnectAsync(new Uri("http://test/hubs"),
-                    new JsonNetInvocationAdapter(), transport, httpClient, loggerFactory))
+                using (var connection = new HubConnection(new Uri("http://test/hubs"), new JsonNetInvocationAdapter(), loggerFactory))
                 {
+                    await connection.StartAsync(transport, httpClient);
+
                     var ex = await Assert.ThrowsAnyAsync<Exception>(
                         async () => await connection.Invoke<object>("!@#$%"));
 

--- a/test/Microsoft.AspNetCore.SignalR.Tests/EndToEndTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/EndToEndTests.cs
@@ -64,35 +64,19 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             using (var httpClient = new HttpClient())
             {
                 var transport = new LongPollingTransport(httpClient, loggerFactory);
-                using (var connection = await ClientConnection.ConnectAsync(new Uri(baseUrl + "/echo"), transport, httpClient, loggerFactory))
+                using (var connection = new ClientConnection(new Uri(baseUrl + "/echo"), loggerFactory))
                 {
+                    await connection.StartAsync(transport, httpClient);
+
                     await connection.SendAsync(Encoding.UTF8.GetBytes(message), MessageType.Text);
 
                     var receiveData = new ReceiveData();
 
                     Assert.True(await connection.ReceiveAsync(receiveData).OrTimeout());
                     Assert.Equal(message, Encoding.UTF8.GetString(receiveData.Data));
+
+                    await connection.StopAsync();
                 }
-            }
-        }
-
-        [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.Windows, WindowsVersions.Win7, WindowsVersions.Win2008R2, SkipReason = "No WebSockets Client for this platform")]
-        public async Task ConnectionCanSendAndReceiveSmallMessagesWebSocketsTransport()
-        {
-            const string message = "Major Key";
-            var baseUrl = _serverFixture.BaseUrl;
-            var loggerFactory = new LoggerFactory();
-
-            var transport = new WebSocketsTransport();
-            using (var connection = await ClientConnection.ConnectAsync(new Uri(baseUrl + "/echo/ws"), transport, loggerFactory))
-            {
-                await connection.SendAsync(Encoding.UTF8.GetBytes(message), MessageType.Text);
-
-                var receiveData = new ReceiveData();
-
-                Assert.True(await connection.ReceiveAsync(receiveData).OrTimeout());
-                Assert.Equal(message, Encoding.UTF8.GetString(receiveData.Data));
             }
         }
 
@@ -114,14 +98,18 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             var loggerFactory = new LoggerFactory();
 
             var transport = new WebSocketsTransport();
-            using (var connection = await ClientConnection.ConnectAsync(new Uri(baseUrl + "/echo/ws"), transport, loggerFactory))
+            using (var connection = new ClientConnection(new Uri(baseUrl + "/echo/ws"), loggerFactory))
             {
+                await connection.StartAsync(transport);
+
                 await connection.SendAsync(Encoding.UTF8.GetBytes(message), MessageType.Text);
 
                 var receiveData = new ReceiveData();
 
                 Assert.True(await connection.ReceiveAsync(receiveData).OrTimeout());
                 Assert.Equal(message, Encoding.UTF8.GetString(receiveData.Data));
+
+                await connection.StopAsync();
             }
         }
     }

--- a/test/Microsoft.AspNetCore.Sockets.Client.Tests/ConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.Sockets.Client.Tests/ConnectionTests.cs
@@ -199,7 +199,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
             }
         }
 
-        [Fact(Skip = "Need draining to make it work. Receive event may fix that.")]
+        [Fact]
         public async Task ClosedEventRaisedWhenTheClientIsStopped()
         {
             var mockHttpHandler = new Mock<HttpMessageHandler>();
@@ -221,14 +221,13 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
                 await connection.StartAsync(longPollingTransport, httpClient);
                 await connection.StopAsync();
 
-                
                 Assert.Equal(closedEventTcs.Task, await Task.WhenAny(Task.Delay(1000), closedEventTcs.Task));
                 // in case of clean disconnect error should be null
                 Assert.Null(await closedEventTcs.Task);
             }
         }
 
-        [Fact(Skip = "Need draining to make it work. Receive event may fix that.")]
+        [Fact]
         public async Task ClosedEventRaisedWhenTheClientIsDisposed()
         {
             var mockHttpHandler = new Mock<HttpMessageHandler>();
@@ -260,7 +259,6 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
         [Fact]
         public async Task ClosedEventRaisedWhenConnectionToServerLost()
         {
-            var allowPollTcs = new TaskCompletionSource<object>();
             var mockHttpHandler = new Mock<HttpMessageHandler>();
             mockHttpHandler.Protected()
                 .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
@@ -269,7 +267,6 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
                     await Task.Yield();
                     if (request.RequestUri.AbsolutePath.EndsWith("/poll"))
                     {
-                        await allowPollTcs.Task;
                         return new HttpResponseMessage(HttpStatusCode.InternalServerError) { Content = new StringContent(string.Empty) };
                     }
                     return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(string.Empty) };
@@ -282,10 +279,6 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
                 var closedEventTcs = new TaskCompletionSource<Exception>();
                 connection.Closed += e => closedEventTcs.TrySetResult(e);
                 await connection.StartAsync(longPollingTransport, httpClient);
-
-                var receiveTask = connection.ReceiveAsync(new ReceiveData());
-                allowPollTcs.TrySetResult(null);
-                await Assert.ThrowsAsync<HttpRequestException>(async () => await receiveTask);
 
                 Assert.Equal(closedEventTcs.Task, await Task.WhenAny(Task.Delay(1000), closedEventTcs.Task));
                 Assert.IsType<HttpRequestException>(await closedEventTcs.Task);
@@ -411,11 +404,24 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
             using (var longPollingTransport = new LongPollingTransport(httpClient, new LoggerFactory()))
             using (var connection = new Connection(new Uri("http://fakeuri.org/")))
             {
+                var receiveTcs = new TaskCompletionSource<string>();
+                connection.Received += (data, format) => receiveTcs.TrySetResult(Encoding.UTF8.GetString(data));
+                connection.Closed += e =>
+                    {
+                        if (e != null)
+                        {
+                            receiveTcs.TrySetException(e);
+                        }
+                        else
+                        {
+                            receiveTcs.TrySetCanceled();
+                        }
+                    };
+
                 await connection.StartAsync(longPollingTransport, httpClient);
 
-                var receiveData = new ReceiveData();
-                Assert.True(await connection.ReceiveAsync(receiveData));
-                Assert.Equal("42", Encoding.UTF8.GetString(receiveData.Data));
+                // TODO: timeout
+                Assert.Equal("42", await receiveTcs.Task);
 
                 await connection.StopAsync();
             }
@@ -444,35 +450,8 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
         }
 
         [Fact]
-        public async Task CannotReceiveAfterConnectionIsStopped()
-        {
-            var mockHttpHandler = new Mock<HttpMessageHandler>();
-            mockHttpHandler.Protected()
-                .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
-                .Returns<HttpRequestMessage, CancellationToken>(async (request, cancellationToken) =>
-                {
-                    await Task.Yield();
-                    return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(string.Empty) };
-                });
-
-            using (var httpClient = new HttpClient(mockHttpHandler.Object))
-            using (var longPollingTransport = new LongPollingTransport(httpClient, new LoggerFactory()))
-            using (var connection = new Connection(new Uri("http://fakeuri.org/")))
-            {
-                await connection.StartAsync(longPollingTransport, httpClient);
-
-                await connection.StopAsync();
-                var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-                    async () => await connection.ReceiveAsync(new ReceiveData()));
-
-                Assert.Equal("Cannot receive messages when the connection is stopped.", exception.Message);
-            }
-        }
-
-        [Fact]
         public async Task CannotSendAfterReceiveThrewException()
         {
-            var allowPollTcs = new TaskCompletionSource<object>();
             var mockHttpHandler = new Mock<HttpMessageHandler>();
             mockHttpHandler.Protected()
                 .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
@@ -481,7 +460,6 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
                     await Task.Yield();
                     if (request.RequestUri.AbsolutePath.EndsWith("/poll"))
                     {
-                        await allowPollTcs.Task;
                         return new HttpResponseMessage(HttpStatusCode.InternalServerError) { Content = new StringContent(string.Empty) };
                     }
                     return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(string.Empty) };
@@ -491,11 +469,13 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
             using (var longPollingTransport = new LongPollingTransport(httpClient, new LoggerFactory()))
             using (var connection = new Connection(new Uri("http://fakeuri.org/")))
             {
+                var closeTcs = new TaskCompletionSource<Exception>();
+                connection.Closed += e => closeTcs.TrySetResult(e);
+
                 await connection.StartAsync(longPollingTransport, httpClient);
 
-                var receiveTask = connection.ReceiveAsync(new ReceiveData());
-                allowPollTcs.TrySetResult(null);
-                await Assert.ThrowsAsync<HttpRequestException>(async () => await receiveTask);
+                // Exception in send should shutdown the connection
+                await closeTcs.Task.OrTimeout();
 
                 Assert.False(await connection.SendAsync(new byte[] { 1, 1, 3, 5, 8 }, MessageType.Binary));
             }
@@ -504,7 +484,6 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
         [Fact]
         public async Task CannotReceiveAfterReceiveThrewException()
         {
-            var allowPollTcs = new TaskCompletionSource<object>();
             var mockHttpHandler = new Mock<HttpMessageHandler>();
             mockHttpHandler.Protected()
                 .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
@@ -513,7 +492,6 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
                     await Task.Yield();
                     if (request.RequestUri.AbsolutePath.EndsWith("/poll"))
                     {
-                        await allowPollTcs.Task;
                         return new HttpResponseMessage(HttpStatusCode.InternalServerError) { Content = new StringContent(string.Empty) };
                     }
                     return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(string.Empty) };
@@ -523,16 +501,15 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
             using (var longPollingTransport = new LongPollingTransport(httpClient, new LoggerFactory()))
             using (var connection = new Connection(new Uri("http://fakeuri.org/")))
             {
+                var closeTcs = new TaskCompletionSource<Exception>();
+                connection.Closed += e => closeTcs.TrySetResult(e);
+
                 await connection.StartAsync(longPollingTransport, httpClient);
 
-                var receiveTask = connection.ReceiveAsync(new ReceiveData());
-                allowPollTcs.TrySetResult(null);
-                await Assert.ThrowsAsync<HttpRequestException>(async () => await receiveTask);
+                // Exception in send should shutdown the connection
+                await closeTcs.Task.OrTimeout();
 
-                var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-                    async () => await connection.ReceiveAsync(new ReceiveData()));
-
-                Assert.Equal("Cannot receive messages when the connection is stopped.", exception.Message);
+                Assert.False(await connection.SendAsync(new byte[] { 1, 1, 3, 5, 8 }, MessageType.Binary));
             }
         }
     }

--- a/test/Microsoft.AspNetCore.Sockets.Client.Tests/HubConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.Sockets.Client.Tests/HubConnectionTests.cs
@@ -1,0 +1,188 @@
+﻿using Microsoft.AspNetCore.Sockets;
+using Microsoft.AspNetCore.Sockets.Client;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Moq.Protected;
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.AspNetCore.SignalR.Client.Tests
+{
+    public class HubConnectionTests
+    {
+        [Fact]
+        public void CannotCreateHubConnectionWithNullUrl()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(
+                () => new HubConnection(null, Mock.Of<IInvocationAdapter>(), Mock.Of<ILoggerFactory>()));
+            Assert.Equal("url", exception.ParamName);
+        }
+
+        [Fact]
+        public void CanDisposeNotStartedHubConnection()
+        {
+            using (new HubConnection(new Uri("http://fakeuri.org"), Mock.Of<IInvocationAdapter>(), Mock.Of<ILoggerFactory>()))
+            { }
+        }
+
+        [Fact]
+        public async Task CanStopNotStartedHubConnection()
+        {
+            using (var hubConnection = new HubConnection(new Uri("http://fakeuri.org"), Mock.Of<IInvocationAdapter>(), Mock.Of<ILoggerFactory>()))
+            {
+                await hubConnection.StopAsync();
+            }
+        }
+
+        [Fact]
+        public async Task CannotStartRunningHubConnection()
+        {
+            var mockHttpHandler = new Mock<HttpMessageHandler>();
+            mockHttpHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                .Returns<HttpRequestMessage, CancellationToken>(async (request, cancellationToken) =>
+                {
+                    await Task.Yield();
+                    return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(string.Empty) };
+                });
+
+            using (var httpClient = new HttpClient(mockHttpHandler.Object))
+            using (var longPollingTransport = new LongPollingTransport(httpClient, new LoggerFactory()))
+            using (var hubConnection = new HubConnection(new Uri("http://fakeuri.org/"), Mock.Of<IInvocationAdapter>(), new LoggerFactory()))
+            {
+                await hubConnection.StartAsync(longPollingTransport, httpClient);
+                var exception =
+                    await Assert.ThrowsAsync<InvalidOperationException>(
+                        async () => await hubConnection.StartAsync(longPollingTransport));
+                Assert.Equal("Cannot start a connection that is not in the Initial state.", exception.Message);
+
+                await hubConnection.StopAsync();
+            }
+        }
+
+        [Fact]
+        public async Task CannotStartStoppedHubConnection()
+        {
+            var mockHttpHandler = new Mock<HttpMessageHandler>();
+            mockHttpHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                .Returns<HttpRequestMessage, CancellationToken>(async (request, cancellationToken) =>
+                {
+                    await Task.Yield();
+                    return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(string.Empty) };
+                });
+
+            using (var httpClient = new HttpClient(mockHttpHandler.Object))
+            using (var longPollingTransport = new LongPollingTransport(httpClient, new LoggerFactory()))
+            using (var hubConnection = new HubConnection(new Uri("http://fakeuri.org/"), Mock.Of<IInvocationAdapter>(), new LoggerFactory()))
+            {
+                await hubConnection.StartAsync(longPollingTransport, httpClient);
+                await hubConnection.StopAsync();
+                var exception =
+                    await Assert.ThrowsAsync<InvalidOperationException>(
+                        async () => await hubConnection.StartAsync(longPollingTransport));
+
+                Assert.Equal("Cannot start a connection that is not in the Initial state.", exception.Message);
+            }
+        }
+
+        [Fact]
+        public async Task CannotStartDisposedHubConnection()
+        {
+            using (var httpClient = new HttpClient())
+            using (var longPollingTransport = new LongPollingTransport(httpClient, new LoggerFactory()))
+            {
+                var hubConnection = new HubConnection(new Uri("http://fakeuri.org/"), Mock.Of<IInvocationAdapter>(), new LoggerFactory());
+                hubConnection.Dispose();
+                var exception =
+                    await Assert.ThrowsAsync<InvalidOperationException>(
+                        async () => await hubConnection.StartAsync(longPollingTransport));
+
+                Assert.Equal("Cannot start a connection that is not in the Initial state.", exception.Message);
+            }
+        }
+
+        [Fact(Skip = "Not implemented")]
+        public async Task InvokeThrowsIfHubConnectionNotStarted()
+        {
+            using (var hubConnection = new HubConnection(new Uri("http://fakeuri.org"), Mock.Of<IInvocationAdapter>(), Mock.Of<ILoggerFactory>()))
+            {
+                var exception = 
+                    await Assert.ThrowsAsync<InvalidOperationException>(async () => await hubConnection.Invoke<int>("test"));
+                Assert.Equal("Cannot invoke methods on non-started connections.", exception.Message);
+            }
+        }
+
+        [Fact(Skip = "Not implemented")]
+        public async Task InvokeThrowsIfHubConnectionDisposed()
+        {
+            using (var hubConnection = new HubConnection(new Uri("http://fakeuri.org"), Mock.Of<IInvocationAdapter>(), Mock.Of<ILoggerFactory>()))
+            {
+                hubConnection.Dispose();
+                var exception =
+                    await Assert.ThrowsAsync<InvalidOperationException>(async () => await hubConnection.Invoke<int>("test"));
+                Assert.Equal("Cannot invoke methods on disposed connections.", exception.Message);
+            }
+        }
+
+        // TODO: If HubConnection takes (I)Connection we could just tests if events are wired up 
+
+        [Fact]
+        public async Task HubConnectionConnectedEventRaisedWhenTheClientIsConnected()
+        {
+            var mockHttpHandler = new Mock<HttpMessageHandler>();
+            mockHttpHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                .Returns<HttpRequestMessage, CancellationToken>(async (request, cancellationToken) =>
+                {
+                    await Task.Yield();
+                    return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(string.Empty) };
+                });
+
+            using (var httpClient = new HttpClient(mockHttpHandler.Object))
+            using (var longPollingTransport = new LongPollingTransport(httpClient, new LoggerFactory()))
+            using (var hubConnection = new HubConnection(new Uri("http://fakeuri.org"), Mock.Of<IInvocationAdapter>(), new LoggerFactory()))
+            {
+                var connectedEventRaised = false;
+                hubConnection.Connected += () => connectedEventRaised = true;
+
+                await hubConnection.StartAsync(longPollingTransport, httpClient);
+
+                Assert.True(connectedEventRaised);
+            }
+        }
+
+        [Fact]
+        public async Task ClosedEventRaisedWhenTheClientIsStopped()
+        {
+            var mockHttpHandler = new Mock<HttpMessageHandler>();
+            mockHttpHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                .Returns<HttpRequestMessage, CancellationToken>(async (request, cancellationToken) =>
+                {
+                    await Task.Yield();
+                    return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(string.Empty) };
+                });
+
+            using (var httpClient = new HttpClient(mockHttpHandler.Object))
+            using (var longPollingTransport = new LongPollingTransport(httpClient, new LoggerFactory()))
+            using (var hubConnection = new HubConnection(new Uri("http://fakeuri.org"), Mock.Of<IInvocationAdapter>(), new LoggerFactory()))
+            {
+                var closedEventTcs = new TaskCompletionSource<Exception>();
+                hubConnection.Closed += e => closedEventTcs.SetResult(e);
+
+                await hubConnection.StartAsync(longPollingTransport, httpClient);
+                await hubConnection.StopAsync();
+
+
+                Assert.Equal(closedEventTcs.Task, await Task.WhenAny(Task.Delay(1000), closedEventTcs.Task));
+                // in case of clean disconnect error should be null
+                Assert.Null(await closedEventTcs.Task);
+            }
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Sockets.Client.Tests/Microsoft.AspNetCore.Client.Tests.csproj
+++ b/test/Microsoft.AspNetCore.Sockets.Client.Tests/Microsoft.AspNetCore.Client.Tests.csproj
@@ -14,8 +14,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Microsoft.AspNetCore.SignalR.Client\Microsoft.AspNetCore.SignalR.Client.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.AspNetCore.Sockets.Client\Microsoft.AspNetCore.Sockets.Client.csproj" />
-    <ProjectReference Include="..\..\src\Microsoft.AspNetCore.Sockets.Common\Microsoft.AspNetCore.Sockets.Common.csproj" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="1.2.0-*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-*" />
     <PackageReference Include="Moq" Version="4.6.36-*" />


### PR DESCRIPTION
- changing static ConnectAsync to instance StartAsync 
- adding Connected, Received, Closed events

There is a few items that still need attention but are not blocking. I don't want to make this change any bigger. I will create a comment with a running issues to address. Feedback will be addressed in this PR or, if bigger/not-critical added to this list to be addressed separately. 