### PR TITLE
Fix travis failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,6 @@ branches:
 before_install:
   - if test "$TRAVIS_OS_NAME" == "osx"; then brew update; brew install openssl python; ln -s /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/; ln -s /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/; fi
 install:
-  - sudo pip install autobahntestsuite "six>=1.9.0"
+  - pip install autobahntestsuite "six>=1.9.0"
 script:
   - ./build.sh --quiet verify


### PR DESCRIPTION
There was a conflict between a globally-installed python package and a package autobahn needs, so we remove `sudo` from the installation call and it doesn't try to mess with those packages.