### PR TITLE
Fix issue where multiple calls to dispose don't wait properly

### DIFF
--- a/src/Microsoft.AspNetCore.Sockets/Internal/ConnectionState.cs
+++ b/src/Microsoft.AspNetCore.Sockets/Internal/ConnectionState.cs
@@ -38,8 +38,7 @@ namespace Microsoft.AspNetCore.Sockets.Internal
 
         public async Task DisposeAsync()
         {
-            Task applicationTask = TaskCache.CompletedTask;
-            Task transportTask = TaskCache.CompletedTask;
+            Task disposeTask = TaskCache.CompletedTask;
 
             try
             {
@@ -47,31 +46,34 @@ namespace Microsoft.AspNetCore.Sockets.Internal
 
                 if (Status == ConnectionStatus.Disposed)
                 {
-                    await _disposeTcs.Task;
-                    return;
+                    disposeTask = _disposeTcs.Task;
                 }
-
-                Status = ConnectionStatus.Disposed;
-
-                RequestId = null;
-
-                // If the application task is faulted, propagate the error to the transport
-                if (ApplicationTask?.IsFaulted == true)
+                else
                 {
-                    Connection.Transport.Output.TryComplete(ApplicationTask.Exception.InnerException);
+                    Status = ConnectionStatus.Disposed;
+
+                    RequestId = null;
+
+                    // If the application task is faulted, propagate the error to the transport
+                    if (ApplicationTask?.IsFaulted == true)
+                    {
+                        Connection.Transport.Output.TryComplete(ApplicationTask.Exception.InnerException);
+                    }
+
+                    // If the transport task is faulted, propagate the error to the application
+                    if (TransportTask?.IsFaulted == true)
+                    {
+                        Application.Output.TryComplete(TransportTask.Exception.InnerException);
+                    }
+
+                    Connection.Dispose();
+                    Application.Dispose();
+
+                    var applicationTask = ApplicationTask ?? TaskCache.CompletedTask;
+                    var transportTask = TransportTask ?? TaskCache.CompletedTask;
+
+                    disposeTask = Task.WhenAll(applicationTask, transportTask);
                 }
-
-                // If the transport task is faulted, propagate the error to the application
-                if (TransportTask?.IsFaulted == true)
-                {
-                    Application.Output.TryComplete(TransportTask.Exception.InnerException);
-                }
-
-                Connection.Dispose();
-                Application.Dispose();
-
-                applicationTask = ApplicationTask ?? applicationTask;
-                transportTask = TransportTask ?? transportTask;
             }
             finally
             {
@@ -79,7 +81,7 @@ namespace Microsoft.AspNetCore.Sockets.Internal
             }
 
             // REVIEW: Add a timeout so we don't wait forever
-            await Task.WhenAll(applicationTask, transportTask);
+            await disposeTask;
 
             // Notify all waiters that we're done disposing
             _disposeTcs.TrySetResult(null);


### PR DESCRIPTION
- DisposeAsync returned immediately to anyone but the first caller.
This means that it was possible to end the request before properly
waiting on the transport task which means writing after dispose was possible.
- Added a test

Fixes #347