### PR TITLE
Change the size header to little endian

### DIFF
--- a/specs/TransportProtocols.md
+++ b/specs/TransportProtocols.md
@@ -174,7 +174,7 @@ The body is encoded as follows. The `Content-Type` response header is set to `ap
 B([Length][Type][Body])([Length][Type][Body])... continues until end of the response body ...
 ```
 
-* `[Length]` - A 64-bit integer in Network Byte Order (Big-endian) representing the length of the body in bytes
+* `[Length]` - A 64-bit integer in Little Endian Byte Order representing the length of the body in bytes
 * `[Type]` - An 8-bit integer indicating the type of the message.
     * `0x00` => `Text` - `[Body]` is UTF-8 encoded text data
     * `0x01` => `Binary` - `[Body]` is raw binary data


### PR DESCRIPTION
While it has been traditional to use Big Endian byte orders in protocols, it really is only that a tradition. As almost all platforms (ARM can run in both in theory, but isn't normally configured for anything other than Little, and I think the XBOX) will run in little endian is there a good reason to burn ops/the hassle of bit flipping?