### PR TITLE
autobahn + appveyor = sadness

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,8 +10,6 @@ branches:
 build_script:
   - ps: .\build.ps1
 install:
-  - set PATH=C:\Python27\scripts;%PATH%
-  - pip install autobahntestsuite
   - ps: Install-Product node 6
 clone_depth: 1
 test: off


### PR DESCRIPTION
AppVeyor isn't a fan of autobahn, I'm just going to remove the install command (and the test condition will skip the tests since they aren't available). We test it on Travis and our CI so it's still OK. This has been a consistent problem, and I'm just tired of restarting builds ;)

See https://ci.appveyor.com/project/aspnetci/signalr/build/1.0.502