### PR TITLE
ServerSentEvents for the C# client

### DIFF
--- a/src/Microsoft.AspNetCore.Sockets.Client/DefaultTransportFactory.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client/DefaultTransportFactory.cs
@@ -39,7 +39,7 @@ namespace Microsoft.AspNetCore.Sockets.Client
 
             if ((availableServerTransports & TransportType.ServerSentEvents & _requestedTransportType) == TransportType.ServerSentEvents)
             {
-                throw new NotImplementedException();
+                return new ServerSentEventsTransport(_httpClient, _loggerFactory);
             }
 
             if ((availableServerTransports & TransportType.LongPolling & _requestedTransportType) == TransportType.LongPolling)

--- a/src/Microsoft.AspNetCore.Sockets.Client/ServerSentEventsTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client/ServerSentEventsTransport.cs
@@ -1,0 +1,232 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Pipelines;
+using System.IO.Pipelines.Text.Primitives;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Formatting;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Sockets.Internal.Formatters;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Internal;
+
+namespace Microsoft.AspNetCore.Sockets.Client
+{
+    public class ServerSentEventsTransport : ITransport
+    {
+        private static readonly string DefaultUserAgent = "Microsoft.AspNetCore.SignalR.Client/0.0.0";
+        private static readonly ProductInfoHeaderValue DefaultUserAgentHeader = ProductInfoHeaderValue.Parse(DefaultUserAgent);
+
+        private readonly HttpClient _httpClient;
+        private readonly ILogger _logger;
+        private readonly CancellationTokenSource _transportCts = new CancellationTokenSource();
+
+        private IChannelConnection<SendMessage, Message> _application;
+        private ServerSentEventsMessageParser _parser = new ServerSentEventsMessageParser();
+
+        public Task Running { get; private set; } = Task.CompletedTask;
+
+        public ServerSentEventsTransport(HttpClient httpClient)
+            : this(httpClient, null)
+        { }
+
+        public ServerSentEventsTransport(HttpClient httpClient, ILoggerFactory loggerFactory)
+        {
+            if (httpClient == null)
+            {
+                throw new ArgumentNullException(nameof(_httpClient));
+            }
+
+            _httpClient = httpClient;
+            _logger = (loggerFactory ?? NullLoggerFactory.Instance).CreateLogger<ServerSentEventsTransport>();
+        }
+
+        public Task StartAsync(Uri url, IChannelConnection<SendMessage, Message> application)
+        {
+            _logger.LogInformation("Starting {0}", nameof(ServerSentEventsTransport));
+
+            _application = application;
+            var sseUrl = Utils.AppendPath(url, "sse");
+            var sendUrl = Utils.AppendPath(url, "send");
+            var sendTask = SendMessages(sendUrl, _transportCts.Token);
+            var receiveTask = OpenConnection(_application, sseUrl, _transportCts.Token);
+
+            Running = Task.WhenAll(sendTask, receiveTask).ContinueWith(t =>
+            {
+                _logger.LogDebug("Transport stopped. Exception: '{0}'", t.Exception?.InnerException);
+
+                _application.Output.TryComplete(t.IsFaulted ? t.Exception.InnerException : null);
+                return t;
+            }).Unwrap();
+
+            return TaskCache.CompletedTask;
+        }
+
+        public async Task OpenConnection(IChannelConnection<SendMessage, Message> application, Uri url, CancellationToken cancellationToken)
+        {
+            _logger.LogInformation("Starting receive loop");
+
+            var request = new HttpRequestMessage(HttpMethod.Get, url);
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/event-stream"));
+            var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+
+            var stream = await response.Content.ReadAsStreamAsync();
+
+            var pipelineReader = stream.AsPipelineReader();
+            try
+            {
+
+            while (true)
+            {
+                var result = await pipelineReader.ReadAsync();
+                var input = result.Buffer;
+                var consumed = input.Start;
+                var examined = input.End;
+
+                try
+                {
+                    if (input.IsEmpty && result.IsCompleted)
+                    {
+                        _logger.LogDebug("Done reading from pipeline");
+                        break;
+                    }
+
+                    var parseResult = _parser.ParseMessage(input, out consumed, out examined, out var message);
+
+                    switch (parseResult)
+                    {
+                        case ServerSentEventsMessageParser.ParseResult.Completed:
+                            _application.Output.TryWrite(message);
+                            _parser.Reset();
+                            break;
+                        case ServerSentEventsMessageParser.ParseResult.Incomplete:
+                            if (result.IsCompleted)
+                            {
+                                throw new FormatException("Error parsing data from event stream");
+                            }
+                            break;
+                    }
+                }
+                finally
+                {
+                    pipelineReader.Advance(consumed, examined);
+                }
+            }
+            }
+            finally
+            {
+                _transportCts.Cancel();
+            }
+        }
+
+        public async Task SendMessages(Uri sendUrl, CancellationToken cancellationToken)
+        {
+            _logger.LogInformation("Starting the send loop");
+
+            IList<SendMessage> messages = null;
+            try
+            {
+                while (await _application.Input.WaitToReadAsync(cancellationToken))
+                {
+                    messages = new List<SendMessage>();
+                    while (!cancellationToken.IsCancellationRequested && _application.Input.TryRead(out SendMessage message))
+                    {
+                        messages.Add(message);
+                    }
+
+                    if (messages.Count > 0)
+                    {
+                        _logger.LogDebug("Sending {0} message(s) to the server using url: {1}", messages.Count, sendUrl);
+
+                        var request = new HttpRequestMessage(HttpMethod.Post, sendUrl);
+                        request.Headers.UserAgent.Add(DefaultUserAgentHeader);
+
+                        var memoryStream = new MemoryStream();
+
+                        var pipe = memoryStream.AsPipelineWriter();
+                        var output = new PipelineTextOutput(pipe, TextEncoder.Utf8);
+                        await WriteMessagesAsync(messages, output, MessageFormat.Binary);
+
+                        memoryStream.Seek(0, SeekOrigin.Begin);
+
+                        request.Content = new StreamContent(memoryStream);
+                        request.Content.Headers.ContentType = MediaTypeHeaderValue.Parse(MessageFormatter.GetContentType(MessageFormat.Binary));
+
+                        var response = await _httpClient.SendAsync(request);
+                        response.EnsureSuccessStatusCode();
+
+                        _logger.LogDebug("Message(s) sent successfully");
+                        foreach (var message in messages)
+                        {
+                            message.SendResult?.TrySetResult(null);
+                        }
+                    }
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                _logger.LogError("Send cancelled");
+
+                if (messages != null)
+                {
+                    foreach (var message in messages)
+                    {
+                        message.SendResult?.TrySetCanceled();
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug("Error while sending to '{0}' : '{1}'", sendUrl, ex);
+                if (messages != null)
+                {
+                    foreach (var message in messages)
+                    {
+                        message.SendResult?.TrySetException(ex);
+                    }
+                }
+                throw;
+            }
+            finally
+            {
+                // Make sure the poll loop is terminated
+                _transportCts.Cancel();
+            }
+
+            _logger.LogInformation("Send loop stopped");
+        }
+
+        private async Task WriteMessagesAsync(IList<SendMessage> messages, PipelineTextOutput output, MessageFormat format)
+        {
+            output.Append(MessageFormatter.GetFormatIndicator(format), TextEncoder.Utf8);
+
+            foreach (var message in messages)
+            {
+                _logger.LogDebug("Writing '{0}' message to the server", message.Type);
+
+                var payload = message.Payload ?? Array.Empty<byte>();
+                if (!MessageFormatter.TryWriteMessage(new Message(payload, message.Type, endOfMessage: true), output, format))
+                {
+                    // We didn't get any more memory!
+                    throw new InvalidOperationException("Unable to write message to pipeline");
+                }
+                await output.FlushAsync();
+            }
+        }
+
+        public async Task StopAsync()
+        {
+            _logger.LogInformation("Transport {0} is stopping", nameof(ServerSentEventsTransport));
+            _transportCts.Cancel();
+            _application.Output.TryComplete();
+            await Running;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Sockets.Common/Internal/Formatters/ServerSentEventsMessageFormatter.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Common/Internal/Formatters/ServerSentEventsMessageFormatter.cs
@@ -14,11 +14,11 @@ namespace Microsoft.AspNetCore.Sockets.Internal.Formatters
         private static readonly byte[] DataPrefix = new byte[] { (byte)'d', (byte)'a', (byte)'t', (byte)'a', (byte)':', (byte)' ' };
         private static readonly byte[] Newline = new byte[] { (byte)'\r', (byte)'\n' };
 
-        private const byte LineFeed = (byte)'\n';
-        private const char TextTypeFlag = 'T';
-        private const char BinaryTypeFlag = 'B';
-        private const char CloseTypeFlag = 'C';
-        private const char ErrorTypeFlag = 'E';
+        static readonly byte LineFeed = (byte)'\n';
+        static readonly char TextTypeFlag = 'T';
+        static readonly char BinaryTypeFlag = 'B';
+        static readonly char CloseTypeFlag = 'C';
+        static readonly char ErrorTypeFlag = 'E';
 
         public static bool TryWriteMessage(Message message, IOutput output)
         {

--- a/src/Microsoft.AspNetCore.Sockets.Common/Internal/Formatters/ServerSentEventsMessageParser.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Common/Internal/Formatters/ServerSentEventsMessageParser.cs
@@ -1,0 +1,193 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.using System;
+
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.IO.Pipelines;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace Microsoft.AspNetCore.Sockets.Internal.Formatters
+{
+    public class ServerSentEventsMessageParser
+    {
+        static readonly byte ByteCR = (byte)'\r';
+        static readonly byte ByteLF = (byte)'\n';
+
+        private InternalParseState _internalParserState = InternalParseState.ReadMessageType;
+        private IList<byte[]> _data = new List<byte[]>();
+
+        public ParseResult ParseMessage(ReadableBuffer buffer, out ReadCursor consumed, out ReadCursor examined, out Message message)
+        { 
+            consumed = buffer.Start;
+            examined = buffer.End;
+            message = new Message();
+            var messageType = MessageType.Text;
+            var reader = new ReadableBufferReader(buffer);
+
+            var start = consumed;
+            var end = examined;
+
+            while (!reader.End)
+            {
+                if (ReadCursorOperations.Seek(start, end, out var lineEnd, ByteLF) == -1)
+                {
+                    //Partial message. We need to read more.
+                    return ParseResult.Incomplete;
+                }
+
+                lineEnd = buffer.Move(lineEnd, 1);
+                var line = ConvertBufferToSpan(buffer.Slice(start, lineEnd));
+                reader.Skip(line.Length);
+
+                //Check for a misplaced '\n'
+                if (line.Length <= 1 || line[line.Length - 2] != ByteCR)
+                {
+                    throw new FormatException("There was an issue with the frame format");
+                }
+
+                //Strip the \r\n from the span
+                line = line.Slice(0, line.Length - 2);
+
+                switch (_internalParserState)
+                {
+                    case InternalParseState.ReadMessageType:
+                        messageType = GetMessageType(line);
+                        start = lineEnd;
+                        _internalParserState = InternalParseState.ReadMessagePayload;
+                        consumed = lineEnd;
+
+                        break;
+                    case InternalParseState.ReadMessagePayload:
+                        if (!StartsWithDataPrefix(line))
+                        {
+                            throw new FormatException("Expected the message prefix 'data: '");
+                        }
+
+                        //Slice away the 'data: '
+                        var newData = line.Slice(6).ToArray();
+
+                        start = lineEnd;
+                        _data.Add(newData);
+                        consumed = lineEnd;
+                        break;
+                    case InternalParseState.ReadEndOfMessage:
+                        if (ReadCursorOperations.Seek(start, end, out lineEnd, ByteLF) == -1)
+                        {
+                            // The message has ended with \r\n\r
+                            return ParseResult.Incomplete;
+                        }
+
+                        if (_data.Count > 0)
+                        {
+                            //Find the final size of the payload
+                            var payloadSize = 0;
+                            foreach (var dataLine in _data)
+                            {
+                                payloadSize += dataLine.Length;
+                            }
+                            var payload = new byte[payloadSize];
+
+                            //Copy the contents of the data array to a single buffer
+                            var offset = 0;
+                            foreach (var dataLine in _data)
+                            {
+                                dataLine.CopyTo(payload, offset);
+                                offset += dataLine.Length;
+                            }
+
+                            message = new Message(payload, messageType);
+                        }
+                        else
+                        {
+                            //Empty message
+                            message = new Message(Array.Empty<byte>(), messageType);
+                        }
+
+                        consumed = buffer.End;
+                        return ParseResult.Completed;
+                }
+
+                //Peek into next byte. If it is a carriage return byte, then advance to the next state
+                if (reader.Peek() == ByteCR)
+                {
+                    _internalParserState = InternalParseState.ReadEndOfMessage;
+                }
+            }
+            return ParseResult.Incomplete;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private Span<byte> ConvertBufferToSpan(ReadableBuffer buffer)
+        {
+            if (buffer.IsSingleSpan)
+            {
+                return buffer.First.Span;
+            }
+            return buffer.ToArray();
+        }
+
+        public void Reset()
+        {
+            _internalParserState = InternalParseState.ReadMessageType;
+            _data.Clear();
+        }
+
+        private bool StartsWithDataPrefix(ReadOnlySpan<byte> line)
+        {
+            var dataPrefix = Encoding.UTF8.GetBytes("data: ");
+            var prefixSpan = new ReadOnlySpan<byte>(dataPrefix);
+            if (line.StartsWith(dataPrefix))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private MessageType GetMessageType(ReadOnlySpan<byte> line)
+        {
+            if (!StartsWithDataPrefix(line))
+            {
+                throw new FormatException("Expected the message prefix 'data: '");
+            }
+
+            if (line.Length != 7)
+            {
+                throw new FormatException("There was an error parsing the message type");
+            }
+
+            //Skip the "data: " part of the line
+            var type = (char)line[6];
+            switch (type)
+            {
+                case 'T':
+                    return MessageType.Text;
+                case 'B':
+                    return MessageType.Binary;
+                case 'C':
+                    return MessageType.Close;
+                case 'E':
+                    return MessageType.Error;
+                default:
+                    throw new FormatException($"Unknown message type: '{type}'");
+            }
+        }
+
+        public enum ParseResult
+        {
+            Completed,
+            Incomplete,
+        }
+
+        private enum InternalParseState
+        {
+            Initial,
+            ReadMessageType,
+            ReadMessagePayload,
+            ReadEndOfMessage,
+            Error
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.SignalR.Tests/EndToEndTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/EndToEndTests.cs
@@ -78,16 +78,16 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                 var receiveTcs = new TaskCompletionSource<string>();
                 connection.Received += (data, format) => receiveTcs.TrySetResult(Encoding.UTF8.GetString(data));
                 connection.Closed += e =>
+                {
+                    if (e != null)
                     {
-                        if (e != null)
-                        {
-                            receiveTcs.TrySetException(e);
-                        }
-                        else
-                        {
-                            receiveTcs.TrySetResult(null);
-                        }
-                    };
+                        receiveTcs.TrySetException(e);
+                    }
+                    else
+                    {
+                        receiveTcs.TrySetResult(null);
+                    }
+                };
 
                 await connection.StartAsync(transportType);
 
@@ -146,6 +146,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             new[]
             {
                 new object[] { TransportType.WebSockets },
+                new object[] { TransportType.ServerSentEvents },
                 new object[] { TransportType.LongPolling }
             };
     }

--- a/test/Microsoft.AspNetCore.Sockets.Common.Tests/Internal/Formatters/ServerSentEventsParserTests.cs
+++ b/test/Microsoft.AspNetCore.Sockets.Common.Tests/Internal/Formatters/ServerSentEventsParserTests.cs
@@ -1,0 +1,83 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO.Pipelines;
+using System.Text;
+using Microsoft.AspNetCore.Sockets.Internal.Formatters;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Sockets.Common.Tests.Internal.Formatters
+{
+    public class ServerSentEventsParserTests
+    {
+        [Theory]
+        [InlineData("data: T\r\ndata: Hello, World\r\n\r\n", "Hello, World")]
+        [InlineData("data: E\r\ndata: Hello, World\r\n\r\n", "Hello, World")]
+        [InlineData("data: T\r\ndata: Hello\r\ndata: , World\r\n\r\n", "Hello, World")]
+        [InlineData("data: T\r\ndata: Major\r\ndata:  Key\r\ndata:  Alert\r\n\r\n", "Major Key Alert")]
+        [InlineData("data: T\r\n\r\n", "")]
+        public void ParseSSEMessageSuccessCases(string encodedMessage, string expectedMessage)
+        {
+            var buffer = Encoding.UTF8.GetBytes(encodedMessage);
+            var readableBuffer = ReadableBuffer.Create(buffer);
+            var parser = new ServerSentEventsMessageParser();
+            var consumed = new ReadCursor();
+            var examined = new ReadCursor();
+
+            var parsePhase = parser.ParseMessage(readableBuffer, out consumed, out examined, out Message message);
+            Assert.Equal(ServerSentEventsMessageParser.ParseResult.Completed, parsePhase);
+
+            var result = Encoding.UTF8.GetString(message.Payload);
+            Assert.Equal(expectedMessage, result);
+        }
+
+        [Theory]
+        [InlineData("data: X\r\n", "Unknown message type: 'X'")]
+        [InlineData("data: T\n", "There was an issue with the frame format")]
+        [InlineData("data: X\r\n\r\n", "Unknown message type: 'X'")]
+        [InlineData("data: Not the message type\r\n\r\n", "There was an error parsing the message type")]
+        [InlineData("data: T\r\ndata: Hello, World\r\r\n\n", "There was an issue with the frame format")]
+        [InlineData("data: Not the message type\r\r\n", "There was an error parsing the message type")]
+        [InlineData("data: T\r\ndata: Hello, World\n\n", "There was an issue with the frame format")]
+        [InlineData("data: T\r\nfoo: Hello, World\r\n\r\n", "Expected the message prefix 'data: '")]
+        [InlineData("foo: T\r\ndata: Hello, World\r\n\r\n", "Expected the message prefix 'data: '")]
+        [InlineData("food: T\r\ndata: Hello, World\r\n\r\n", "Expected the message prefix 'data: '")]
+        public void ParseSSEMessageFailureCases(string encodedMessage, string expectedExceptionMessage)
+        {
+            var buffer = Encoding.UTF8.GetBytes(encodedMessage);
+            var readableBuffer = ReadableBuffer.Create(buffer);
+            var parser = new ServerSentEventsMessageParser();
+            var consumed = new ReadCursor();
+            var examined = new ReadCursor();
+
+            var ex = Assert.Throws<FormatException>(() => { parser.ParseMessage(readableBuffer, out consumed, out examined, out Message message); });
+            Assert.Equal(expectedExceptionMessage, ex.Message);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("data:")]
+        [InlineData("data: T\r\nda")]
+        [InlineData("data: T\r\ndata:")]
+        [InlineData("data: T\r\ndata: Hello, World")]
+        [InlineData("data: T\r\ndata: Hello, World\r")]
+        [InlineData("data: T\r\ndata: Hello, World\r\n")]
+        [InlineData("data: T\r\ndata: Hello, World\r\n\r")]
+        [InlineData("data: T\r\ndata: Hello, World\r\n\r\\")]
+        [InlineData("data: T\r\ndata: Major\r\ndata:  Key\rndata:  Alert\r\n\r\\")]
+        [InlineData("data: T\r\ndata: Major\r\ndata:  Key\r\ndata:  Alert\r\n\r\\")]
+        public void ParseSSEMessageIncompleteParseResult(string encodedMessage)
+        {
+            var buffer = Encoding.UTF8.GetBytes(encodedMessage);
+            var readableBuffer = ReadableBuffer.Create(buffer);
+            var parser = new ServerSentEventsMessageParser();
+            var consumed = new ReadCursor();
+            var examined = new ReadCursor();
+
+            var parseResult = parser.ParseMessage(readableBuffer, out consumed, out examined, out Message message);
+
+            Assert.Equal(ServerSentEventsMessageParser.ParseResult.Incomplete, parseResult);
+        }
+    }
+}


### PR DESCRIPTION
+ ServerSentEventsTransport 
+ ServerSentEventsParser
+ Some basic unit tests

I shouldn't reset the parser on incomplete parse results. I need to look into this