### PR TITLE
Increase the size of the WebSockets buffer to 4K.

### DIFF
--- a/src/Microsoft.AspNetCore.Sockets.Client/WebSocketsTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client/WebSocketsTransport.cs
@@ -68,7 +68,7 @@ namespace Microsoft.AspNetCore.Sockets.Client
 
             while (!cancellationToken.IsCancellationRequested)
             {
-                const int bufferSize = 1024;
+                const int bufferSize = 4096;
                 var totalBytes = 0;
                 var incomingMessage = new List<ArraySegment<byte>>();
                 WebSocketReceiveResult receiveResult;

--- a/test/Microsoft.AspNetCore.SignalR.Tests/EndToEndTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/EndToEndTests.cs
@@ -142,8 +142,8 @@ namespace Microsoft.AspNetCore.SignalR.Tests
         {
             get
             {
-                yield return new object[] { new string('A', 5 * 1024) };
-                yield return new object[] { new string('A', 5 * 1024 * 1024 + 32) };
+                yield return new object[] { new string('A', 5 * 4096) };
+                yield return new object[] { new string('A', 1000 * 4096 + 32) };
             }
         }
 


### PR DESCRIPTION
Addresses issue: https://github.com/aspnet/SignalR/issues/271