### PR TITLE
Removing site.js

### DIFF
--- a/samples/ChatSample/Views/Shared/_Layout.cshtml
+++ b/samples/ChatSample/Views/Shared/_Layout.cshtml
@@ -55,7 +55,6 @@
                 asp-fallback-src="~/lib/bootstrap/dist/js/bootstrap.min.js"
                 asp-fallback-test="window.jQuery && window.jQuery.fn && window.jQuery.fn.modal">
         </script>
-        <script src="~/js/site.min.js" asp-append-version="true"></script>
     </environment>
 
     @RenderSection("scripts", required: false)

--- a/samples/ChatSample/bundleconfig.json
+++ b/samples/ChatSample/bundleconfig.json
@@ -7,18 +7,5 @@
     "inputFiles": [
       "wwwroot/css/site.css"
     ]
-  },
-  {
-    "outputFileName": "wwwroot/js/site.min.js",
-    "inputFiles": [
-      "wwwroot/js/site.js"
-    ],
-    // Optionally specify minification options
-    "minify": {
-      "enabled": true,
-      "renameLocals": true
-    },
-    // Optinally generate .map file
-    "sourceMap": false
   }
 ]

--- a/samples/ChatSample/wwwroot/js/site.js
+++ b/samples/ChatSample/wwwroot/js/site.js
@@ -1,1 +1,0 @@
-﻿// Write your Javascript code.


### PR DESCRIPTION
site.js is basically empty but was configured to create a (empty) site.min.js which would occasionally be marked as modified even there was no content (presumably because of encoding change?)