### PR TITLE
Support binary messages in SSE parser

### DIFF
--- a/src/Microsoft.AspNetCore.Sockets.Common/Internal/Formatters/MessageFormatUtils.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Common/Internal/Formatters/MessageFormatUtils.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Binary;
+
+namespace Microsoft.AspNetCore.Sockets.Internal.Formatters
+{
+    internal static class MessageFormatUtils
+    {
+        public static byte[] DecodePayload(byte[] inputPayload)
+        {
+            if (inputPayload.Length > 0)
+            {
+                // Determine the output size
+                // Every 4 Base64 characters represents 3 bytes
+                var decodedLength = (inputPayload.Length / 4) * 3;
+
+                // Subtract padding bytes
+                if (inputPayload[inputPayload.Length - 1] == '=')
+                {
+                    decodedLength -= 1;
+                }
+                if (inputPayload.Length > 1 && inputPayload[inputPayload.Length - 2] == '=')
+                {
+                    decodedLength -= 1;
+                }
+
+                // Allocate a new buffer to decode to
+                var decodeBuffer = new byte[decodedLength];
+                if (Base64.Decode(inputPayload, decodeBuffer) != decodedLength)
+                {
+                    throw new FormatException("Invalid Base64 payload");
+                }
+                return decodeBuffer;
+            }
+
+            return inputPayload;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Sockets.Common/Internal/Formatters/ServerSentEventsMessageParser.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Common/Internal/Formatters/ServerSentEventsMessageParser.cs
@@ -128,6 +128,14 @@ namespace Microsoft.AspNetCore.Sockets.Internal.Formatters
                                     offset += _newLine.Length;
                                 }
                             }
+
+                            switch (_messageType)
+                            {
+                                case MessageType.Binary:
+                                    payload = MessageFormatUtils.DecodePayload(payload);
+                                    break;
+                            }
+
                             message = new Message(payload, _messageType);
                         }
                         else
@@ -188,7 +196,7 @@ namespace Microsoft.AspNetCore.Sockets.Internal.Formatters
                 case ByteT:
                     return MessageType.Text;
                 case ByteB:
-                    throw new NotSupportedException("Support for binary messages has not been implemented yet");
+                    return MessageType.Binary;
                 case ByteC:
                     return MessageType.Close;
                 case ByteE:

--- a/src/Microsoft.AspNetCore.Sockets.Common/Internal/Formatters/ServerSentEventsMessageParser.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Common/Internal/Formatters/ServerSentEventsMessageParser.cs
@@ -107,26 +107,34 @@ namespace Microsoft.AspNetCore.Sockets.Internal.Formatters
                         {
                             payload = _data[0];
                         }
-
                         else if (_data.Count > 1)
                         {
                             // Find the final size of the payload
                             var payloadSize = 0;
                             foreach (var dataLine in _data)
                             {
-                                payloadSize += dataLine.Length + _newLine.Length;
+                                payloadSize += dataLine.Length;
                             }
 
-                            // Allocate space in the paylod buffer for the data and the new lines. 
-                            // Subtract newLine length because we don't want a trailing newline. 
-                            payload = new byte[payloadSize - _newLine.Length];
+                            if (_messageType != MessageType.Binary)
+                            {
+                                payloadSize += _newLine.Length*_data.Count;
+
+                                // Allocate space in the paylod buffer for the data and the new lines.
+                                // Subtract newLine length because we don't want a trailing newline.
+                                payload = new byte[payloadSize - _newLine.Length];
+                            }
+                            else
+                            {
+                                payload = new byte[payloadSize];
+                            }
 
                             var offset = 0;
                             foreach (var dataLine in _data)
                             {
                                 dataLine.CopyTo(payload, offset);
                                 offset += dataLine.Length;
-                                if (offset < payload.Length)
+                                if (offset < payload.Length && _messageType != MessageType.Binary)
                                 {
                                     _newLine.CopyTo(payload, offset);
                                     offset += _newLine.Length;

--- a/src/Microsoft.AspNetCore.Sockets.Common/Internal/Formatters/ServerSentEventsMessageParser.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Common/Internal/Formatters/ServerSentEventsMessageParser.cs
@@ -94,7 +94,6 @@ namespace Microsoft.AspNetCore.Sockets.Internal.Formatters
                         consumed = lineEnd;
                         break;
                     case InternalParseState.ReadMessagePayload:
-
                         // Slice away the 'data: '
                         var payloadLength = line.Length - (_dataPrefix.Length + _sseLineEnding.Length);
                         var newData = line.Slice(_dataPrefix.Length, payloadLength).ToArray();
@@ -106,15 +105,9 @@ namespace Microsoft.AspNetCore.Sockets.Internal.Formatters
                     case InternalParseState.ReadEndOfMessage:
                         if (_data.Count == 1)
                         {
-                            if (_messageType == MessageType.Binary)
-                            {
-                                payload = MessageFormatUtils.DecodePayload(_data[0]);
-                            }
-                            else
-                            {
-                                payload = _data[0];
-                            }
+                            payload = _data[0];
                         }
+
                         else if (_data.Count > 1)
                         {
                             // Find the final size of the payload
@@ -139,13 +132,11 @@ namespace Microsoft.AspNetCore.Sockets.Internal.Formatters
                                     offset += _newLine.Length;
                                 }
                             }
+                        }
 
-                            if( _messageType == MessageType.Binary)
-                            {
-                                payload = MessageFormatUtils.DecodePayload(payload);
-                            }
-
-                            message = new Message(payload, _messageType);
+                        if (_messageType == MessageType.Binary)
+                        {
+                            payload = MessageFormatUtils.DecodePayload(payload);
                         }
 
                         message = new Message(payload, _messageType);
@@ -153,6 +144,7 @@ namespace Microsoft.AspNetCore.Sockets.Internal.Formatters
                         examined = consumed;
                         return ParseResult.Completed;
                 }
+
                 if (reader.Peek() == ByteCR)
                 {
                     _internalParserState = InternalParseState.ReadEndOfMessage;

--- a/src/Microsoft.AspNetCore.Sockets.Common/Internal/Formatters/ServerSentEventsMessageParser.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Common/Internal/Formatters/ServerSentEventsMessageParser.cs
@@ -32,7 +32,6 @@ namespace Microsoft.AspNetCore.Sockets.Internal.Formatters
             examined = buffer.End;
             message = new Message();
             var reader = new ReadableBufferReader(buffer);
-            _messageType = MessageType.Text;
 
             var start = consumed;
             var end = examined;

--- a/test/Microsoft.AspNetCore.Sockets.Common.Tests/Internal/Formatters/ServerSentEventsParserTests.cs
+++ b/test/Microsoft.AspNetCore.Sockets.Common.Tests/Internal/Formatters/ServerSentEventsParserTests.cs
@@ -14,12 +14,12 @@ namespace Microsoft.AspNetCore.Sockets.Common.Tests.Internal.Formatters
     public class ServerSentEventsParserTests
     {
         [Theory]
-        //[InlineData("data: T\r\n\r\n", "")]
-        //[InlineData("data: T\r\ndata: \r\r\n\r\n", "\r")]
-        //[InlineData("data: T\r\ndata: A\rB\r\n\r\n", "A\rB")]
-        //[InlineData("data: T\r\ndata: Hello, World\r\n\r\n", "Hello, World")]
-        //[InlineData("data: T\r\ndata: Hello, World\r\n\r\n", "Hello, World")]
-        //[InlineData("data: T\r\ndata: Hello, World\r\n\r\ndata: ", "Hello, World")]
+        [InlineData("data: T\r\n\r\n", "", MessageType.Text)]
+        [InlineData("data: T\r\ndata: \r\r\n\r\n", "\r", MessageType.Text)]
+        [InlineData("data: T\r\ndata: A\rB\r\n\r\n", "A\rB", MessageType.Text)]
+        [InlineData("data: T\r\ndata: Hello, World\r\n\r\n", "Hello, World", MessageType.Text)]
+        [InlineData("data: T\r\ndata: Hello, World\r\n\r\n", "Hello, World", MessageType.Text)]
+        [InlineData("data: T\r\ndata: Hello, World\r\n\r\ndata: ", "Hello, World", MessageType.Text)]
         [InlineData("data: B\r\ndata: SGVsbG8sIFdvcmxk\r\n\r\n", "Hello, World", MessageType.Binary)]
         public void ParseSSEMessageSuccessCases(string encodedMessage, string expectedMessage, MessageType messageType)
         {
@@ -36,23 +36,23 @@ namespace Microsoft.AspNetCore.Sockets.Common.Tests.Internal.Formatters
             Assert.Equal(expectedMessage, result);
         }
 
-        //[Theory]
-        //[InlineData("data: X\r\n", "Unknown message type: 'X'")]
-        //[InlineData("data: T\n", "Unexpected '\n' in message. A '\n' character can only be used as part of the newline sequence '\r\n'")]
-        //[InlineData("data: X\r\n\r\n", "Unknown message type: 'X'")]
-        //[InlineData("data: Not the message type\r\n\r\n", "Unknown message type: 'N'")]
-        //[InlineData("data: T\r\ndata: Hello, World\r\r\n\n", "There was an error in the frame format")]
-        //[InlineData("data: Not the message type\r\r\n", "Unknown message type: 'N'")]
-        //[InlineData("data: T\r\ndata: Hello, World\n\n", "Unexpected '\n' in message. A '\n' character can only be used as part of the newline sequence '\r\n'")]
-        //[InlineData("data: T\r\nfoo: Hello, World\r\n\r\n", "Expected the message prefix 'data: '")]
-        //[InlineData("foo: T\r\ndata: Hello, World\r\n\r\n", "Expected the message prefix 'data: '")]
-        //[InlineData("food: T\r\ndata: Hello, World\r\n\r\n", "Expected the message prefix 'data: '")]
-        //[InlineData("data: T\r\ndata: Hello, World\r\n\n", "There was an error in the frame format")]
-        //[InlineData("data: T\r\ndata: Hello\n, World\r\n\r\n", "Unexpected '\n' in message. A '\n' character can only be used as part of the newline sequence '\r\n'")]
-        //[InlineData("data: data: \r\n", "Unknown message type: 'd'")]
-        //[InlineData("data: T\r\ndata: Hello, World\r\n\r\\", "Expected a \\r\\n frame ending")]
-        //[InlineData("data: T\r\ndata: Major\r\ndata:  Key\rndata:  Alert\r\n\r\\", "Expected a \\r\\n frame ending")]
-        //[InlineData("data: T\r\ndata: Major\r\ndata:  Key\r\ndata:  Alert\r\n\r\\", "Expected a \\r\\n frame ending")]
+        [Theory]
+        [InlineData("data: X\r\n", "Unknown message type: 'X'")]
+        [InlineData("data: T\n", "Unexpected '\n' in message. A '\n' character can only be used as part of the newline sequence '\r\n'")]
+        [InlineData("data: X\r\n\r\n", "Unknown message type: 'X'")]
+        [InlineData("data: Not the message type\r\n\r\n", "Unknown message type: 'N'")]
+        [InlineData("data: T\r\ndata: Hello, World\r\r\n\n", "There was an error in the frame format")]
+        [InlineData("data: Not the message type\r\r\n", "Unknown message type: 'N'")]
+        [InlineData("data: T\r\ndata: Hello, World\n\n", "Unexpected '\n' in message. A '\n' character can only be used as part of the newline sequence '\r\n'")]
+        [InlineData("data: T\r\nfoo: Hello, World\r\n\r\n", "Expected the message prefix 'data: '")]
+        [InlineData("foo: T\r\ndata: Hello, World\r\n\r\n", "Expected the message prefix 'data: '")]
+        [InlineData("food: T\r\ndata: Hello, World\r\n\r\n", "Expected the message prefix 'data: '")]
+        [InlineData("data: T\r\ndata: Hello, World\r\n\n", "There was an error in the frame format")]
+        [InlineData("data: T\r\ndata: Hello\n, World\r\n\r\n", "Unexpected '\n' in message. A '\n' character can only be used as part of the newline sequence '\r\n'")]
+        [InlineData("data: data: \r\n", "Unknown message type: 'd'")]
+        [InlineData("data: T\r\ndata: Hello, World\r\n\r\\", "Expected a \\r\\n frame ending")]
+        [InlineData("data: T\r\ndata: Major\r\ndata:  Key\rndata:  Alert\r\n\r\\", "Expected a \\r\\n frame ending")]
+        [InlineData("data: T\r\ndata: Major\r\ndata:  Key\r\ndata:  Alert\r\n\r\\", "Expected a \\r\\n frame ending")]
         public void ParseSSEMessageFailureCases(string encodedMessage, string expectedExceptionMessage)
         {
             var buffer = Encoding.UTF8.GetBytes(encodedMessage);
@@ -63,16 +63,16 @@ namespace Microsoft.AspNetCore.Sockets.Common.Tests.Internal.Formatters
             Assert.Equal(expectedExceptionMessage, ex.Message);
         }
 
-        //[Theory]
-        //[InlineData("")]
-        //[InlineData("data:")]
-        //[InlineData("data: \r")]
-        //[InlineData("data: T\r\nda")]
-        //[InlineData("data: T\r\ndata:")]
-        //[InlineData("data: T\r\ndata: Hello, World")]
-        //[InlineData("data: T\r\ndata: Hello, World\r")]
-        //[InlineData("data: T\r\ndata: Hello, World\r\n")]
-        //[InlineData("data: T\r\ndata: Hello, World\r\n\r")]
+        [Theory]
+        [InlineData("")]
+        [InlineData("data:")]
+        [InlineData("data: \r")]
+        [InlineData("data: T\r\nda")]
+        [InlineData("data: T\r\ndata:")]
+        [InlineData("data: T\r\ndata: Hello, World")]
+        [InlineData("data: T\r\ndata: Hello, World\r")]
+        [InlineData("data: T\r\ndata: Hello, World\r\n")]
+        [InlineData("data: T\r\ndata: Hello, World\r\n\r")]
         public void ParseSSEMessageIncompleteParseResult(string encodedMessage)
         {
             var buffer = Encoding.UTF8.GetBytes(encodedMessage);
@@ -84,17 +84,17 @@ namespace Microsoft.AspNetCore.Sockets.Common.Tests.Internal.Formatters
             Assert.Equal(ServerSentEventsMessageParser.ParseResult.Incomplete, parseResult);
         }
 
-        //[Theory]
-        //[InlineData("d", "ata: T\r\ndata: Hello, World\r\n\r\n", "Hello, World")]
-        //[InlineData("data: T", "\r\ndata: Hello, World\r\n\r\n", "Hello, World")]
-        //[InlineData("data: T\r", "\ndata: Hello, World\r\n\r\n", "Hello, World")]
-        //[InlineData("data: T\r\n", "data: Hello, World\r\n\r\n", "Hello, World")]
-        //[InlineData("data: T\r\nd", "ata: Hello, World\r\n\r\n", "Hello, World")]
-        //[InlineData("data: T\r\ndata: ", "Hello, World\r\n\r\n", "Hello, World")]
-        //[InlineData("data: T\r\ndata: Hello, World", "\r\n\r\n", "Hello, World")]
-        //[InlineData("data: T\r\ndata: Hello, World\r\n", "\r\n", "Hello, World")]
-        //[InlineData("data: T", "\r\ndata: Hello, World\r\n\r\n", "Hello, World")]
-        //[InlineData("data: ", "T\r\ndata: Hello, World\r\n\r\n", "Hello, World")]
+        [Theory]
+        [InlineData("d", "ata: T\r\ndata: Hello, World\r\n\r\n", "Hello, World")]
+        [InlineData("data: T", "\r\ndata: Hello, World\r\n\r\n", "Hello, World")]
+        [InlineData("data: T\r", "\ndata: Hello, World\r\n\r\n", "Hello, World")]
+        [InlineData("data: T\r\n", "data: Hello, World\r\n\r\n", "Hello, World")]
+        [InlineData("data: T\r\nd", "ata: Hello, World\r\n\r\n", "Hello, World")]
+        [InlineData("data: T\r\ndata: ", "Hello, World\r\n\r\n", "Hello, World")]
+        [InlineData("data: T\r\ndata: Hello, World", "\r\n\r\n", "Hello, World")]
+        [InlineData("data: T\r\ndata: Hello, World\r\n", "\r\n", "Hello, World")]
+        [InlineData("data: T", "\r\ndata: Hello, World\r\n\r\n", "Hello, World")]
+        [InlineData("data: ", "T\r\ndata: Hello, World\r\n\r\n", "Hello, World")]
         public async Task ParseMessageAcrossMultipleReadsSuccess(string encodedMessagePart1, string encodedMessagePart2, string expectedMessage)
         {
             using (var pipeFactory = new PipeFactory())
@@ -126,21 +126,21 @@ namespace Microsoft.AspNetCore.Sockets.Common.Tests.Internal.Formatters
             }
         }
 
-        //[Theory]
-        //[InlineData("data: ", "X\r\n", "Unknown message type: 'X'")]
-        //[InlineData("data: T", "\n", "Unexpected '\n' in message. A '\n' character can only be used as part of the newline sequence '\r\n'")]
-        //[InlineData("data: ", "X\r\n\r\n", "Unknown message type: 'X'")]
-        //[InlineData("data: ", "Not the message type\r\n\r\n", "Unknown message type: 'N'")]
-        //[InlineData("data: T\r\n", "data: Hello, World\r\r\n\n", "There was an error in the frame format")]
-        //[InlineData("data:", " Not the message type\r\r\n", "Unknown message type: 'N'")]
-        //[InlineData("data: T\r\n", "data: Hello, World\n\n", "Unexpected '\n' in message. A '\n' character can only be used as part of the newline sequence '\r\n'")]
-        //[InlineData("data: T\r\nf", "oo: Hello, World\r\n\r\n", "Expected the message prefix 'data: '")]
-        //[InlineData("foo", ": T\r\ndata: Hello, World\r\n\r\n", "Expected the message prefix 'data: '")]
-        //[InlineData("food:", " T\r\ndata: Hello, World\r\n\r\n", "Expected the message prefix 'data: '")]
-        //[InlineData("data: T\r\ndata: Hello, W", "orld\r\n\n", "There was an error in the frame format")]
-        //[InlineData("data: T\r\nda", "ta: Hello\n, World\r\n\r\n", "Unexpected '\n' in message. A '\n' character can only be used as part of the newline sequence '\r\n'")]
-        //[InlineData("data:", " data: \r\n", "Unknown message type: 'd'")]
-        //[InlineData("data: ", "T\r\ndata: Major\r\ndata:  Key\r\ndata:  Alert\r\n\r\\", "Expected a \\r\\n frame ending")]
+        [Theory]
+        [InlineData("data: ", "X\r\n", "Unknown message type: 'X'")]
+        [InlineData("data: T", "\n", "Unexpected '\n' in message. A '\n' character can only be used as part of the newline sequence '\r\n'")]
+        [InlineData("data: ", "X\r\n\r\n", "Unknown message type: 'X'")]
+        [InlineData("data: ", "Not the message type\r\n\r\n", "Unknown message type: 'N'")]
+        [InlineData("data: T\r\n", "data: Hello, World\r\r\n\n", "There was an error in the frame format")]
+        [InlineData("data:", " Not the message type\r\r\n", "Unknown message type: 'N'")]
+        [InlineData("data: T\r\n", "data: Hello, World\n\n", "Unexpected '\n' in message. A '\n' character can only be used as part of the newline sequence '\r\n'")]
+        [InlineData("data: T\r\nf", "oo: Hello, World\r\n\r\n", "Expected the message prefix 'data: '")]
+        [InlineData("foo", ": T\r\ndata: Hello, World\r\n\r\n", "Expected the message prefix 'data: '")]
+        [InlineData("food:", " T\r\ndata: Hello, World\r\n\r\n", "Expected the message prefix 'data: '")]
+        [InlineData("data: T\r\ndata: Hello, W", "orld\r\n\n", "There was an error in the frame format")]
+        [InlineData("data: T\r\nda", "ta: Hello\n, World\r\n\r\n", "Unexpected '\n' in message. A '\n' character can only be used as part of the newline sequence '\r\n'")]
+        [InlineData("data:", " data: \r\n", "Unknown message type: 'd'")]
+        [InlineData("data: ", "T\r\ndata: Major\r\ndata:  Key\r\ndata:  Alert\r\n\r\\", "Expected a \\r\\n frame ending")]
         public async Task ParseMessageAcrossMultipleReadsFailure(string encodedMessagePart1, string encodedMessagePart2, string expectedMessage)
         {
             using (var pipeFactory = new PipeFactory())
@@ -168,7 +168,7 @@ namespace Microsoft.AspNetCore.Sockets.Common.Tests.Internal.Formatters
             }
         }
 
-        //[Fact]
+        [Fact]
         public async Task ParseMultipleMessages()
         {
             using (var pipeFactory = new PipeFactory())
@@ -211,8 +211,8 @@ namespace Microsoft.AspNetCore.Sockets.Common.Tests.Internal.Formatters
             }
         }
 
-        //[Theory]
-        //[MemberData(nameof(MultilineMessages))]
+        [Theory]
+        [MemberData(nameof(MultilineMessages))]
         public void ParseMessagesWithMultipleDataLines(string encodedMessage, string expectedMessage)
         {
             var buffer = Encoding.UTF8.GetBytes(encodedMessage);

--- a/test/Microsoft.AspNetCore.Sockets.Common.Tests/Internal/Formatters/ServerSentEventsParserTests.cs
+++ b/test/Microsoft.AspNetCore.Sockets.Common.Tests/Internal/Formatters/ServerSentEventsParserTests.cs
@@ -146,7 +146,6 @@ namespace Microsoft.AspNetCore.Sockets.Common.Tests.Internal.Formatters
         [InlineData("data:", " data: \r\n", "Unknown message type: 'd'")]
         [InlineData("data: ", "T\r\ndata: Major\r\ndata:  Key\r\ndata:  Alert\r\n\r\\", "Expected a \\r\\n frame ending")]
         [InlineData("data: B\r\ndata: SGVs", "bG8sIFdvcmxk\r\n\n\n", "There was an error in the frame format")]
-
         public async Task ParseMessageAcrossMultipleReadsFailure(string encodedMessagePart1, string encodedMessagePart2, string expectedMessage)
         {
             using (var pipeFactory = new PipeFactory())

--- a/test/Microsoft.AspNetCore.Sockets.Common.Tests/Internal/Formatters/ServerSentEventsParserTests.cs
+++ b/test/Microsoft.AspNetCore.Sockets.Common.Tests/Internal/Formatters/ServerSentEventsParserTests.cs
@@ -14,13 +14,14 @@ namespace Microsoft.AspNetCore.Sockets.Common.Tests.Internal.Formatters
     public class ServerSentEventsParserTests
     {
         [Theory]
-        [InlineData("data: T\r\n\r\n", "")]
-        [InlineData("data: T\r\ndata: \r\r\n\r\n", "\r")]
-        [InlineData("data: T\r\ndata: A\rB\r\n\r\n", "A\rB")]
-        [InlineData("data: T\r\ndata: Hello, World\r\n\r\n", "Hello, World")]
-        [InlineData("data: T\r\ndata: Hello, World\r\n\r\n", "Hello, World")]
-        [InlineData("data: T\r\ndata: Hello, World\r\n\r\ndata: ", "Hello, World")]
-        public void ParseSSEMessageSuccessCases(string encodedMessage, string expectedMessage)
+        //[InlineData("data: T\r\n\r\n", "")]
+        //[InlineData("data: T\r\ndata: \r\r\n\r\n", "\r")]
+        //[InlineData("data: T\r\ndata: A\rB\r\n\r\n", "A\rB")]
+        //[InlineData("data: T\r\ndata: Hello, World\r\n\r\n", "Hello, World")]
+        //[InlineData("data: T\r\ndata: Hello, World\r\n\r\n", "Hello, World")]
+        //[InlineData("data: T\r\ndata: Hello, World\r\n\r\ndata: ", "Hello, World")]
+        [InlineData("data: B\r\ndata: SGVsbG8sIFdvcmxk\r\n\r\n", "Hello, World", MessageType.Binary)]
+        public void ParseSSEMessageSuccessCases(string encodedMessage, string expectedMessage, MessageType messageType)
         {
             var buffer = Encoding.UTF8.GetBytes(encodedMessage);
             var readableBuffer = ReadableBuffer.Create(buffer);
@@ -28,30 +29,30 @@ namespace Microsoft.AspNetCore.Sockets.Common.Tests.Internal.Formatters
 
             var parseResult = parser.ParseMessage(readableBuffer, out var consumed, out var examined, out Message message);
             Assert.Equal(ServerSentEventsMessageParser.ParseResult.Completed, parseResult);
-            Assert.Equal(MessageType.Text, message.Type);
+            Assert.Equal(messageType, message.Type);
             Assert.Equal(consumed, examined);
 
             var result = Encoding.UTF8.GetString(message.Payload);
             Assert.Equal(expectedMessage, result);
         }
 
-        [Theory]
-        [InlineData("data: X\r\n", "Unknown message type: 'X'")]
-        [InlineData("data: T\n", "Unexpected '\n' in message. A '\n' character can only be used as part of the newline sequence '\r\n'")]
-        [InlineData("data: X\r\n\r\n", "Unknown message type: 'X'")]
-        [InlineData("data: Not the message type\r\n\r\n", "Unknown message type: 'N'")]
-        [InlineData("data: T\r\ndata: Hello, World\r\r\n\n", "There was an error in the frame format")]
-        [InlineData("data: Not the message type\r\r\n", "Unknown message type: 'N'")]
-        [InlineData("data: T\r\ndata: Hello, World\n\n", "Unexpected '\n' in message. A '\n' character can only be used as part of the newline sequence '\r\n'")]
-        [InlineData("data: T\r\nfoo: Hello, World\r\n\r\n", "Expected the message prefix 'data: '")]
-        [InlineData("foo: T\r\ndata: Hello, World\r\n\r\n", "Expected the message prefix 'data: '")]
-        [InlineData("food: T\r\ndata: Hello, World\r\n\r\n", "Expected the message prefix 'data: '")]
-        [InlineData("data: T\r\ndata: Hello, World\r\n\n", "There was an error in the frame format")]
-        [InlineData("data: T\r\ndata: Hello\n, World\r\n\r\n", "Unexpected '\n' in message. A '\n' character can only be used as part of the newline sequence '\r\n'")]
-        [InlineData("data: data: \r\n", "Unknown message type: 'd'")]
-        [InlineData("data: T\r\ndata: Hello, World\r\n\r\\", "Expected a \\r\\n frame ending")]
-        [InlineData("data: T\r\ndata: Major\r\ndata:  Key\rndata:  Alert\r\n\r\\", "Expected a \\r\\n frame ending")]
-        [InlineData("data: T\r\ndata: Major\r\ndata:  Key\r\ndata:  Alert\r\n\r\\", "Expected a \\r\\n frame ending")]
+        //[Theory]
+        //[InlineData("data: X\r\n", "Unknown message type: 'X'")]
+        //[InlineData("data: T\n", "Unexpected '\n' in message. A '\n' character can only be used as part of the newline sequence '\r\n'")]
+        //[InlineData("data: X\r\n\r\n", "Unknown message type: 'X'")]
+        //[InlineData("data: Not the message type\r\n\r\n", "Unknown message type: 'N'")]
+        //[InlineData("data: T\r\ndata: Hello, World\r\r\n\n", "There was an error in the frame format")]
+        //[InlineData("data: Not the message type\r\r\n", "Unknown message type: 'N'")]
+        //[InlineData("data: T\r\ndata: Hello, World\n\n", "Unexpected '\n' in message. A '\n' character can only be used as part of the newline sequence '\r\n'")]
+        //[InlineData("data: T\r\nfoo: Hello, World\r\n\r\n", "Expected the message prefix 'data: '")]
+        //[InlineData("foo: T\r\ndata: Hello, World\r\n\r\n", "Expected the message prefix 'data: '")]
+        //[InlineData("food: T\r\ndata: Hello, World\r\n\r\n", "Expected the message prefix 'data: '")]
+        //[InlineData("data: T\r\ndata: Hello, World\r\n\n", "There was an error in the frame format")]
+        //[InlineData("data: T\r\ndata: Hello\n, World\r\n\r\n", "Unexpected '\n' in message. A '\n' character can only be used as part of the newline sequence '\r\n'")]
+        //[InlineData("data: data: \r\n", "Unknown message type: 'd'")]
+        //[InlineData("data: T\r\ndata: Hello, World\r\n\r\\", "Expected a \\r\\n frame ending")]
+        //[InlineData("data: T\r\ndata: Major\r\ndata:  Key\rndata:  Alert\r\n\r\\", "Expected a \\r\\n frame ending")]
+        //[InlineData("data: T\r\ndata: Major\r\ndata:  Key\r\ndata:  Alert\r\n\r\\", "Expected a \\r\\n frame ending")]
         public void ParseSSEMessageFailureCases(string encodedMessage, string expectedExceptionMessage)
         {
             var buffer = Encoding.UTF8.GetBytes(encodedMessage);
@@ -62,16 +63,16 @@ namespace Microsoft.AspNetCore.Sockets.Common.Tests.Internal.Formatters
             Assert.Equal(expectedExceptionMessage, ex.Message);
         }
 
-        [Theory]
-        [InlineData("")]
-        [InlineData("data:")]
-        [InlineData("data: \r")]
-        [InlineData("data: T\r\nda")]
-        [InlineData("data: T\r\ndata:")]
-        [InlineData("data: T\r\ndata: Hello, World")]
-        [InlineData("data: T\r\ndata: Hello, World\r")]
-        [InlineData("data: T\r\ndata: Hello, World\r\n")]
-        [InlineData("data: T\r\ndata: Hello, World\r\n\r")]
+        //[Theory]
+        //[InlineData("")]
+        //[InlineData("data:")]
+        //[InlineData("data: \r")]
+        //[InlineData("data: T\r\nda")]
+        //[InlineData("data: T\r\ndata:")]
+        //[InlineData("data: T\r\ndata: Hello, World")]
+        //[InlineData("data: T\r\ndata: Hello, World\r")]
+        //[InlineData("data: T\r\ndata: Hello, World\r\n")]
+        //[InlineData("data: T\r\ndata: Hello, World\r\n\r")]
         public void ParseSSEMessageIncompleteParseResult(string encodedMessage)
         {
             var buffer = Encoding.UTF8.GetBytes(encodedMessage);
@@ -83,17 +84,17 @@ namespace Microsoft.AspNetCore.Sockets.Common.Tests.Internal.Formatters
             Assert.Equal(ServerSentEventsMessageParser.ParseResult.Incomplete, parseResult);
         }
 
-        [Theory]
-        [InlineData("d", "ata: T\r\ndata: Hello, World\r\n\r\n", "Hello, World")]
-        [InlineData("data: T", "\r\ndata: Hello, World\r\n\r\n", "Hello, World")]
-        [InlineData("data: T\r", "\ndata: Hello, World\r\n\r\n", "Hello, World")]
-        [InlineData("data: T\r\n", "data: Hello, World\r\n\r\n", "Hello, World")]
-        [InlineData("data: T\r\nd", "ata: Hello, World\r\n\r\n", "Hello, World")]
-        [InlineData("data: T\r\ndata: ", "Hello, World\r\n\r\n", "Hello, World")]
-        [InlineData("data: T\r\ndata: Hello, World", "\r\n\r\n", "Hello, World")]
-        [InlineData("data: T\r\ndata: Hello, World\r\n", "\r\n", "Hello, World")]
-        [InlineData("data: T", "\r\ndata: Hello, World\r\n\r\n", "Hello, World")]
-        [InlineData("data: ", "T\r\ndata: Hello, World\r\n\r\n", "Hello, World")]
+        //[Theory]
+        //[InlineData("d", "ata: T\r\ndata: Hello, World\r\n\r\n", "Hello, World")]
+        //[InlineData("data: T", "\r\ndata: Hello, World\r\n\r\n", "Hello, World")]
+        //[InlineData("data: T\r", "\ndata: Hello, World\r\n\r\n", "Hello, World")]
+        //[InlineData("data: T\r\n", "data: Hello, World\r\n\r\n", "Hello, World")]
+        //[InlineData("data: T\r\nd", "ata: Hello, World\r\n\r\n", "Hello, World")]
+        //[InlineData("data: T\r\ndata: ", "Hello, World\r\n\r\n", "Hello, World")]
+        //[InlineData("data: T\r\ndata: Hello, World", "\r\n\r\n", "Hello, World")]
+        //[InlineData("data: T\r\ndata: Hello, World\r\n", "\r\n", "Hello, World")]
+        //[InlineData("data: T", "\r\ndata: Hello, World\r\n\r\n", "Hello, World")]
+        //[InlineData("data: ", "T\r\ndata: Hello, World\r\n\r\n", "Hello, World")]
         public async Task ParseMessageAcrossMultipleReadsSuccess(string encodedMessagePart1, string encodedMessagePart2, string expectedMessage)
         {
             using (var pipeFactory = new PipeFactory())
@@ -125,21 +126,21 @@ namespace Microsoft.AspNetCore.Sockets.Common.Tests.Internal.Formatters
             }
         }
 
-        [Theory]
-        [InlineData("data: ", "X\r\n", "Unknown message type: 'X'")]
-        [InlineData("data: T", "\n", "Unexpected '\n' in message. A '\n' character can only be used as part of the newline sequence '\r\n'")]
-        [InlineData("data: ", "X\r\n\r\n", "Unknown message type: 'X'")]
-        [InlineData("data: ", "Not the message type\r\n\r\n", "Unknown message type: 'N'")]
-        [InlineData("data: T\r\n", "data: Hello, World\r\r\n\n", "There was an error in the frame format")]
-        [InlineData("data:", " Not the message type\r\r\n", "Unknown message type: 'N'")]
-        [InlineData("data: T\r\n", "data: Hello, World\n\n", "Unexpected '\n' in message. A '\n' character can only be used as part of the newline sequence '\r\n'")]
-        [InlineData("data: T\r\nf", "oo: Hello, World\r\n\r\n", "Expected the message prefix 'data: '")]
-        [InlineData("foo", ": T\r\ndata: Hello, World\r\n\r\n", "Expected the message prefix 'data: '")]
-        [InlineData("food:", " T\r\ndata: Hello, World\r\n\r\n", "Expected the message prefix 'data: '")]
-        [InlineData("data: T\r\ndata: Hello, W", "orld\r\n\n", "There was an error in the frame format")]
-        [InlineData("data: T\r\nda", "ta: Hello\n, World\r\n\r\n", "Unexpected '\n' in message. A '\n' character can only be used as part of the newline sequence '\r\n'")]
-        [InlineData("data:", " data: \r\n", "Unknown message type: 'd'")]
-        [InlineData("data: ", "T\r\ndata: Major\r\ndata:  Key\r\ndata:  Alert\r\n\r\\", "Expected a \\r\\n frame ending")]
+        //[Theory]
+        //[InlineData("data: ", "X\r\n", "Unknown message type: 'X'")]
+        //[InlineData("data: T", "\n", "Unexpected '\n' in message. A '\n' character can only be used as part of the newline sequence '\r\n'")]
+        //[InlineData("data: ", "X\r\n\r\n", "Unknown message type: 'X'")]
+        //[InlineData("data: ", "Not the message type\r\n\r\n", "Unknown message type: 'N'")]
+        //[InlineData("data: T\r\n", "data: Hello, World\r\r\n\n", "There was an error in the frame format")]
+        //[InlineData("data:", " Not the message type\r\r\n", "Unknown message type: 'N'")]
+        //[InlineData("data: T\r\n", "data: Hello, World\n\n", "Unexpected '\n' in message. A '\n' character can only be used as part of the newline sequence '\r\n'")]
+        //[InlineData("data: T\r\nf", "oo: Hello, World\r\n\r\n", "Expected the message prefix 'data: '")]
+        //[InlineData("foo", ": T\r\ndata: Hello, World\r\n\r\n", "Expected the message prefix 'data: '")]
+        //[InlineData("food:", " T\r\ndata: Hello, World\r\n\r\n", "Expected the message prefix 'data: '")]
+        //[InlineData("data: T\r\ndata: Hello, W", "orld\r\n\n", "There was an error in the frame format")]
+        //[InlineData("data: T\r\nda", "ta: Hello\n, World\r\n\r\n", "Unexpected '\n' in message. A '\n' character can only be used as part of the newline sequence '\r\n'")]
+        //[InlineData("data:", " data: \r\n", "Unknown message type: 'd'")]
+        //[InlineData("data: ", "T\r\ndata: Major\r\ndata:  Key\r\ndata:  Alert\r\n\r\\", "Expected a \\r\\n frame ending")]
         public async Task ParseMessageAcrossMultipleReadsFailure(string encodedMessagePart1, string encodedMessagePart2, string expectedMessage)
         {
             using (var pipeFactory = new PipeFactory())
@@ -167,7 +168,7 @@ namespace Microsoft.AspNetCore.Sockets.Common.Tests.Internal.Formatters
             }
         }
 
-        [Fact]
+        //[Fact]
         public async Task ParseMultipleMessages()
         {
             using (var pipeFactory = new PipeFactory())
@@ -210,8 +211,8 @@ namespace Microsoft.AspNetCore.Sockets.Common.Tests.Internal.Formatters
             }
         }
 
-        [Theory]
-        [MemberData(nameof(MultilineMessages))]
+        //[Theory]
+        //[MemberData(nameof(MultilineMessages))]
         public void ParseMessagesWithMultipleDataLines(string encodedMessage, string expectedMessage)
         {
             var buffer = Encoding.UTF8.GetBytes(encodedMessage);
@@ -225,18 +226,6 @@ namespace Microsoft.AspNetCore.Sockets.Common.Tests.Internal.Formatters
 
             var result = Encoding.UTF8.GetString(message.Payload);
             Assert.Equal(expectedMessage, result);
-        }
-
-        [Fact]
-        public void ParseSSEMessageBinaryNotSupported()
-        {
-            var encodedMessage = "data: B\r\ndata: \r\n\r\n";
-            var buffer = Encoding.UTF8.GetBytes(encodedMessage);
-            var readableBuffer = ReadableBuffer.Create(buffer);
-            var parser = new ServerSentEventsMessageParser();
-
-            var ex = Assert.Throws<NotSupportedException>(() => { parser.ParseMessage(readableBuffer, out var consumed, out var examined, out Message message); });
-            Assert.Equal("Support for binary messages has not been implemented yet", ex.Message);
         }
     }
 }


### PR DESCRIPTION
This add functionality for properly handling binary messages over SSE. 
It introduces a new `MessageFormatUtils` class that handles the binary payload.
It also fixes a bug where the message type was being reset on calls to ParseMessage