### PR TITLE
Prototype: Enabling feedback to SendAsync via asymmetric channels

### DIFF
--- a/samples/ClientSample/HubSample.cs
+++ b/samples/ClientSample/HubSample.cs
@@ -30,7 +30,8 @@ namespace ClientSample
             {
                 logger.LogInformation("Connecting to {0}", baseUrl);
                 var transport = new LongPollingTransport(httpClient, loggerFactory);
-                using (var connection = new HubConnection(new Uri(baseUrl), new JsonNetInvocationAdapter(), loggerFactory))
+                var connection = new HubConnection(new Uri(baseUrl), new JsonNetInvocationAdapter(), loggerFactory);
+                try
                 {
                     await connection.StartAsync(transport, httpClient);
                     logger.LogInformation("Connected to {0}", baseUrl);
@@ -57,6 +58,10 @@ namespace ClientSample
 
                         await connection.Invoke<object>("Send", line);
                     }
+                }
+                finally
+                {
+                    await connection.DisposeAsync();
                 }
             }
         }

--- a/samples/ClientSample/RawSample.cs
+++ b/samples/ClientSample/RawSample.cs
@@ -30,7 +30,8 @@ namespace ClientSample
             {
                 logger.LogInformation("Connecting to {0}", baseUrl);
                 var transport = new LongPollingTransport(httpClient, loggerFactory);
-                using (var connection = new Connection(new Uri(baseUrl), loggerFactory))
+                var connection = new Connection(new Uri(baseUrl), loggerFactory);
+                try
                 {
                     var cts = new CancellationTokenSource();
                     connection.Received += (data, format) => logger.LogInformation($"Received: {Encoding.UTF8.GetString(data)}");
@@ -48,8 +49,10 @@ namespace ClientSample
                     };
 
                     await StartSending(loggerFactory.CreateLogger("SendLoop"), connection, cts.Token).ContinueWith(_ => cts.Cancel());
-
-                    await connection.StopAsync();
+                }
+                finally
+                {
+                    await connection.DisposeAsync();
                 }
             }
         }

--- a/src/Microsoft.AspNetCore.SignalR.Client/HubConnection.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client/HubConnection.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNetCore.SignalR.Client
     public class HubConnection
     {
         private readonly ILogger _logger;
-        private readonly Connection _connection;
+        private readonly IConnection _connection;
         private readonly IInvocationAdapter _adapter;
         private readonly HubBinder _binder;
 
@@ -46,6 +46,10 @@ namespace Microsoft.AspNetCore.SignalR.Client
         }
 
         public HubConnection(Uri url, IInvocationAdapter adapter, ILoggerFactory loggerFactory)
+            : this(new Connection(url, loggerFactory), adapter, loggerFactory)
+        { }
+
+        public HubConnection(IConnection connection, IInvocationAdapter adapter, ILoggerFactory loggerFactory)
         {
             // TODO: loggerFactory shouldn't be required
             if (loggerFactory == null)
@@ -53,8 +57,9 @@ namespace Microsoft.AspNetCore.SignalR.Client
                 throw new ArgumentNullException(nameof(loggerFactory));
             }
 
+            _connection = connection ?? throw new ArgumentNullException(nameof(connection));
+
             _binder = new HubBinder(this);
-            _connection = new Connection(url, loggerFactory);
             _adapter = adapter;
             _logger = loggerFactory.CreateLogger<HubConnection>();
 

--- a/src/Microsoft.AspNetCore.SignalR.Client/HubConnection.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client/HubConnection.cs
@@ -116,7 +116,7 @@ namespace Microsoft.AspNetCore.SignalR.Client
             {
                 if (_connectionActive.IsCancellationRequested)
                 {
-                    throw new InvalidOperationException("Connection has been terminated");
+                    throw new InvalidOperationException("Connection has been terminated.");
                 }
                 _pendingCalls.Add(descriptor.Id, irq);
             }
@@ -180,11 +180,11 @@ namespace Microsoft.AspNetCore.SignalR.Client
                 {
                     if (ex != null)
                     {
-                        call.Completion.TrySetCanceled();
+                        call.Completion.TrySetException(ex);
                     }
                     else
                     {
-                        call.Completion.TrySetException(ex);
+                        call.Completion.TrySetCanceled();
                     }
                 }
                 _pendingCalls.Clear();

--- a/src/Microsoft.AspNetCore.SignalR.Client/HubConnection.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client/HubConnection.cs
@@ -16,7 +16,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.SignalR.Client
 {
-    public class HubConnection : IDisposable
+    public class HubConnection
     {
         private readonly ILogger _logger;
         private readonly Connection _connection;
@@ -71,14 +71,9 @@ namespace Microsoft.AspNetCore.SignalR.Client
             await _connection.StartAsync(transport, httpClient);
         }
 
-        public async Task StopAsync()
+        public async Task DisposeAsync()
         {
-            await _connection.StopAsync();
-        }
-
-        public void Dispose()
-        {
-            _connection.Dispose();
+            await _connection.DisposeAsync();
         }
 
         // TODO: Client return values/tasks?

--- a/src/Microsoft.AspNetCore.Sockets.Client/Connection.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client/Connection.cs
@@ -12,7 +12,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Sockets.Client
 {
-    public class Connection
+    public class Connection: IConnection
     {
         private readonly ILoggerFactory _loggerFactory;
         private readonly ILogger _logger;

--- a/src/Microsoft.AspNetCore.Sockets.Client/Connection.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client/Connection.cs
@@ -12,7 +12,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Sockets.Client
 {
-    public class Connection : IDisposable
+    public class Connection
     {
         private readonly ILoggerFactory _loggerFactory;
         private readonly ILogger _logger;
@@ -213,7 +213,7 @@ namespace Microsoft.AspNetCore.Sockets.Client
             return false;
         }
 
-        public async Task StopAsync()
+        public async Task DisposeAsync()
         {
             Interlocked.Exchange(ref _connectionState, ConnectionState.Disconnected);
 
@@ -230,21 +230,6 @@ namespace Microsoft.AspNetCore.Sockets.Client
             if (_receiveLoopTask != null)
             {
                 await _receiveLoopTask;
-            }
-        }
-
-        public void Dispose()
-        {
-            Interlocked.Exchange(ref _connectionState, ConnectionState.Disconnected);
-
-            if (_transportChannel != null)
-            {
-                Output.TryComplete();
-            }
-
-            if (_transport != null)
-            {
-                _transport.Dispose();
             }
         }
 

--- a/src/Microsoft.AspNetCore.Sockets.Client/IConnection.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client/IConnection.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNetCore.Sockets.Client
     public interface IConnection
     {
         Task StartAsync(ITransport transport, HttpClient httpClient);
-        Task<bool> SendAsync(byte[] data, MessageType type, CancellationToken cancellationToken);
+        Task<Exception> SendAsync(byte[] data, MessageType type, CancellationToken cancellationToken);
         Task DisposeAsync();
 
         event Action Connected;

--- a/src/Microsoft.AspNetCore.Sockets.Client/IConnection.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client/IConnection.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.Sockets.Client
+{
+    public interface IConnection
+    {
+        Task StartAsync(ITransport transport, HttpClient httpClient);
+        Task<bool> SendAsync(byte[] data, MessageType type, CancellationToken cancellationToken);
+        Task DisposeAsync();
+
+        event Action Connected;
+        event Action<byte[], MessageType> Received;
+        event Action<Exception> Closed;
+    }
+}

--- a/src/Microsoft.AspNetCore.Sockets.Client/IConnection.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client/IConnection.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNetCore.Sockets.Client
     public interface IConnection
     {
         Task StartAsync(ITransport transport, HttpClient httpClient);
-        Task<Exception> SendAsync(byte[] data, MessageType type, CancellationToken cancellationToken);
+        Task<bool> SendAsync(byte[] data, MessageType type, CancellationToken cancellationToken);
         Task DisposeAsync();
 
         event Action Connected;

--- a/src/Microsoft.AspNetCore.Sockets.Client/ITransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client/ITransport.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNetCore.Sockets.Client
 {
     public interface ITransport
     {
-        Task StartAsync(Uri url, IChannelConnection<Message> application);
+        Task StartAsync(Uri url, IChannelConnection<SendMessage, Message> application);
         Task StopAsync();
     }
 }

--- a/src/Microsoft.AspNetCore.Sockets.Client/ITransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client/ITransport.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.AspNetCore.Sockets.Client
 {
-    public interface ITransport : IDisposable
+    public interface ITransport
     {
         Task StartAsync(Uri url, IChannelConnection<Message> application);
         Task StopAsync();

--- a/src/Microsoft.AspNetCore.Sockets.Client/LongPollingTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client/LongPollingTransport.cs
@@ -42,7 +42,8 @@ namespace Microsoft.AspNetCore.Sockets.Client
             _poller = Poll(Utils.AppendPath(url, "poll"), _transportCts.Token);
             _sender = SendMessages(Utils.AppendPath(url, "send"), _transportCts.Token);
 
-            Running = Task.WhenAll(_sender, _poller).ContinueWith(t => {
+            Running = Task.WhenAll(_sender, _poller).ContinueWith(t =>
+            {
                 _application.Output.TryComplete(t.IsFaulted ? t.Exception.InnerException : null);
                 return t;
             }).Unwrap();
@@ -53,12 +54,14 @@ namespace Microsoft.AspNetCore.Sockets.Client
         public async Task StopAsync()
         {
             _transportCts.Cancel();
-            await Running;
-        }
-
-        public void Dispose()
-        {
-            _transportCts.Cancel();
+            try
+            {
+                await Running;
+            }
+            catch
+            {
+                // exceptions have been handled in the Running task continuation by closing the channel with the exception
+            }
         }
 
         private async Task Poll(Uri pollUrl, CancellationToken cancellationToken)

--- a/src/Microsoft.AspNetCore.Sockets.Client/SendMessage.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client/SendMessage.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.IO.Pipelines;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.Sockets.Client
+{
+    public struct SendMessage : IDisposable
+    {
+        public MessageType Type { get; }
+        public PreservedBuffer Payload { get; }
+        public TaskCompletionSource<Exception> Result { get; }
+
+        public SendMessage(PreservedBuffer payload, MessageType type, TaskCompletionSource<Exception> result)
+        {
+            Type = type;
+            Payload = payload;
+            Result = result;
+        }
+
+        public void Dispose()
+        {
+            Payload.Dispose();
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Sockets.Client/SendMessage.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client/SendMessage.cs
@@ -8,9 +8,9 @@ namespace Microsoft.AspNetCore.Sockets.Client
     {
         public MessageType Type { get; }
         public PreservedBuffer Payload { get; }
-        public TaskCompletionSource<Exception> Result { get; }
+        public TaskCompletionSource<bool> Result { get; }
 
-        public SendMessage(PreservedBuffer payload, MessageType type, TaskCompletionSource<Exception> result)
+        public SendMessage(PreservedBuffer payload, MessageType type, TaskCompletionSource<bool> result)
         {
             Type = type;
             Payload = payload;

--- a/src/Microsoft.AspNetCore.Sockets.Client/WebSocketsTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client/WebSocketsTransport.cs
@@ -122,19 +122,17 @@ namespace Microsoft.AspNetCore.Sockets.Client
                             await _webSocket.SendAsync(new ArraySegment<byte>(message.Payload.Buffer.ToArray()),
                             message.Type == MessageType.Text ? WebSocketMessageType.Text : WebSocketMessageType.Binary, true,
                             cancellationToken);
-                            message.Result.SetResult(null);
+                            message.Result.SetResult(true);
                         }
                         catch (OperationCanceledException ex)
                         {
                             _logger?.LogError(ex.Message);
                             await _webSocket.CloseAsync(WebSocketCloseStatus.Empty, null, _cancellationToken);
-                            message.Result.SetResult(new OperationCanceledException());
                             break;
                         }
-                        catch (Exception ex)
+                        finally
                         {
-                            message.Result.SetResult(ex);
-                            throw;
+                            message.Result.TrySetResult(false);
                         }
                     }
                 }

--- a/src/Microsoft.AspNetCore.Sockets.Common/IChannelConnection.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Common/IChannelConnection.cs
@@ -8,10 +8,8 @@ namespace Microsoft.AspNetCore.Sockets
 {
     // REVIEW: These should probably move to Channels. Why not use IChannel? Because I think it's better to be clear that this is providing
     // access to two separate channels, the read end for one and the write end for the other.
-    public interface IChannelConnection<T> : IDisposable
+    public interface IChannelConnection<T> : IChannelConnection<T, T>
     {
-        ReadableChannel<T> Input { get; }
-        WritableChannel<T> Output { get; }
     }
 
     public interface IChannelConnection<T, U> : IDisposable

--- a/src/Microsoft.AspNetCore.Sockets.Common/IChannelConnection.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Common/IChannelConnection.cs
@@ -13,4 +13,10 @@ namespace Microsoft.AspNetCore.Sockets
         ReadableChannel<T> Input { get; }
         WritableChannel<T> Output { get; }
     }
+
+    public interface IChannelConnection<T, U> : IDisposable
+    {
+        ReadableChannel<T> Input { get; }
+        WritableChannel<U> Output { get; }
+    }
 }

--- a/src/Microsoft.AspNetCore.Sockets.Common/Internal/ChannelConnection.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Common/Internal/ChannelConnection.cs
@@ -18,25 +18,11 @@ namespace Microsoft.AspNetCore.Sockets.Internal
         }
     }
 
-    public class ChannelConnection<T> : IChannelConnection<T>
+    public class ChannelConnection<T> : ChannelConnection<T, T>, IChannelConnection<T>
     {
-        public Channel<T> Input { get; }
-        public Channel<T> Output { get; }
-
-        ReadableChannel<T> IChannelConnection<T>.Input => Input;
-        WritableChannel<T> IChannelConnection<T>.Output => Output;
-
         public ChannelConnection(Channel<T> input, Channel<T> output)
-        {
-            Input = input;
-            Output = output;
-        }
-
-        public void Dispose()
-        {
-            Output.Out.TryComplete();
-            Input.Out.TryComplete();
-        }
+            : base(input, output)
+        { }
     }
 
     public class ChannelConnection<T, U> : IChannelConnection<T, U>
@@ -59,5 +45,4 @@ namespace Microsoft.AspNetCore.Sockets.Internal
             Input.Out.TryComplete();
         }
     }
-
 }

--- a/src/Microsoft.AspNetCore.Sockets.Common/Internal/ChannelConnection.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Common/Internal/ChannelConnection.cs
@@ -7,6 +7,11 @@ namespace Microsoft.AspNetCore.Sockets.Internal
 {
     public static class ChannelConnection
     {
+        public static ChannelConnection<T, U> Create<T, U>(Channel<T> input, Channel<U> output)
+        {
+            return new ChannelConnection<T, U>(input, output);
+        }
+
         public static ChannelConnection<T> Create<T>(Channel<T> input, Channel<T> output)
         {
             return new ChannelConnection<T>(input, output);
@@ -33,4 +38,26 @@ namespace Microsoft.AspNetCore.Sockets.Internal
             Input.Out.TryComplete();
         }
     }
+
+    public class ChannelConnection<T, U> : IChannelConnection<T, U>
+    {
+        public Channel<T> Input { get; }
+        public Channel<U> Output { get; }
+
+        ReadableChannel<T> IChannelConnection<T, U>.Input => Input;
+        WritableChannel<U> IChannelConnection<T, U>.Output => Output;
+
+        public ChannelConnection(Channel<T> input, Channel<U> output)
+        {
+            Input = input;
+            Output = output;
+        }
+
+        public void Dispose()
+        {
+            Output.Out.TryComplete();
+            Input.Out.TryComplete();
+        }
+    }
+
 }

--- a/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/HubConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/HubConnectionTests.cs
@@ -51,13 +51,18 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
             using (var httpClient = _testServer.CreateClient())
             {
                 var transport = new LongPollingTransport(httpClient, loggerFactory);
-                using (var connection = new HubConnection(new Uri("http://test/hubs"), new JsonNetInvocationAdapter(), loggerFactory))
+                var connection = new HubConnection(new Uri("http://test/hubs"), new JsonNetInvocationAdapter(), loggerFactory);
+                try
                 {
                     await connection.StartAsync(transport, httpClient);
 
                     var result = await connection.Invoke<string>("HelloWorld");
 
                     Assert.Equal("Hello World!", result);
+                }
+                finally
+                {
+                    await connection.DisposeAsync();
                 }
             }
         }
@@ -71,13 +76,18 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
             using (var httpClient = _testServer.CreateClient())
             {
                 var transport = new LongPollingTransport(httpClient, loggerFactory);
-                using (var connection = new HubConnection(new Uri("http://test/hubs"), new JsonNetInvocationAdapter(), loggerFactory))
+                var connection = new HubConnection(new Uri("http://test/hubs"), new JsonNetInvocationAdapter(), loggerFactory);
+                try
                 {
                     await connection.StartAsync(transport, httpClient);
 
                     var result = await connection.Invoke<string>("Echo", originalMessage);
 
                     Assert.Equal(originalMessage, result);
+                }
+                finally
+                {
+                    await connection.DisposeAsync();
                 }
             }
         }
@@ -91,13 +101,18 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
             using (var httpClient = _testServer.CreateClient())
             {
                 var transport = new LongPollingTransport(httpClient, loggerFactory);
-                using (var connection = new HubConnection(new Uri("http://test/hubs"), new JsonNetInvocationAdapter(), loggerFactory))
+                var connection = new HubConnection(new Uri("http://test/hubs"), new JsonNetInvocationAdapter(), loggerFactory);
+                try
                 {
                     await connection.StartAsync(transport, httpClient);
 
                     var result = await connection.Invoke<string>("echo", originalMessage);
 
                     Assert.Equal(originalMessage, result);
+                }
+                finally
+                {
+                    await connection.DisposeAsync();
                 }
             }
         }
@@ -111,7 +126,8 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
             using (var httpClient = _testServer.CreateClient())
             {
                 var transport = new LongPollingTransport(httpClient, loggerFactory);
-                using (var connection = new HubConnection(new Uri("http://test/hubs"), new JsonNetInvocationAdapter(), loggerFactory))
+                var connection = new HubConnection(new Uri("http://test/hubs"), new JsonNetInvocationAdapter(), loggerFactory);
+                try
                 {
                     await connection.StartAsync(transport, httpClient);
 
@@ -125,6 +141,10 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
 
                     Assert.Equal(originalMessage, await tcs.Task.OrTimeout());
                 }
+                finally
+                {
+                    await connection.DisposeAsync();
+                }
             }
         }
 
@@ -136,7 +156,8 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
             using (var httpClient = _testServer.CreateClient())
             {
                 var transport = new LongPollingTransport(httpClient, loggerFactory);
-                using (var connection = new HubConnection(new Uri("http://test/hubs"), new JsonNetInvocationAdapter(), loggerFactory))
+                var connection = new HubConnection(new Uri("http://test/hubs"), new JsonNetInvocationAdapter(), loggerFactory);
+                try
                 {
                     await connection.StartAsync(transport, httpClient);
 
@@ -144,6 +165,10 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
                         async () => await connection.Invoke<object>("!@#$%"));
 
                     Assert.Equal(ex.Message, "Unknown hub method '!@#$%'");
+                }
+                finally
+                {
+                    await connection.DisposeAsync();
                 }
             }
         }

--- a/test/Microsoft.AspNetCore.SignalR.Tests/TestClient.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/TestClient.cs
@@ -30,8 +30,8 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             var transportToApplication = Channel.CreateUnbounded<Message>();
             var applicationToTransport = Channel.CreateUnbounded<Message>();
 
-            Application = ChannelConnection.Create(input: applicationToTransport, output: transportToApplication);
-            var transport = ChannelConnection.Create(input: transportToApplication, output: applicationToTransport);
+            Application = ChannelConnection.Create<Message>(input: applicationToTransport, output: transportToApplication);
+            var transport = ChannelConnection.Create<Message>(input: transportToApplication, output: applicationToTransport);
 
             Connection = new Connection(Guid.NewGuid().ToString(), transport);
             Connection.Metadata["formatType"] = format;

--- a/test/Microsoft.AspNetCore.Sockets.Client.Tests/ConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.Sockets.Client.Tests/ConnectionTests.cs
@@ -109,7 +109,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
         public async Task SendReturnsFalseIfConnectionIsNotStarted()
         {
             var connection = new Connection(new Uri("http://fakeuri.org/"));
-            Assert.False(await connection.SendAsync(new byte[0], MessageType.Binary));
+            Assert.IsType<InvalidOperationException>(await connection.SendAsync(new byte[0], MessageType.Binary));
         }
 
         [Fact]
@@ -132,7 +132,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
                 await connection.StartAsync(longPollingTransport, httpClient);
                 await connection.DisposeAsync();
 
-                Assert.False(await connection.SendAsync(new byte[0], MessageType.Binary));
+                Assert.IsType<InvalidOperationException>(await connection.SendAsync(new byte[0], MessageType.Binary));
             }
         }
 
@@ -182,7 +182,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
                 });
 
             var mockTransport = new Mock<ITransport>();
-            mockTransport.Setup(t => t.StartAsync(It.IsAny<Uri>(), It.IsAny<IChannelConnection<Message>>()))
+            mockTransport.Setup(t => t.StartAsync(It.IsAny<Uri>(), It.IsAny<IChannelConnection<SendMessage, Message>>()))
                 .Returns(Task.FromException(new InvalidOperationException("Transport failed to start")));
 
             using (var httpClient = new HttpClient(mockHttpHandler.Object))
@@ -401,7 +401,6 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
             }
         }
 
-        [Fact]
         public async Task CannotSendAfterConnectionIsStopped()
         {
             var mockHttpHandler = new Mock<HttpMessageHandler>();
@@ -420,11 +419,12 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
 
                 await connection.StartAsync(longPollingTransport, httpClient);
                 await connection.DisposeAsync();
-                Assert.False(await connection.SendAsync(new byte[] { 1, 1, 3, 5, 8 }, MessageType.Binary));
+                Assert.IsType<InvalidOperationException>(
+                    await connection.SendAsync(new byte[] { 1, 1, 3, 5, 8 }, MessageType.Binary));
             }
         }
 
-        [Fact]
+        [Fact(Skip = "TODO")]
         public async Task CannotSendAfterReceiveThrewException()
         {
             var mockHttpHandler = new Mock<HttpMessageHandler>();
@@ -454,7 +454,8 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
                     // Exception in send should shutdown the connection
                     await closeTcs.Task.OrTimeout();
 
-                    Assert.False(await connection.SendAsync(new byte[] { 1, 1, 3, 5, 8 }, MessageType.Binary));
+                    Assert.IsType<InvalidOperationException>(
+                        await connection.SendAsync(new byte[] { 1, 1, 3, 5, 8 }, MessageType.Binary));
                 }
                 finally
                 {
@@ -493,7 +494,8 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
                     // Exception in send should shutdown the connection
                     await closeTcs.Task.OrTimeout();
 
-                    Assert.False(await connection.SendAsync(new byte[] { 1, 1, 3, 5, 8 }, MessageType.Binary));
+                    Assert.IsType<InvalidOperationException>(
+                        await connection.SendAsync(new byte[] { 1, 1, 3, 5, 8 }, MessageType.Binary));
                 }
                 finally
                 {

--- a/test/Microsoft.AspNetCore.Sockets.Client.Tests/ConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.Sockets.Client.Tests/ConnectionTests.cs
@@ -109,7 +109,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
         public async Task SendReturnsFalseIfConnectionIsNotStarted()
         {
             var connection = new Connection(new Uri("http://fakeuri.org/"));
-            Assert.IsType<InvalidOperationException>(await connection.SendAsync(new byte[0], MessageType.Binary));
+            Assert.False(await connection.SendAsync(new byte[0], MessageType.Binary));
         }
 
         [Fact]
@@ -132,7 +132,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
                 await connection.StartAsync(longPollingTransport, httpClient);
                 await connection.DisposeAsync();
 
-                Assert.IsType<InvalidOperationException>(await connection.SendAsync(new byte[0], MessageType.Binary));
+                Assert.False(await connection.SendAsync(new byte[0], MessageType.Binary));
             }
         }
 
@@ -419,12 +419,11 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
 
                 await connection.StartAsync(longPollingTransport, httpClient);
                 await connection.DisposeAsync();
-                Assert.IsType<InvalidOperationException>(
-                    await connection.SendAsync(new byte[] { 1, 1, 3, 5, 8 }, MessageType.Binary));
+                Assert.False(await connection.SendAsync(new byte[] { 1, 1, 3, 5, 8 }, MessageType.Binary));
             }
         }
 
-        [Fact(Skip = "TODO")]
+        [Fact]
         public async Task CannotSendAfterReceiveThrewException()
         {
             var mockHttpHandler = new Mock<HttpMessageHandler>();
@@ -454,10 +453,9 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
                     // Exception in send should shutdown the connection
                     await closeTcs.Task.OrTimeout();
 
-                    Assert.IsType<InvalidOperationException>(
-                        await connection.SendAsync(new byte[] { 1, 1, 3, 5, 8 }, MessageType.Binary));
+                    Assert.False(await connection.SendAsync(new byte[] { 1, 1, 3, 5, 8 }, MessageType.Binary));
                 }
-                finally
+  finally
                 {
                     await connection.DisposeAsync();
                 }
@@ -494,8 +492,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
                     // Exception in send should shutdown the connection
                     await closeTcs.Task.OrTimeout();
 
-                    Assert.IsType<InvalidOperationException>(
-                        await connection.SendAsync(new byte[] { 1, 1, 3, 5, 8 }, MessageType.Binary));
+                    Assert.False(await connection.SendAsync(new byte[] { 1, 1, 3, 5, 8 }, MessageType.Binary));
                 }
                 finally
                 {

--- a/test/Microsoft.AspNetCore.Sockets.Client.Tests/HubConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.Sockets.Client.Tests/HubConnectionTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
         public void CannotCreateHubConnectionWithNullUrl()
         {
             var exception = Assert.Throws<ArgumentNullException>(
-                () => new HubConnection(null, Mock.Of<IInvocationAdapter>(), Mock.Of<ILoggerFactory>()));
+                () => new HubConnection((Uri)null, Mock.Of<IInvocationAdapter>(), Mock.Of<ILoggerFactory>()));
             Assert.Equal("url", exception.ParamName);
         }
 

--- a/test/Microsoft.AspNetCore.Sockets.Client.Tests/LongPollingTransportTests.cs
+++ b/test/Microsoft.AspNetCore.Sockets.Client.Tests/LongPollingTransportTests.cs
@@ -38,9 +38,9 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
 
                 try
                 {
-                    var connectionToTransport = Channel.CreateUnbounded<Message>();
+                    var connectionToTransport = Channel.CreateUnbounded<SendMessage>();
                     var transportToConnection = Channel.CreateUnbounded<Message>();
-                    var channelConnection = new ChannelConnection<Message>(connectionToTransport, transportToConnection);
+                    var channelConnection = new ChannelConnection<SendMessage, Message>(connectionToTransport, transportToConnection);
                     await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection);
 
                     transportActiveTask = longPollingTransport.Running;
@@ -74,9 +74,9 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
                 var longPollingTransport = new LongPollingTransport(httpClient, new LoggerFactory());
                 try
                 {
-                    var connectionToTransport = Channel.CreateUnbounded<Message>();
+                    var connectionToTransport = Channel.CreateUnbounded<SendMessage>();
                     var transportToConnection = Channel.CreateUnbounded<Message>();
-                    var channelConnection = new ChannelConnection<Message>(connectionToTransport, transportToConnection);
+                    var channelConnection = new ChannelConnection<SendMessage, Message>(connectionToTransport, transportToConnection);
                     await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection);
 
                     await longPollingTransport.Running.OrTimeout();
@@ -106,9 +106,9 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
                 var longPollingTransport = new LongPollingTransport(httpClient, new LoggerFactory());
                 try
                 {
-                    var connectionToTransport = Channel.CreateUnbounded<Message>();
+                    var connectionToTransport = Channel.CreateUnbounded<SendMessage>();
                     var transportToConnection = Channel.CreateUnbounded<Message>();
-                    var channelConnection = new ChannelConnection<Message>(connectionToTransport, transportToConnection);
+                    var channelConnection = new ChannelConnection<SendMessage, Message>(connectionToTransport, transportToConnection);
                     await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection);
 
                     var exception =
@@ -142,12 +142,12 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
                 var longPollingTransport = new LongPollingTransport(httpClient, new LoggerFactory());
                 try
                 {
-                    var connectionToTransport = Channel.CreateUnbounded<Message>();
+                    var connectionToTransport = Channel.CreateUnbounded<SendMessage>();
                     var transportToConnection = Channel.CreateUnbounded<Message>();
-                    var channelConnection = new ChannelConnection<Message>(connectionToTransport, transportToConnection);
+                    var channelConnection = new ChannelConnection<SendMessage, Message>(connectionToTransport, transportToConnection);
                     await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection);
 
-                    await connectionToTransport.Out.WriteAsync(new Message());
+                    await connectionToTransport.Out.WriteAsync(new SendMessage());
 
                     await Assert.ThrowsAsync<HttpRequestException>(async () => await longPollingTransport.Running.OrTimeout());
 
@@ -184,9 +184,9 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
                 var longPollingTransport = new LongPollingTransport(httpClient, new LoggerFactory());
                 try
                 {
-                    var connectionToTransport = Channel.CreateUnbounded<Message>();
+                    var connectionToTransport = Channel.CreateUnbounded<SendMessage>();
                     var transportToConnection = Channel.CreateUnbounded<Message>();
-                    var channelConnection = new ChannelConnection<Message>(connectionToTransport, transportToConnection);
+                    var channelConnection = new ChannelConnection<SendMessage, Message>(connectionToTransport, transportToConnection);
                     await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection);
 
                     connectionToTransport.Out.Complete();


### PR DESCRIPTION
Returning errors to the user if send failed.