### PR TITLE
disable npm optional dependencies

### DIFF
--- a/build/repo.targets
+++ b/build/repo.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="RestoreNpm" AfterTargets="Restore" Condition="'$(PreflightRestore)' != 'True'">
     <Message Text="Restoring NPM modules" Importance="high" />
-    <Exec Command="npm install" WorkingDirectory="$(RepositoryRoot)client-ts" />
+    <Exec Command="npm install --no-optional" WorkingDirectory="$(RepositoryRoot)client-ts" />
   </Target>
 
   <Target Name="RunTSClientNodeTests" AfterTargets="Test">


### PR DESCRIPTION
'microtime' doesn't build properly on our CI agents

This should unblock the build @mikeharder 

@moozzyk We should discuss the right way to solve this, SignalR builds were failing in CI with: `C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\V140\Platforms\x64\PlatformToolsets\v140\Toolset.targets(36,5): error MSB8036: The Windows SDK version 8.1 was not found. Install the required version of Windows SDK or change the SDK version in the project property pages or by right-clicking the solution and selecting "Retarget solution". [C:\b\w\590aeb6bc9b87cb8\.r\SignalR\client-ts\node_modules\microtime\build\microtime.vcxproj] [C:\b\w\590aeb6bc9b87cb8\.r\SignalR\.build\KoreBuild.proj]`

We could just install the Windows 8.1 SDK, but we need to make sure our repo dependencies are documented.