### PR TITLE
prevent websocket deadlock

### DIFF
--- a/test/Microsoft.AspNetCore.SignalR.Tests/EchoEndPoint.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/EchoEndPoint.cs
@@ -1,10 +1,8 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.IO.Pipelines;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Sockets;
-
 
 namespace Microsoft.AspNetCore.SignalR.Tests
 {

--- a/test/Microsoft.AspNetCore.SignalR.Tests/EndToEndTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/EndToEndTests.cs
@@ -92,6 +92,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                 try
                 {
                     var receiveTcs = new TaskCompletionSource<string>();
+                    var closeTcs = new TaskCompletionSource<object>();
                     connection.Received += (data, format) =>
                     {
                         logger.LogInformation("Received {length} byte message", data.Length);
@@ -108,6 +109,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                         {
                             receiveTcs.TrySetResult(null);
                         }
+                        closeTcs.TrySetResult(null);
                     };
 
                     logger.LogInformation("Starting connection to {url}", url);
@@ -124,6 +126,8 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                     logger.LogInformation("Receiving message");
                     Assert.Equal(message, await receiveTcs.Task.OrTimeout());
                     logger.LogInformation("Completed receive");
+
+                    await closeTcs.Task.OrTimeout();
                 }
                 finally
                 {


### PR DESCRIPTION
This should avoid the hung tests we're seeing.

/cc @mikeharder 