### PR TITLE
Fixing build warning

### DIFF
--- a/samples/ChatSample/Startup.cs
+++ b/samples/ChatSample/Startup.cs
@@ -27,7 +27,7 @@ namespace ChatSample
             if (env.IsDevelopment())
             {
                 // For more details on using the user secret store see http://go.microsoft.com/fwlink/?LinkID=532709
-                builder.AddUserSecrets();
+                builder.AddUserSecrets<Startup>();
             }
 
             builder.AddEnvironmentVariables();


### PR DESCRIPTION
13:40:19.336     1>Startup.cs(30,17): warning CS0618: 'ConfigurationExtensions.AddUserSecrets(IConfigurationBuilder)' is obsolete: 'This method is obsolete and will be removed in a future version. The recommended alternative is .AddUserSecrets(string userSecretsId) or .AddUserSecrets<TStartup>().' [C:\Source\SignalR-Core\samples\ChatSample\ChatSample.csproj] [C:\Source\SignalR-Core\.build\makefile.proj]