### PR TITLE
Adding support for Hub and HubMethod [Authorize]

### DIFF
--- a/samples/ChatSample/Hubs/Chat.cs
+++ b/samples/ChatSample/Hubs/Chat.cs
@@ -8,7 +8,6 @@ using Microsoft.AspNetCore.SignalR;
 
 namespace ChatSample.Hubs
 {
-    // TODO: Make this work
     [Authorize]
     public class Chat : Hub
     {
@@ -30,6 +29,12 @@ namespace ChatSample.Hubs
         public async Task Send(string message)
         {
             await Clients.All.InvokeAsync("Send", $"{Context.User.Identity.Name}: {message}");
+        }
+
+        [Authorize(Roles = "Moderator")]
+        public async Task Shout(string message)
+        {
+            await Clients.All.InvokeAsync("Shout", $"{Context.User.Identity.Name}: {message}");
         }
     }
 }

--- a/samples/ChatSample/Views/Home/Index.cshtml
+++ b/samples/ChatSample/Views/Home/Index.cshtml
@@ -10,6 +10,7 @@
     <form id="sendmessage" action="#">
         <input type="text" id="new-message" />
         <input type="submit" id="send" value="Send" class="send" />
+        <input type="button" id="shout" value="Shout" class="shout" />
     </form>
 </div>
 <script src="lib/signalr-client/signalr-client.js"></script>
@@ -22,17 +23,37 @@ connection.on('Send', function (message) {
     document.getElementById('messages').appendChild(child);
 });
 
+connection.on('Shout', function (message) {
+    var child = document.createElement('li');
+    child.style.color = 'blue';
+    child.style.fontWeight = 'bold';
+    child.innerText = message;
+    document.getElementById('messages').appendChild(child);
+});
+
 connection.start();
 
-document.getElementById('sendmessage').addEventListener('submit', event => {
-    let data = document.getElementById('new-message').value;
+function onSendError(err) {
+    var child = document.createElement('li');
+    child.style.color = 'red';
+    child.innerText = err;
+    document.getElementById('messages').appendChild(child);
+}
 
-    connection.invoke('Send', data).catch(err => {
-        var child = document.createElement('li');
-        child.style.color = 'red';
-        child.innerText = err;
-        document.getElementById('messages').appendChild(child);
-    });
+document.getElementById('sendmessage').addEventListener('submit', event => {
+    let element = document.getElementById('new-message');
+
+    connection.invoke('Send', element.value).catch(onSendError);
+    element.value = '';
+
+    event.preventDefault();
+});
+
+document.getElementById('shout').addEventListener('click', event => {
+    let element = document.getElementById('new-message');
+
+    connection.invoke('Shout', element.value).catch(onSendError);
+    element.value = '';
 
     event.preventDefault();
 });

--- a/test/Microsoft.AspNetCore.SignalR.Tests/HubEndpointTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/HubEndpointTests.cs
@@ -447,6 +447,298 @@ namespace Microsoft.AspNetCore.SignalR.Tests
         }
 
         [Fact]
+        public async Task CanCallProtectedHubMethodWithNamedPolicyWhenAuthenticated()
+        {
+            var serviceProvider = CreateServiceProvider(s =>
+            {
+                s.AddAuthorization(options =>
+                {
+                    options.AddPolicy("RequireAuthenticatedPolicy", policy => policy.RequireAuthenticatedUser());
+                });
+            });
+
+            var endPoint = serviceProvider.GetService<HubEndPoint<UnprotectedHub>>();
+
+            using (var client = new TestClient(serviceProvider))
+            {
+                client.Connection.User = new GenericPrincipal(new GenericIdentity("Bob"), null);
+                var endPointTask = endPoint.OnConnectedAsync(client.Connection);
+
+                var result = await client.Invoke<InvocationResultDescriptor>(nameof(UnprotectedHub.RequireAuthenticatedMethod)).OrTimeout();
+
+                Assert.Null(result.Result);
+
+                // kill the connection
+                client.Dispose();
+
+                await endPointTask.OrTimeout();
+            }
+        }
+
+        [Fact]
+        public async Task CannotCallProtectedHubMethodWithNamedPolicyWhenNotAuthenticated()
+        {
+            var serviceProvider = CreateServiceProvider(s =>
+            {
+                s.AddAuthorization(options =>
+                {
+                    options.AddPolicy("RequireAuthenticatedPolicy", policy => policy.RequireAuthenticatedUser());
+                });
+            });
+
+            var endPoint = serviceProvider.GetService<HubEndPoint<UnprotectedHub>>();
+
+            using (var client = new TestClient(serviceProvider))
+            {
+                var endPointTask = endPoint.OnConnectedAsync(client.Connection);
+
+                var result = await client.Invoke<InvocationResultDescriptor>(nameof(UnprotectedHub.RequireAuthenticatedMethod)).OrTimeout();
+
+                Assert.Equal($"Unauthorized access for Hub method '{nameof(UnprotectedHub.RequireAuthenticatedMethod)}'", result.Error);
+
+                // kill the connection
+                client.Dispose();
+
+                await endPointTask.OrTimeout();
+            }
+        }
+
+        [Fact]
+        public async Task CanCallProtectedHubMethodWithManyNamedPoliciesWhenAuthenticated()
+        {
+            var serviceProvider = CreateServiceProvider(s =>
+            {
+                s.AddAuthorization(options =>
+                {
+                    options.AddPolicy("RequireAuthenticatedPolicy", policy => policy.RequireAuthenticatedUser());
+                    options.AddPolicy("RequireUserRolePolicy", policy => policy.RequireRole("User"));
+                });
+            });
+
+            var endPoint = serviceProvider.GetService<HubEndPoint<UnprotectedHub>>();
+
+            using (var client = new TestClient(serviceProvider))
+            {
+                client.Connection.User = new GenericPrincipal(new GenericIdentity("Bob"), new[] { "User" });
+                var endPointTask = endPoint.OnConnectedAsync(client.Connection);
+
+                var result = await client.Invoke<InvocationResultDescriptor>(nameof(UnprotectedHub.RequireAuthenciatedAndUserRoleMethod)).OrTimeout();
+
+                Assert.Null(result.Result);
+
+                // kill the connection
+                client.Dispose();
+
+                await endPointTask.OrTimeout();
+            }
+        }
+
+        [Fact]
+        public async Task CannotCallProtectedHubMethodWithManyNamedPoliciesWhenNotAuthenticated()
+        {
+            var serviceProvider = CreateServiceProvider(s =>
+            {
+                s.AddAuthorization(options =>
+                {
+                    options.AddPolicy("RequireAuthenticatedPolicy", policy => policy.RequireAuthenticatedUser());
+                    options.AddPolicy("RequireUserRolePolicy", policy => policy.RequireRole("User"));
+                });
+            });
+
+            var endPoint = serviceProvider.GetService<HubEndPoint<UnprotectedHub>>();
+
+            using (var client = new TestClient(serviceProvider))
+            {
+                // Partially authenticated with authentication status
+                client.Connection.User = new GenericPrincipal(new GenericIdentity("Bob"), null);
+                var endPointTask = endPoint.OnConnectedAsync(client.Connection);
+
+                var result = await client.Invoke<InvocationResultDescriptor>(nameof(UnprotectedHub.RequireAuthenciatedAndUserRoleMethod)).OrTimeout();
+
+                Assert.Equal($"Unauthorized access for Hub method '{nameof(UnprotectedHub.RequireAuthenciatedAndUserRoleMethod)}'", result.Error);
+
+                // Partially authenticated with role
+                client.Connection.User = new GenericPrincipal(new GenericIdentity(""), new []{ "User" });
+
+                result = await client.Invoke<InvocationResultDescriptor>(nameof(UnprotectedHub.RequireAuthenciatedAndUserRoleMethod)).OrTimeout();
+
+                Assert.Equal($"Unauthorized access for Hub method '{nameof(UnprotectedHub.RequireAuthenciatedAndUserRoleMethod)}'", result.Error);
+
+                // kill the connection
+                client.Dispose();
+
+                await endPointTask.OrTimeout();
+            }
+        }
+
+        [Fact]
+        public async Task CanCallProtectedHubMethodWithRoleWhenAuthenticated()
+        {
+            var serviceProvider = CreateServiceProvider(s =>
+            {
+                s.AddAuthorization();
+            });
+
+            var endPoint = serviceProvider.GetService<HubEndPoint<UnprotectedHub>>();
+
+            using (var client = new TestClient(serviceProvider))
+            {
+                client.Connection.User = new GenericPrincipal(new GenericIdentity("Bob"), new []{ "User" });
+                var endPointTask = endPoint.OnConnectedAsync(client.Connection);
+
+                var result = await client.Invoke<InvocationResultDescriptor>(nameof(UnprotectedHub.RequireUserRoleMethod)).OrTimeout();
+
+                Assert.Null(result.Result);
+
+                // kill the connection
+                client.Dispose();
+
+                await endPointTask.OrTimeout();
+            }
+        }
+
+        [Fact]
+        public async Task CannotCallProtectedHubMethodWithRoleWhenNotAuthenticated()
+        {
+            var serviceProvider = CreateServiceProvider(s =>
+            {
+                s.AddAuthorization();
+            });
+
+            var endPoint = serviceProvider.GetService<HubEndPoint<UnprotectedHub>>();
+
+            using (var client = new TestClient(serviceProvider))
+            {
+                var endPointTask = endPoint.OnConnectedAsync(client.Connection);
+
+                var result = await client.Invoke<InvocationResultDescriptor>(nameof(UnprotectedHub.RequireUserRoleMethod)).OrTimeout();
+
+                Assert.Equal($"Unauthorized access for Hub method '{nameof(UnprotectedHub.RequireUserRoleMethod)}'", result.Error);
+
+                // kill the connection
+                client.Dispose();
+
+                await endPointTask.OrTimeout();
+            }
+        }
+
+        [Fact]
+        public async Task CanCallProtectedHubMethodWithManyRolesWhenAuthenticated()
+        {
+            var serviceProvider = CreateServiceProvider(s =>
+            {
+                s.AddAuthorization();
+            });
+
+            var endPoint = serviceProvider.GetService<HubEndPoint<UnprotectedHub>>();
+
+            using (var client = new TestClient(serviceProvider))
+            {
+                client.Connection.User = new GenericPrincipal(new GenericIdentity("Bob"), new[] { "User", "Moderator" });
+                var endPointTask = endPoint.OnConnectedAsync(client.Connection);
+
+                var result = await client.Invoke<InvocationResultDescriptor>(nameof(UnprotectedHub.RequireUserAndModeratorRoleMethod)).OrTimeout();
+
+                Assert.Null(result.Result);
+
+                // kill the connection
+                client.Dispose();
+
+                await endPointTask.OrTimeout();
+            }
+        }
+
+        [Fact]
+        public async Task CannotCallProtectedHubMethodWithManyRolesWhenNotAuthenticated()
+        {
+            var serviceProvider = CreateServiceProvider(s =>
+            {
+                s.AddAuthorization();
+            });
+
+            var endPoint = serviceProvider.GetService<HubEndPoint<UnprotectedHub>>();
+
+            using (var client = new TestClient(serviceProvider))
+            {
+                // Partially authenticated with User role
+                client.Connection.User = new GenericPrincipal(new GenericIdentity("Bob"), new[] { "User" });
+                var endPointTask = endPoint.OnConnectedAsync(client.Connection);
+
+                var result = await client.Invoke<InvocationResultDescriptor>(nameof(UnprotectedHub.RequireUserAndModeratorRoleMethod)).OrTimeout();
+
+                Assert.Equal($"Unauthorized access for Hub method '{nameof(UnprotectedHub.RequireUserAndModeratorRoleMethod)}'", result.Error);
+
+                // Partially authenticated with Moderator role
+                client.Connection.User = new GenericPrincipal(new GenericIdentity("Bob"), new[] { "Moderator" });
+
+                result = await client.Invoke<InvocationResultDescriptor>(nameof(UnprotectedHub.RequireUserAndModeratorRoleMethod)).OrTimeout();
+
+                Assert.Equal($"Unauthorized access for Hub method '{nameof(UnprotectedHub.RequireUserAndModeratorRoleMethod)}'", result.Error);
+
+                // kill the connection
+                client.Dispose();
+
+                await endPointTask.OrTimeout();
+            }
+        }
+
+        [Theory]
+        [InlineData("User")]
+        [InlineData("Moderator")]
+        [InlineData("User", "Moderator")]
+        public async Task CanCallProtectedHubMethodWithAtLeastOneRoleWhenAuthenticated(params string[] roles)
+        {
+            var serviceProvider = CreateServiceProvider(s =>
+            {
+                s.AddAuthorization();
+            });
+
+            var endPoint = serviceProvider.GetService<HubEndPoint<UnprotectedHub>>();
+
+            using (var client = new TestClient(serviceProvider))
+            {
+                client.Connection.User = new GenericPrincipal(new GenericIdentity("Bob"), roles);
+                var endPointTask = endPoint.OnConnectedAsync(client.Connection);
+
+                var result = await client.Invoke<InvocationResultDescriptor>(nameof(UnprotectedHub.RequireUserOrModeratorRoleMethod)).OrTimeout();
+
+                Assert.Null(result.Result);
+
+                // kill the connection
+                client.Dispose();
+
+                await endPointTask.OrTimeout();
+            }
+        }
+
+        [Fact]
+        public async Task CannotCallProtectedHubMethodWithAtLeastOneRoleWhenNotAuthenticated()
+        {
+            var serviceProvider = CreateServiceProvider(s =>
+            {
+                s.AddAuthorization();
+            });
+
+            var endPoint = serviceProvider.GetService<HubEndPoint<UnprotectedHub>>();
+
+            using (var client = new TestClient(serviceProvider))
+            {
+                // Partially authenticated with User role
+                client.Connection.User = new GenericPrincipal(new GenericIdentity("Bob"), null);
+                var endPointTask = endPoint.OnConnectedAsync(client.Connection);
+
+                var result = await client.Invoke<InvocationResultDescriptor>(nameof(UnprotectedHub.RequireUserOrModeratorRoleMethod)).OrTimeout();
+
+                Assert.Equal($"Unauthorized access for Hub method '{nameof(UnprotectedHub.RequireUserOrModeratorRoleMethod)}'", result.Error);
+
+                // kill the connection
+                client.Dispose();
+
+                await endPointTask.OrTimeout();
+            }
+        }
+
+        [Fact]
         public void HubsCannotHaveOverloadedMethods()
         {
             var serviceProvider = CreateServiceProvider();
@@ -788,22 +1080,33 @@ namespace Microsoft.AspNetCore.SignalR.Tests
         [Authorize]
         private class ProtectedHub : Hub
         {
-            public void ImplicitlyProtectedMethod()
-            {
-            }
+            public void ImplicitlyProtectedMethod() { }
 
             [AllowAnonymous]
-            public void UnprotectedMethod()
-            {
-            }
+            public void UnprotectedMethod() { }
         }
 
         private class UnprotectedHub : Hub
         {
             [Authorize]
-            public void ProtectedMethod()
-            {
-            }
+            public void ProtectedMethod() { }
+
+            [Authorize(Policy = "RequireAuthenticatedPolicy")]
+            public void RequireAuthenticatedMethod() { }
+
+            [Authorize(Policy = "RequireAuthenticatedPolicy")]
+            [Authorize(Policy = "RequireUserRolePolicy")]
+            public void RequireAuthenciatedAndUserRoleMethod() { }
+
+            [Authorize(Roles = "User")]
+            public void RequireUserRoleMethod() { }
+
+            [Authorize(Roles = "User")]
+            [Authorize(Roles = "Moderator")]
+            public void RequireUserAndModeratorRoleMethod() { }
+
+            [Authorize(Roles = "User,Moderator")]
+            public void RequireUserOrModeratorRoleMethod() { }
         }
 
         private class TrackDispose


### PR DESCRIPTION
- Allows for implicit method protection with [Authorize] on Hub
- Allows for [AllowAnonymous] to allow unauthorized access on protected Hub

Addresses #256 

Sneak peak / first draft for authorization implementation on Hub and Hub Methods. I'm hoping this is in alignment with the changes @BrennanConroy is doing in #254 / #255 and doesn't step on any toes there.

I added test cases and updated the ChatSample to include a Role requirement. Presently, [Authorize] on Hub is mostly useful for protecting all underlying methods as it doesn't prevent a connection unlike `EndPointOptions<>.AuthorizationPolicyNames`. There's some loose ends too on what, if at all, Authentication and Challenging looks like within the Hub context.