### PR TITLE
use new Base64 codec in Text and SSE Formatters

### DIFF
--- a/src/Microsoft.AspNetCore.Sockets.Common/Formatters/ServerSentEventsMessageFormatter.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Common/Formatters/ServerSentEventsMessageFormatter.cs
@@ -76,7 +76,6 @@ namespace Microsoft.AspNetCore.Sockets.Formatters
             var writtenSoFar = 0;
             if (type == MessageType.Binary)
             {
-                // TODO: We're going to need to fix this as part of https://github.com/aspnet/SignalR/issues/192
                 var encodedSize = DataPrefix.Length + Base64.ComputeEncodedLength(payload.Length) + Newline.Length;
                 if (buffer.Length < encodedSize)
                 {

--- a/src/Microsoft.AspNetCore.Sockets.Common/Formatters/ServerSentEventsMessageFormatter.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Common/Formatters/ServerSentEventsMessageFormatter.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Text;
+using System.Binary;
 
 namespace Microsoft.AspNetCore.Sockets.Formatters
 {
@@ -77,8 +77,7 @@ namespace Microsoft.AspNetCore.Sockets.Formatters
             if (type == MessageType.Binary)
             {
                 // TODO: We're going to need to fix this as part of https://github.com/aspnet/SignalR/issues/192
-                var message = Convert.ToBase64String(payload.ToArray());
-                var encodedSize = DataPrefix.Length + Encoding.UTF8.GetByteCount(message) + Newline.Length;
+                var encodedSize = DataPrefix.Length + Base64.ComputeEncodedLength(payload.Length) + Newline.Length;
                 if (buffer.Length < encodedSize)
                 {
                     bytesWritten = 0;
@@ -87,9 +86,8 @@ namespace Microsoft.AspNetCore.Sockets.Formatters
                 DataPrefix.CopyTo(buffer);
                 buffer = buffer.Slice(DataPrefix.Length);
 
-                var array = Encoding.UTF8.GetBytes(message);
-                array.CopyTo(buffer);
-                buffer = buffer.Slice(array.Length);
+                var encodedLength = Base64.Encode(payload, buffer);
+                buffer = buffer.Slice(encodedLength);
 
                 Newline.CopyTo(buffer);
                 writtenSoFar += encodedSize;

--- a/src/Microsoft.AspNetCore.Sockets.Common/Microsoft.AspNetCore.Sockets.Common.csproj
+++ b/src/Microsoft.AspNetCore.Sockets.Common/Microsoft.AspNetCore.Sockets.Common.csproj
@@ -12,6 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Binary.Base64" Version="$(CoreFxLabsVersion)" />
     <PackageReference Include="System.IO.Pipelines" Version="$(CoreFxLabsVersion)" />
     <PackageReference Include="System.Text.Primitives" Version="$(CoreFxLabsVersion)" />
     <PackageReference Include="System.Threading.Tasks.Channels" Version="$(CoreFxLabsVersion)" />

--- a/test/Microsoft.AspNetCore.Sockets.Common.Tests/Formatters/ServerSentEventsMessageFormatterTests.cs
+++ b/test/Microsoft.AspNetCore.Sockets.Common.Tests/Formatters/ServerSentEventsMessageFormatterTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.IO.Pipelines;
 using System.Text;
 using Microsoft.AspNetCore.Sockets.Tests;
 using Xunit;


### PR DESCRIPTION
fix #192 

/cc @KrzysztofCwalina - Btw it's kinda odd that `Base64` doesn't have `TryDecode`/`TryEncode` APIs.