### PR TITLE
[experiment] Use yarn instead of npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ PublishProfiles/
 *.cache
 *.docstates
 _ReSharper.*
-nuget.exe
+*.exe
 *net45.csproj
 *net451.csproj
 *k10.csproj
@@ -25,7 +25,6 @@ nuget.exe
 *.ncrunchsolution
 *.*sdf
 *.ipch
-project.lock.json
 runtimes/
 .build/
 .testPublish/
@@ -33,11 +32,11 @@ launchSettings.json
 node_modules/
 npm-debug.log
 *.tmp
-*.nuget.props
-*.nuget.targets
 autobahnreports/
-site.min.css
 .idea/
 .vscode/
 signalr-client/
 dist/
+yarn.lock
+*.min.css
+*.min.js

--- a/build/repo.targets
+++ b/build/repo.targets
@@ -1,11 +1,20 @@
 <Project>
-  <Target Name="RestoreNpm" AfterTargets="Restore" Condition="'$(PreflightRestore)' != 'True'">
-    <Message Text="Restoring NPM modules" Importance="high" />
-    <Exec Command="npm install" WorkingDirectory="$(RepositoryRoot)/client-ts" />
+  <ItemGroup>
+    <PackageReference Include="Yarn.MSBuild" Version="0.21.3-*" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <!-- Prevent yarn from running on 'Build' and 'Clean'. -->
+    <SuppressAutoYarn>true</SuppressAutoYarn>
+  </PropertyGroup>
+
+  <Target Name="RestoreYarn" AfterTargets="Restore" Condition="'$(PreflightRestore)' != 'True'">
+    <Message Text="Restoring Node modules" Importance="high" />
+    <Yarn Command="install" WorkingDirectory="$(RepositoryRoot)/client-ts" />
   </Target>
 
   <Target Name="RunTSClientNodeTests" AfterTargets="Test">
     <Message Text="Running TypeScript client Node tests" Importance="high" />
-    <Exec Command="npm test" WorkingDirectory="$(RepositoryRoot)/client-ts" />
+    <Exec Command="yarn run test" WorkingDirectory="$(RepositoryRoot)/client-ts" />
   </Target>
 </Project>

--- a/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/Microsoft.AspNetCore.SignalR.Client.TS.csproj
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/Microsoft.AspNetCore.SignalR.Client.TS.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <YarnDir>$(MSBuildThisFileDirectory)..\</YarnDir>
     <SignalRClientDistFolder>$(MSBuildThisFileDirectory)..\dist\</SignalRClientDistFolder>
   </PropertyGroup>
 
@@ -17,13 +18,15 @@
     <Outputs Include="@(Inputs -> '$(SignalRClientDistFolder)src\%(FileName).js')" />
     <Outputs Include="$(SignalRClientDistFolder)browser\signalr-client.js" />
   </ItemGroup>
+
   <ItemGroup>
     <None Include="tsconfig.json" />
+    <PackageReference Include="Yarn.MSBuild" Version="0.21.3-*" />
   </ItemGroup>
 
-  <!-- this target relies on npm packages being restored manually or when running full build -->
   <Target Name="BuildTSClient" Inputs="@(Inputs)" Outputs="@(Outputs)" BeforeTargets="Build">
-    <Exec Command="npm run gulp -- --gulpfile $(MSBuildThisFileDirectory)gulpfile.js build-ts-client" />
+    <Yarn Command="run gulp -- --gulpfile $(MSBuildThisFileDirectory)gulpfile.js build-ts-client"
+      WorkingDirectory="$(YarnDir)" />
   </Target>
 
   <Target Name="CleanTSClient" AfterTargets="Clean">


### PR DESCRIPTION
Trying to prove if https://github.com/natemcmaster/yarn.msbuild is actually useful. It seems like it will provide better perf. Need to still test on Windows.

# Comparison

On macOS:
## npm
```
./build.sh /t:RestoreNpm /clp:PerformanceSummary
```
RestoreNpm - cold cache
Ran "npm cache clean" once.
Ran "rm -rf client-ts/node_modules/" between each iteration
Run 1 : 40044 ms
Run 2 : 18277 ms
Run 3 : 15932 ms

RestoreNpm - warm cache
node_modules folder exists, no changes to package.json, cache warmed up
Run 1 : 1982 ms
Run 2 : 1975 ms 
Run 3 : 1996 ms


## yarn
```
./build.sh /t:RestoreYarn /clp:PerformanceSummary
```
RestoreYarn - cold cache
Ran "yarn cache clean" once.
Ran "rm -rf client-ts/node_modules/" between each iteration
Run 1 : 46541 ms
Run 2 : 4730 ms
Run 3 : 5320 ms

RestoreYarn - warm cache
node_modules folder exists, no changes to package.json, cache warmed up
Run 1 : 856 ms
Run 2 : 859 ms
Run 3 : 859 ms  

