### PR TITLE
0b11111000 is not a valid first UTF8-8 byte

### DIFF
--- a/src/Microsoft.Extensions.WebSockets.Internal/Utf8Validator.cs
+++ b/src/Microsoft.Extensions.WebSockets.Internal/Utf8Validator.cs
@@ -12,6 +12,9 @@ namespace Microsoft.Extensions.WebSockets.Internal
     public class Utf8Validator
     {
         // Table of UTF-8 code point widths. '0' indicates an invalid first byte.
+        // 0x80 - 0xBF are the continuation bytes and invalid as first byte.
+        // 0xC0 - 0xC1 are overlong encodings of ASCII characters
+        // 0xF5 - 0xFF encode numbers that are larger than the Unicode limit (0x10FFFF)
         private static readonly byte[] _utf8Width = new byte[256]
         {
             /* 0x00 */ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, /* 0x0F */
@@ -26,10 +29,10 @@ namespace Microsoft.Extensions.WebSockets.Internal
             /* 0x90 */ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* 0x9F */
             /* 0xA0 */ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* 0xAF */
             /* 0xB0 */ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* 0xBF */
-            /* 0xC0 */ 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, /* 0xCF */
+            /* 0xC0 */ 0, 0, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, /* 0xCF */
             /* 0xD0 */ 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, /* 0xDF */
             /* 0xE0 */ 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, /* 0xEF */
-            /* 0xF0 */ 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0, 0, 0, 0, 0, /* 0xFF */
+            /* 0xF0 */ 4, 4, 4, 4, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* 0xFF */
         };
 
         // Table of masks used to extract the code point bits from the first byte. Indexed by (width - 1)

--- a/test/Microsoft.Extensions.WebSockets.Internal.Tests/WebSocketConnectionTests.Utf8Validation.cs
+++ b/test/Microsoft.Extensions.WebSockets.Internal.Tests/WebSocketConnectionTests.Utf8Validation.cs
@@ -175,8 +175,7 @@ namespace Microsoft.Extensions.WebSockets.Internal.Tests
 
         // Overlong Encoding
 
-        // 'H' (1 byte char) encoded with 2, 3 and 4 bytes
-        [InlineData(new byte[] { 0xC1 }, new byte[] { 0x88 })]
+        // 'H' (1 byte char) encoded with 3 and 4 bytes
         [InlineData(new byte[] { 0xE0 }, new byte[] { 0x81, 0x88 })]
         [InlineData(new byte[] { 0xF0 }, new byte[] { 0x80, 0x81, 0x88 })]
 


### PR DESCRIPTION
I might be overlooking something, or my counting skills are off-by-one, but that are 9 4s and only 7 0s. 0b11111000 (0xF8) is not a valid first byte of a multi-byte character in UTF-8