### PR TITLE
Work around for a Firefox bug

### DIFF
--- a/samples/ChatSample/Views/Home/Index.cshtml
+++ b/samples/ChatSample/Views/Home/Index.cshtml
@@ -14,26 +14,45 @@
 </div>
 <script src="lib/signalr-client/signalr-client.js"></script>
 <script>
+let transportType = signalR.TransportType[getParameterByName('transport')] || signalR.TransportType.WebSockets;
 let connection = new signalR.HubConnection(`http://${document.location.host}/chat`, 'formatType=json&format=text');
 
-connection.on('Send', function (message) {
-    var child = document.createElement('li');
-    child.innerText = message;
-    document.getElementById('messages').appendChild(child);
-});
+connection.on('Send', message => appendLine(message));
+connection.onClosed = e => {
+    if (e) {
+        appendLine('Connection closed with error: ' + e, 'red');
+    }
+    else {
+        appendLine('Disconnected', 'green');
+    }
+};
 
-connection.start();
+connection.start(transportType).catch(err => appendLine(err, 'red'));
 
 document.getElementById('sendmessage').addEventListener('submit', event => {
     let data = document.getElementById('new-message').value;
-
-    connection.invoke('Send', data).catch(err => {
-        var child = document.createElement('li');
-        child.style.color = 'red';
-        child.innerText = err;
-        document.getElementById('messages').appendChild(child);
-    });
-
+    connection.invoke('Send', data).catch(err => appendLine(err, 'red'));
     event.preventDefault();
 });
+
+function appendLine(line, color) {
+    let child = document.createElement('li');
+    if (color) {
+        child.style.color = color;
+    }
+    child.innerText = line;
+    document.getElementById('messages').appendChild(child);
+}
+
+function getParameterByName(name, url) {
+    if (!url) {
+        url = window.location.href;
+    }
+    name = name.replace(/[\[\]]/g, "\\$&");
+    var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
+        results = regex.exec(url);
+    if (!results) return null;
+    if (!results[2]) return '';
+    return decodeURIComponent(results[2].replace(/\+/g, " "));
+}
 </script>

--- a/src/Microsoft.AspNetCore.Sockets.Common/Internal/Formatters/ServerSentEventsMessageParser.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Common/Internal/Formatters/ServerSentEventsMessageParser.cs
@@ -13,6 +13,7 @@ namespace Microsoft.AspNetCore.Sockets.Internal.Formatters
     {
         private const byte ByteCR = (byte)'\r';
         private const byte ByteLF = (byte)'\n';
+        private const byte ByteColon = (byte)':';
         private const byte ByteT = (byte)'T';
         private const byte ByteB = (byte)'B';
         private const byte ByteC = (byte)'C';
@@ -38,7 +39,6 @@ namespace Microsoft.AspNetCore.Sockets.Internal.Formatters
 
             while (!reader.End)
             {
-
                 if (ReadCursorOperations.Seek(start, end, out var lineEnd, ByteLF) == -1)
                 {
                     // For the case of  data: Foo\r\n\r\<Anytine except \n>
@@ -61,6 +61,14 @@ namespace Microsoft.AspNetCore.Sockets.Internal.Formatters
                 if (line.Length <= 1)
                 {
                     throw new FormatException("There was an error in the frame format");
+                }
+
+                // Skip comments
+                if (line[0] == ByteColon)
+                {
+                    start = lineEnd;
+                    consumed = lineEnd;
+                    continue;
                 }
 
                 if (IsMessageEnd(line))

--- a/src/Microsoft.AspNetCore.Sockets/Transports/ServerSentEventsTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets/Transports/ServerSentEventsTransport.cs
@@ -37,6 +37,9 @@ namespace Microsoft.AspNetCore.Sockets.Transports
 
             context.Response.Headers["Content-Encoding"] = "identity";
 
+            // Workaround for a Firefox bug where EventSource won't fire the open event
+            // until it receives some data
+            await context.Response.WriteAsync(":\r\n");
             await context.Response.Body.FlushAsync();
 
             var pipe = context.Response.Body.AsPipelineWriter();

--- a/test/Microsoft.AspNetCore.Sockets.Tests/ServerSentEventsTests.cs
+++ b/test/Microsoft.AspNetCore.Sockets.Tests/ServerSentEventsTests.cs
@@ -49,9 +49,9 @@ namespace Microsoft.AspNetCore.Sockets.Tests
         }
 
         [Theory]
-        [InlineData("Hello World", "data: T\r\ndata: Hello World\r\n\r\n")]
-        [InlineData("Hello\nWorld", "data: T\r\ndata: Hello\r\ndata: World\r\n\r\n")]
-        [InlineData("Hello\r\nWorld", "data: T\r\ndata: Hello\r\ndata: World\r\n\r\n")]
+        [InlineData("Hello World", ":\r\ndata: T\r\ndata: Hello World\r\n\r\n")]
+        [InlineData("Hello\nWorld", ":\r\ndata: T\r\ndata: Hello\r\ndata: World\r\n\r\n")]
+        [InlineData("Hello\r\nWorld", ":\r\ndata: T\r\ndata: Hello\r\ndata: World\r\n\r\n")]
         public async Task SSEAddsAppropriateFraming(string message, string expected)
         {
             var channel = Channel.CreateUnbounded<Message>();


### PR DESCRIPTION
Firefox won't fire EventSource open event until it receives some data. The workaround is to send an empty comment when starting ServerSentEvent transport.

Fixes: #352