### PR TITLE
MSBuildifying gulpified node

### DIFF
--- a/SignalR.sln
+++ b/SignalR.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26208.0
+VisualStudioVersion = 15.0.26222.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{DA69F624-5398-4884-87E4-B816698CDE65}"
 EndProject
@@ -58,6 +58,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.AspNetCore.Sockets.Common", "src\Microsoft.AspNetCore.Sockets.Common\Microsoft.AspNetCore.Sockets.Common.csproj", "{F3EFFD9F-DD85-48A2-9B11-83A133ECC099}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.AspNetCore.Sockets.Common.Tests", "test\Microsoft.AspNetCore.Sockets.Common.Tests\Microsoft.AspNetCore.Sockets.Common.Tests.csproj", "{B0D32729-48AA-4841-B52A-2A61B60EED61}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.SignalR.Client.TS", "src\Microsoft.AspNetCore.SignalR.Client.TS\Microsoft.AspNetCore.SignalR.Client.TS.csproj", "{333526A4-633B-491A-AC45-CC62A0012D1C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -157,6 +159,10 @@ Global
 		{B0D32729-48AA-4841-B52A-2A61B60EED61}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B0D32729-48AA-4841-B52A-2A61B60EED61}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B0D32729-48AA-4841-B52A-2A61B60EED61}.Release|Any CPU.Build.0 = Release|Any CPU
+		{333526A4-633B-491A-AC45-CC62A0012D1C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{333526A4-633B-491A-AC45-CC62A0012D1C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{333526A4-633B-491A-AC45-CC62A0012D1C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{333526A4-633B-491A-AC45-CC62A0012D1C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -185,5 +191,6 @@ Global
 		{455B68D2-C5B6-4BF4-A685-964B07AFAAF8} = {6A35B453-52EC-48AF-89CA-D4A69800F131}
 		{F3EFFD9F-DD85-48A2-9B11-83A133ECC099} = {DA69F624-5398-4884-87E4-B816698CDE65}
 		{B0D32729-48AA-4841-B52A-2A61B60EED61} = {6A35B453-52EC-48AF-89CA-D4A69800F131}
+		{333526A4-633B-491A-AC45-CC62A0012D1C} = {DA69F624-5398-4884-87E4-B816698CDE65}
 	EndGlobalSection
 EndGlobal

--- a/build/repo.targets
+++ b/build/repo.targets
@@ -1,8 +1,4 @@
 <Project>
-  <Target Name="CleanNpm" AfterTargets="Clean">
-    <RemoveDir Directories="$(RepositoryRoot)node_modules" />
-  </Target>
-
   <Target Name="RestoreNpm" AfterTargets="Restore">
     <Message Text="Restoring NPM modules" Importance="high" />
     <Exec Command="npm install" WorkingDirectory="$(RepositoryRoot)" />

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "gulp-typescript": "^3.1.3",
     "jasmine": "^2.5.2",
     "typescript": "^2.0.10",
-    "vinyl-source-stream": "^1.1.0",
-    "yargs": "^6.4.0"
+    "vinyl-source-stream": "^1.1.0"
   }
 }

--- a/samples/ChatSample/ChatSample.csproj
+++ b/samples/ChatSample/ChatSample.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.AspNetCore.SignalR\Microsoft.AspNetCore.SignalR.csproj" />
+    <ProjectReference Include="..\..\src\Microsoft.AspNetCore.SignalR.Client.TS\Microsoft.AspNetCore.SignalR.Client.TS.csproj" />
   </ItemGroup>
 
   <ItemGroup>
@@ -36,16 +37,13 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 
-  <Target Name="BuildTSClient" BeforeTargets="BeforeBuild">
+  <Target Name="DotnetBundle" BeforeTargets="BeforeBuild">
     <Exec Command="dotnet bundle" />
-    <PropertyGroup>
-      <SignalRClientDistPath>..\..\dist\browser\signalr-client.js</SignalRClientDistPath>
-      <SignalRClientTargetFolder>$(MSBuildProjectDirectory)/wwwroot/lib/signalr-client/</SignalRClientTargetFolder>
-      <SignalRClientTargetPath>$(MSBuildProjectDirectory)/wwwroot/lib/signalr-client/signalr-client.js</SignalRClientTargetPath>
-    </PropertyGroup>
-    <Copy Condition="Exists('$(SignalRClientDistPath)')" SourceFiles="$(SignalRClientDistPath)" DestinationFolder="$(SignalRClientTargetFolder)"/>
-    <Exec Condition="!Exists('$(SignalRClientDistPath)')" Command="npm install" />
-    <Exec Condition="!Exists('$(SignalRClientDistPath)')" Command="npm run gulp -- --gulpfile $(MSBuildProjectDirectory)/../../src/Microsoft.AspNetCore.SignalR.Client.TS/gulpfile.js bundle-client --bundleOutDir $(SignalRClientTargetFolder)" />
+  </Target>
+
+  <Target Name="CopyTSClient" BeforeTargets="AfterBuild">
+    <Copy SourceFiles="$(MSBuildThisFileDirectory)..\..\dist\browser\signalr-client.js"
+          DestinationFolder="$(MSBuildThisFileDirectory)wwwroot\lib\signalr-client" />
   </Target>
 
   <Target Name="BowerInstall" BeforeTargets="PrepareForPublish">

--- a/samples/SocketsSample/SocketsSample.csproj
+++ b/samples/SocketsSample/SocketsSample.csproj
@@ -11,21 +11,17 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.AspNetCore.SignalR.Redis\Microsoft.AspNetCore.SignalR.Redis.csproj" />
+    <ProjectReference Include="..\..\src\Microsoft.AspNetCore.SignalR.Client.TS\Microsoft.AspNetCore.SignalR.Client.TS.csproj" />
+
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="Microsoft.AspNetCore" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Google.Protobuf" Version="3.1.0" />
   </ItemGroup>
 
-  <Target Name="BuildTSClient" BeforeTargets="BeforeBuild">
-    <PropertyGroup>
-      <SignalRClientDistPath>..\..\dist\browser\signalr-client.js</SignalRClientDistPath>
-      <SignalRClientTargetFolder>$(MSBuildProjectDirectory)/wwwroot/lib/signalr-client/</SignalRClientTargetFolder>
-      <SignalRClientTargetPath>$(MSBuildProjectDirectory)/wwwroot/lib/signalr-client/signalr-client.js</SignalRClientTargetPath>
-    </PropertyGroup>
-    <Copy Condition="Exists('$(SignalRClientDistPath)')" SourceFiles="$(SignalRClientDistPath)" DestinationFolder="$(SignalRClientTargetFolder)"/>
-    <Exec Condition="!Exists('$(SignalRClientDistPath)')" Command="npm install" />
-    <Exec Condition="!Exists('$(SignalRClientDistPath)')" Command="npm run gulp -- --gulpfile $(MSBuildProjectDirectory)/../../src/Microsoft.AspNetCore.SignalR.Client.TS/gulpfile.js bundle-client --bundleOutDir $(SignalRClientTargetFolder)" />
+  <Target Name="CopyTSClient" BeforeTargets="AfterBuild">
+    <Copy SourceFiles="$(MSBuildThisFileDirectory)..\..\dist\browser\signalr-client.js"
+          DestinationFolder="$(MSBuildThisFileDirectory)wwwroot\lib\signalr-client" />
   </Target>
 
 </Project>

--- a/src/Microsoft.AspNetCore.SignalR.Client.TS/Microsoft.AspNetCore.SignalR.Client.TS.csproj
+++ b/src/Microsoft.AspNetCore.SignalR.Client.TS/Microsoft.AspNetCore.SignalR.Client.TS.csproj
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\..\build\common.props" />
+
+  <PropertyGroup>
+    <TargetFramework>netstandard1.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SignalRClientDistFolder>$(MSBuildThisFileDirectory)..\..\dist\</SignalRClientDistFolder>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Inputs Include="*.ts;" />
+    <Outputs Include="@(Inputs -> '$(SignalRClientDistFolder)src\%(FileName).d.ts')" />
+    <Outputs Include="@(Inputs -> '$(SignalRClientDistFolder)src\%(FileName).js')" />
+    <Outputs Include="$(SignalRClientDistFolder)browser\signalr-client.js" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="tsconfig.json" />
+  </ItemGroup>
+
+  <!-- this target relies on npm packages being restored manually or when running full build -->
+  <Target Name="BuildTSClient" Inputs="@(Inputs)" Outputs="@(Outputs)" BeforeTargets="Build">
+    <Exec Command="npm run gulp -- --gulpfile $(MSBuildThisFileDirectory)gulpfile.js build-ts-client" />
+  </Target>
+
+  <Target Name="CleanTSClient" AfterTargets="Clean">
+    <RemoveDir Directories="$(SignalRClientDistFolder)" />
+  </Target>
+</Project>

--- a/src/Microsoft.AspNetCore.SignalR.Client.TS/gulpfile.js
+++ b/src/Microsoft.AspNetCore.SignalR.Client.TS/gulpfile.js
@@ -3,7 +3,6 @@ const browserify = require('browserify');
 const ts = require('gulp-typescript');
 const source = require('vinyl-source-stream');
 const del = require('del');
-const argv = require('yargs').argv;
 
 const tsProject = ts.createProject('./tsconfig.json');
 const clientOutDir = tsProject.options.outDir;
@@ -26,15 +25,5 @@ gulp.task('browserify-client', ['compile-ts-client'], () => {
 });
 
 gulp.task('build-ts-client', ['clean', 'compile-ts-client', 'browserify-client']);
-
-gulp.task('bundle-client', ['build-ts-client'], () => {
-    if (!argv.bundleOutDir) {
-        console.log('Use \'--bundleOutDir\' option to specify the target file for the bundled client.');
-    }
-    else {
-        return gulp.src(clientOutDir + '/../browser/signalr-client.js')
-            .pipe(gulp.dest(argv.bundleOutDir));
-    }
-});
 
 gulp.task('default', ['build-ts-client']);

--- a/test/Microsoft.AspNetCore.SignalR.Test.Server/Microsoft.AspNetCore.SignalR.Test.Server.csproj
+++ b/test/Microsoft.AspNetCore.SignalR.Test.Server/Microsoft.AspNetCore.SignalR.Test.Server.csproj
@@ -3,11 +3,12 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net46</TargetFrameworks>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.AspNetCore.SignalR\Microsoft.AspNetCore.SignalR.csproj" />
+    <ProjectReference Include="..\..\src\Microsoft.AspNetCore.SignalR.Client.TS\Microsoft.AspNetCore.SignalR.Client.TS.csproj" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="$(AspNetCoreVersion)" />
@@ -15,26 +16,16 @@
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 
-  <Target Name="NpmInstall">
-    <Exec Command="npm install" />
-  </Target>
-
-  <Target Name="CopyJasmine" BeforeTargets="BeforeBuild" DependsOnTargets="NpmInstall">
+  <!-- these targets relies on npm packages being restored when building the TS client -->
+  <Target Name="CopyRequiredArtifacts" BeforeTargets="AfterBuild">
       <ItemGroup>
-        <JasmineFiles Include="../../node_modules/jasmine-core/lib/jasmine-core/*.js" />
-        <JasmineFiles Include="../../node_modules/jasmine-core/lib/jasmine-core/*.css" />
+        <JasmineFiles Include="$(MSBuildProjectDirectory)../../node_modules/jasmine-core/lib/jasmine-core/*.js" />
+        <JasmineFiles Include="$(MSBuildProjectDirectory)../../node_modules/jasmine-core/lib/jasmine-core/*.css" />
       </ItemGroup>
       <Copy SourceFiles="@(JasmineFiles)" DestinationFolder="$(MSBuildProjectDirectory)/wwwroot/lib/jasmine" />
-  </Target>
 
-  <Target Name="BuildTSClient" BeforeTargets="BeforeBuild" DependsOnTargets="NpmInstall">
-    <PropertyGroup>
-      <SignalRClientDistPath>..\..\dist\browser\signalr-client.js</SignalRClientDistPath>
-      <SignalRClientTargetFolder>$(MSBuildProjectDirectory)/wwwroot/lib/signalr-client/</SignalRClientTargetFolder>
-      <SignalRClientTargetPath>$(MSBuildProjectDirectory)/wwwroot/lib/signalr-client/signalr-client.js</SignalRClientTargetPath>
-    </PropertyGroup>
-    <Copy Condition="Exists('$(SignalRClientDistPath)')" SourceFiles="$(SignalRClientDistPath)" DestinationFolder="$(SignalRClientTargetFolder)"/>
-    <Exec Condition="!Exists('$(SignalRClientDistPath)')" Command="npm run gulp -- --gulpfile $(MSBuildProjectDirectory)/../../src/Microsoft.AspNetCore.SignalR.Client.TS/gulpfile.js bundle-client --bundleOutDir $(SignalRClientTargetFolder)" />
+      <Copy SourceFiles="$(MSBuildThisFileDirectory)..\..\dist\browser\signalr-client.js"
+          DestinationFolder="$(MSBuildThisFileDirectory)wwwroot\lib\signalr-client"/>
   </Target>
 
 </Project>


### PR DESCRIPTION
- Creating an MSBuild project for the TS client
- Adding project references to the TS client project from projects that need the client - (ensures the correct targets dependency graph and prevents building the client multiple times and related races)
- Removing gulp tasks from individual projects (allows containing npm only in the TS client source and node tests)
- Using incremental compilation to build the TS client only when inputs change (prevents building the client multiple times or when not needed at all)
- Removing `npm install` from all the projects (takes up to 10 seconds even if there is nothing to restore) - npm packages will still be installed when running full build (if needed) or need to be installed manually