### PR TITLE
Add EndPoint Options

### DIFF
--- a/samples/SocialWeather/Startup.cs
+++ b/samples/SocialWeather/Startup.cs
@@ -17,7 +17,7 @@ namespace SocialWeather
         {
             services.AddRouting();
             services.AddSockets();
-            services.AddSingleton<SocialWeatherEndPoint>();
+            services.AddEndPoint<SocialWeatherEndPoint>();
             services.AddTransient<PersistentConnectionLifeTimeManager>();
             services.AddSingleton(typeof(JsonStreamFormatter<>), typeof(JsonStreamFormatter<>));
             services.AddSingleton<PipeWeatherStreamFormatter>();

--- a/samples/SocketsSample/Startup.cs
+++ b/samples/SocketsSample/Startup.cs
@@ -29,7 +29,7 @@ namespace SocketsSample
                     });
             // .AddRedis();
 
-            services.AddSingleton<MessagesEndPoint>();
+            services.AddEndPoint<MessagesEndPoint>();
             services.AddSingleton<ProtobufSerializer>();
         }
 

--- a/src/Microsoft.AspNetCore.SignalR/HubEndPoint.cs
+++ b/src/Microsoft.AspNetCore.SignalR/HubEndPoint.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.SignalR.Internal;
 using Microsoft.AspNetCore.Sockets;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.SignalR
 {
@@ -21,9 +22,10 @@ namespace Microsoft.AspNetCore.SignalR
         public HubEndPoint(HubLifetimeManager<THub> lifetimeManager,
                            IHubContext<THub> hubContext,
                            InvocationAdapterRegistry registry,
+                           IOptions<EndPointOptions<HubEndPoint<THub, IClientProxy>>> endPointOptions,
                            ILogger<HubEndPoint<THub>> logger,
                            IServiceScopeFactory serviceScopeFactory)
-            : base(lifetimeManager, hubContext, registry, logger, serviceScopeFactory)
+            : base(lifetimeManager, hubContext, registry, endPointOptions, logger, serviceScopeFactory)
         {
         }
     }
@@ -41,6 +43,7 @@ namespace Microsoft.AspNetCore.SignalR
         public HubEndPoint(HubLifetimeManager<THub> lifetimeManager,
                            IHubContext<THub, TClient> hubContext,
                            InvocationAdapterRegistry registry,
+                           IOptions<EndPointOptions<HubEndPoint<THub, TClient>>> endPointOptions,
                            ILogger<HubEndPoint<THub, TClient>> logger,
                            IServiceScopeFactory serviceScopeFactory)
         {

--- a/src/Microsoft.AspNetCore.Sockets/EndPointOptions.cs
+++ b/src/Microsoft.AspNetCore.Sockets/EndPointOptions.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Authorization;
+
+namespace Microsoft.AspNetCore.Sockets
+{
+    public class EndPointOptions<TEndPoint> where TEndPoint : EndPoint
+    {
+        public AuthorizationPolicy Policy { get; set; }
+    }
+}

--- a/src/Microsoft.AspNetCore.Sockets/EndpointDependencyInjectionExtensions.cs
+++ b/src/Microsoft.AspNetCore.Sockets/EndpointDependencyInjectionExtensions.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Sockets;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    public static class EndpointDependencyInjectionExtensions
+    {
+        public static IServiceCollection AddEndPoint<TEndPoint>(this IServiceCollection services) where TEndPoint : EndPoint
+        {
+            services.AddSingleton<TEndPoint>();
+
+            return services;
+        }
+
+        public static IServiceCollection AddEndPoint<TEndPoint>(this IServiceCollection services,
+            Action<EndPointOptions<TEndPoint>> setupAction) where TEndPoint : EndPoint
+        {
+            services.AddEndPoint<TEndPoint>();
+
+            services.Configure(setupAction);
+
+            return services;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Sockets/Microsoft.AspNetCore.Sockets.csproj
+++ b/src/Microsoft.AspNetCore.Sockets/Microsoft.AspNetCore.Sockets.csproj
@@ -14,9 +14,10 @@
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.AspNetCore.Sockets.Common\Microsoft.AspNetCore.Sockets.Common.csproj" />
     <ProjectReference Include="..\Microsoft.AspNetCore.WebSockets.Internal\Microsoft.AspNetCore.WebSockets.Internal.csproj" />
+    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Routing" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.Extensions.TaskCache.Sources" Version="$(AspNetCoreVersion)" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.Extensions.TaskCache.Sources" Version="$(AspNetCoreVersion)" PrivateAssets="All" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="$(CoreFxVersion)" />
     <PackageReference Include="System.Security.Claims" Version="$(CoreFxVersion)" />
     <PackageReference Include="System.Threading.Tasks.Channels" Version="$(CoreFxLabsVersion)" />

--- a/test/Microsoft.AspNetCore.SignalR.Test.Server/Startup.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Test.Server/Startup.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.SignalR.Test.Server
         {
             services.AddSockets();
             services.AddSignalR();
-            services.AddSingleton<EchoEndPoint>();
+            services.AddEndPoint<EchoEndPoint>();
         }
 
         public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)

--- a/test/Microsoft.AspNetCore.SignalR.Tests/ServerFixture.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/ServerFixture.cs
@@ -44,7 +44,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             {
                 services.AddSockets();
                 services.AddSignalR();
-                services.AddSingleton<EchoEndPoint>();
+                services.AddEndPoint<EchoEndPoint>();
             }
 
             public void Configure(IApplicationBuilder app, IHostingEnvironment env)

--- a/test/Microsoft.AspNetCore.Sockets.Tests/HttpConnectionDispatcherTests.cs
+++ b/test/Microsoft.AspNetCore.Sockets.Tests/HttpConnectionDispatcherTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.AspNetCore.Sockets.Tests
             var dispatcher = new HttpConnectionDispatcher(manager, new LoggerFactory());
             var context = new DefaultHttpContext();
             var services = new ServiceCollection();
-            services.AddSingleton<TestEndPoint>();
+            services.AddEndPoint<TestEndPoint>();
             context.RequestServices = services.BuildServiceProvider();
             var ms = new MemoryStream();
             context.Request.Path = "/negotiate";
@@ -56,7 +56,7 @@ namespace Microsoft.AspNetCore.Sockets.Tests
                 context.Response.Body = strm;
 
                 var services = new ServiceCollection();
-                services.AddSingleton<TestEndPoint>();
+                services.AddEndPoint<TestEndPoint>();
                 context.RequestServices = services.BuildServiceProvider();
                 context.Request.Path = path;
                 var values = new Dictionary<string, StringValues>();
@@ -85,7 +85,7 @@ namespace Microsoft.AspNetCore.Sockets.Tests
                 var context = new DefaultHttpContext();
                 context.Response.Body = strm;
                 var services = new ServiceCollection();
-                services.AddSingleton<TestEndPoint>();
+                services.AddEndPoint<TestEndPoint>();
                 context.RequestServices = services.BuildServiceProvider();
                 context.Request.Path = path;
 
@@ -318,7 +318,7 @@ namespace Microsoft.AspNetCore.Sockets.Tests
         {
             var context = new DefaultHttpContext();
             var services = new ServiceCollection();
-            services.AddSingleton<TEndPoint>();
+            services.AddEndPoint<TEndPoint>();
             context.RequestServices = services.BuildServiceProvider();
             context.Request.Path = path;
             var values = new Dictionary<string, StringValues>();


### PR DESCRIPTION
Not a huge fan of `IOptions<EndPointOptions<HubEndPoint<THub, TClient>>> endPointOptions`
Suggestions welcome!

@moozzyk @davidfowl @anurse @mikaelm12 

(Also, currently `AddEndPoint` takes an `EndPoint` like `HubEndPoint<Chat>` but resolves `EndPointOptions<HubEndPoint<Chat, IClientProxy>>` in the constructor which wont contain the values you set.)