### PR TITLE
Fix null ref in DisposeAsync on ConnectionState

### DIFF
--- a/src/Microsoft.AspNetCore.Sockets/Internal/ConnectionState.cs
+++ b/src/Microsoft.AspNetCore.Sockets/Internal/ConnectionState.cs
@@ -51,13 +51,13 @@ namespace Microsoft.AspNetCore.Sockets.Internal
                 RequestId = null;
 
                 // If the application task is faulted, propagate the error to the transport
-                if (ApplicationTask.IsFaulted)
+                if (ApplicationTask?.IsFaulted == true)
                 {
                     Connection.Transport.Output.TryComplete(ApplicationTask.Exception.InnerException);
                 }
 
                 // If the transport task is faulted, propagate the error to the application
-                if (TransportTask.IsFaulted)
+                if (TransportTask?.IsFaulted == true)
                 {
                     Application.Output.TryComplete(TransportTask.Exception.InnerException);
                 }
@@ -65,8 +65,8 @@ namespace Microsoft.AspNetCore.Sockets.Internal
                 Connection.Dispose();
                 Application.Dispose();
 
-                applicationTask = ApplicationTask;
-                transportTask = TransportTask;
+                applicationTask = ApplicationTask ?? applicationTask;
+                transportTask = TransportTask ?? transportTask;
             }
             finally
             {

--- a/test/Microsoft.AspNetCore.Sockets.Tests/ConnectionManagerTests.cs
+++ b/test/Microsoft.AspNetCore.Sockets.Tests/ConnectionManagerTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Sockets.Internal;
 using Microsoft.Extensions.Logging;
@@ -99,6 +98,20 @@ namespace Microsoft.AspNetCore.Sockets.Tests
             connectionManager.CloseConnections();
 
             await state.DisposeAsync();
+        }
+
+        [Fact]
+        public async Task DisposeInactiveConnection()
+        {
+            var connectionManager = CreateConnectionManager();
+            var state = connectionManager.CreateConnection();;
+
+            Assert.NotNull(state.Connection);
+            Assert.NotNull(state.Connection.ConnectionId);
+            Assert.NotNull(state.Connection.Transport);
+
+            await state.DisposeAsync();
+            Assert.Equal(state.Status, ConnectionState.ConnectionStatus.Disposed);
         }
 
         private static ConnectionManager CreateConnectionManager()


### PR DESCRIPTION
#244 

@moozzyk @davidfowl 

Alternatively, we could check `if (Status == Active)` and branch the code