### PR TITLE
Remove logger factory requirement

### DIFF
--- a/src/Microsoft.AspNetCore.SignalR.Client/HubConnection.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client/HubConnection.cs
@@ -44,6 +44,7 @@ namespace Microsoft.AspNetCore.SignalR.Client
             add { _connection.Closed += value; }
             remove { _connection.Closed -= value; }
         }
+
         public HubConnection(Uri url, IInvocationAdapter adapter)
             : this(new Connection(url), adapter, null)
         { }

--- a/src/Microsoft.AspNetCore.SignalR.Client/HubConnection.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client/HubConnection.cs
@@ -44,30 +44,29 @@ namespace Microsoft.AspNetCore.SignalR.Client
             add { _connection.Closed += value; }
             remove { _connection.Closed -= value; }
         }
+        public HubConnection(Uri url, IInvocationAdapter adapter)
+            : this(new Connection(url), adapter, null)
+        { }
 
         public HubConnection(Uri url, IInvocationAdapter adapter, ILoggerFactory loggerFactory)
             : this(new Connection(url, loggerFactory), adapter, loggerFactory)
         { }
 
+        public HubConnection(IConnection connection, IInvocationAdapter adapter)
+            : this(connection, adapter, null)
+        { }
+
         public HubConnection(IConnection connection, IInvocationAdapter adapter, ILoggerFactory loggerFactory)
         {
-            // TODO: loggerFactory shouldn't be required
-            if (loggerFactory == null)
-            {
-                throw new ArgumentNullException(nameof(loggerFactory));
-            }
-
             if (connection == null)
             {
                 throw new ArgumentNullException(nameof(connection));
             }
 
             _connection = connection;
-
             _binder = new HubBinder(this);
             _adapter = adapter;
-            _logger = loggerFactory.CreateLogger<HubConnection>();
-
+            _logger = (loggerFactory ?? NullLoggerFactory.Instance).CreateLogger<HubConnection>();
             _connection.Received += OnDataReceived;
             _connection.Closed += Shutdown;
         }

--- a/src/Microsoft.AspNetCore.SignalR.Client/HubConnection.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client/HubConnection.cs
@@ -12,6 +12,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Sockets;
 using Microsoft.AspNetCore.Sockets.Client;
+using Microsoft.AspNetCore.Sockets.Client.Internal;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.SignalR.Client

--- a/src/Microsoft.AspNetCore.SignalR.Client/HubConnection.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client/HubConnection.cs
@@ -50,12 +50,12 @@ namespace Microsoft.AspNetCore.SignalR.Client
             : this(new Connection(url), adapter, null)
         { }
 
-        public HubConnection(Uri url, IInvocationAdapter adapter, ILoggerFactory loggerFactory)
-            : this(new Connection(url, loggerFactory), adapter, loggerFactory)
+        public HubConnection(Uri url)
+            : this(new Connection(url), new JsonNetInvocationAdapter(), null)
         { }
 
-        public HubConnection(IConnection connection, IInvocationAdapter adapter)
-            : this(connection, adapter, null)
+        public HubConnection(Uri url, IInvocationAdapter adapter, ILoggerFactory loggerFactory)
+            : this(new Connection(url, loggerFactory), adapter, loggerFactory)
         { }
 
         public HubConnection(IConnection connection, IInvocationAdapter adapter, ILoggerFactory loggerFactory)

--- a/src/Microsoft.AspNetCore.Sockets.Client/Connection.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client/Connection.cs
@@ -7,6 +7,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Threading.Tasks.Channels;
+using Microsoft.AspNetCore.Sockets.Client.Internal;
 using Microsoft.AspNetCore.Sockets.Internal;
 using Microsoft.Extensions.Logging;
 

--- a/src/Microsoft.AspNetCore.Sockets.Client/Internal/NullLoggerFactory.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client/Internal/NullLoggerFactory.cs
@@ -4,7 +4,7 @@
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
-namespace Microsoft.AspNetCore.Sockets.Client
+namespace Microsoft.AspNetCore.Sockets.Client.Internal
 {
     public class NullLoggerFactory : ILoggerFactory
     {

--- a/src/Microsoft.AspNetCore.Sockets.Client/LongPollingTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client/LongPollingTransport.cs
@@ -29,7 +29,7 @@ namespace Microsoft.AspNetCore.Sockets.Client
         public Task Running { get; private set; }
 
         public LongPollingTransport(HttpClient httpClient)
-            :this(httpClient, null)
+            : this(httpClient, null)
         { }
 
         public LongPollingTransport(HttpClient httpClient, ILoggerFactory loggerFactory)

--- a/src/Microsoft.AspNetCore.Sockets.Client/LongPollingTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client/LongPollingTransport.cs
@@ -28,6 +28,10 @@ namespace Microsoft.AspNetCore.Sockets.Client
 
         public Task Running { get; private set; }
 
+        public LongPollingTransport(HttpClient httpClient)
+            :this(httpClient, null)
+        { }
+
         public LongPollingTransport(HttpClient httpClient, ILoggerFactory loggerFactory)
         {
             _httpClient = httpClient;

--- a/src/Microsoft.AspNetCore.Sockets.Client/LongPollingTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client/LongPollingTransport.cs
@@ -35,7 +35,7 @@ namespace Microsoft.AspNetCore.Sockets.Client
         public LongPollingTransport(HttpClient httpClient, ILoggerFactory loggerFactory)
         {
             _httpClient = httpClient;
-            _logger = loggerFactory.CreateLogger<LongPollingTransport>();
+            _logger = (loggerFactory ?? NullLoggerFactory.Instance).CreateLogger<LongPollingTransport>();
         }
 
         public Task StartAsync(Uri url, IChannelConnection<Message> application)

--- a/src/Microsoft.AspNetCore.Sockets.Client/LongPollingTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client/LongPollingTransport.cs
@@ -29,10 +29,6 @@ namespace Microsoft.AspNetCore.Sockets.Client
 
         public Task Running { get; private set; }
 
-        public LongPollingTransport(HttpClient httpClient)
-            : this(httpClient, null)
-        { }
-
         public LongPollingTransport(HttpClient httpClient, ILoggerFactory loggerFactory)
         {
             _httpClient = httpClient;

--- a/src/Microsoft.AspNetCore.Sockets.Client/LongPollingTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client/LongPollingTransport.cs
@@ -9,6 +9,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Sockets.Client.Internal;
 using Microsoft.Extensions.Internal;
 using Microsoft.Extensions.Logging;
 

--- a/src/Microsoft.AspNetCore.Sockets.Client/NullLoggerFactory.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client/NullLoggerFactory.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Microsoft.AspNetCore.Sockets.Client
 {
-    internal class NullLoggerFactory : ILoggerFactory
+    public class NullLoggerFactory : ILoggerFactory
     {
         public static readonly ILoggerFactory Instance = new NullLoggerFactory();
 

--- a/src/Microsoft.AspNetCore.Sockets.Client/WebSocketsTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client/WebSocketsTransport.cs
@@ -2,13 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.IO.Pipelines;
+using System.Diagnostics;
 using System.Net.WebSockets;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Generic;
+using Microsoft.AspNetCore.Sockets.Client.Internal;
 using Microsoft.Extensions.Logging;
-using System.Diagnostics;
 
 namespace Microsoft.AspNetCore.Sockets.Client
 {

--- a/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/HubConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/HubConnectionTests.cs
@@ -46,12 +46,10 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
         [Fact]
         public async Task CheckFixedMessage()
         {
-            var loggerFactory = CreateLogger();
-
             using (var httpClient = _testServer.CreateClient())
             {
-                var transport = new LongPollingTransport(httpClient, loggerFactory);
-                var connection = new HubConnection(new Uri("http://test/hubs"), new JsonNetInvocationAdapter(), loggerFactory);
+                var transport = new LongPollingTransport(httpClient);
+                var connection = new HubConnection(new Uri("http://test/hubs"), new JsonNetInvocationAdapter());
                 try
                 {
                     await connection.StartAsync(transport, httpClient);
@@ -70,13 +68,12 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
         [Fact]
         public async Task CanSendAndReceiveMessage()
         {
-            var loggerFactory = CreateLogger();
             const string originalMessage = "SignalR";
 
             using (var httpClient = _testServer.CreateClient())
             {
-                var transport = new LongPollingTransport(httpClient, loggerFactory);
-                var connection = new HubConnection(new Uri("http://test/hubs"), new JsonNetInvocationAdapter(), loggerFactory);
+                var transport = new LongPollingTransport(httpClient);
+                var connection = new HubConnection(new Uri("http://test/hubs"), new JsonNetInvocationAdapter());
                 try
                 {
                     await connection.StartAsync(transport, httpClient);
@@ -120,13 +117,12 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
         [Fact]
         public async Task CanInvokeClientMethodFromServer()
         {
-            var loggerFactory = CreateLogger();
             const string originalMessage = "SignalR";
 
             using (var httpClient = _testServer.CreateClient())
             {
-                var transport = new LongPollingTransport(httpClient, loggerFactory);
-                var connection = new HubConnection(new Uri("http://test/hubs"), new JsonNetInvocationAdapter(), loggerFactory);
+                var transport = new LongPollingTransport(httpClient);
+                var connection = new HubConnection(new Uri("http://test/hubs"), new JsonNetInvocationAdapter());
                 try
                 {
                     await connection.StartAsync(transport, httpClient);
@@ -151,12 +147,10 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
         [Fact]
         public async Task ServerClosesConnectionIfHubMethodCannotBeResolved()
         {
-            var loggerFactory = CreateLogger();
-
             using (var httpClient = _testServer.CreateClient())
             {
-                var transport = new LongPollingTransport(httpClient, loggerFactory);
-                var connection = new HubConnection(new Uri("http://test/hubs"), new JsonNetInvocationAdapter(), loggerFactory);
+                var transport = new LongPollingTransport(httpClient);
+                var connection = new HubConnection(new Uri("http://test/hubs"), new JsonNetInvocationAdapter());
                 try
                 {
                     await connection.StartAsync(transport, httpClient);

--- a/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/HubConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/HubConnectionTests.cs
@@ -46,9 +46,11 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
         [Fact]
         public async Task CheckFixedMessage()
         {
+            var loggerFactory = CreateLogger();
+
             using (var httpClient = _testServer.CreateClient())
             {
-                var transport = new LongPollingTransport(httpClient);
+                var transport = new LongPollingTransport(httpClient, loggerFactory);
                 var connection = new HubConnection(new Uri("http://test/hubs"), new JsonNetInvocationAdapter());
                 try
                 {
@@ -68,11 +70,12 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
         [Fact]
         public async Task CanSendAndReceiveMessage()
         {
+            var loggerFactory = CreateLogger();
             const string originalMessage = "SignalR";
 
             using (var httpClient = _testServer.CreateClient())
             {
-                var transport = new LongPollingTransport(httpClient);
+                var transport = new LongPollingTransport(httpClient, loggerFactory);
                 var connection = new HubConnection(new Uri("http://test/hubs"), new JsonNetInvocationAdapter());
                 try
                 {
@@ -117,11 +120,12 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
         [Fact]
         public async Task CanInvokeClientMethodFromServer()
         {
+            var loggerFactory = CreateLogger();
             const string originalMessage = "SignalR";
 
             using (var httpClient = _testServer.CreateClient())
             {
-                var transport = new LongPollingTransport(httpClient);
+                var transport = new LongPollingTransport(httpClient, loggerFactory);
                 var connection = new HubConnection(new Uri("http://test/hubs"), new JsonNetInvocationAdapter());
                 try
                 {
@@ -147,9 +151,11 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
         [Fact]
         public async Task ServerClosesConnectionIfHubMethodCannotBeResolved()
         {
+            var loggerFactory = CreateLogger();
+
             using (var httpClient = _testServer.CreateClient())
             {
-                var transport = new LongPollingTransport(httpClient);
+                var transport = new LongPollingTransport(httpClient, loggerFactory);
                 var connection = new HubConnection(new Uri("http://test/hubs"), new JsonNetInvocationAdapter());
                 try
                 {


### PR DESCRIPTION
Cleaning things up a little bit. We shouldn't require logger factories to do things.