### PR TITLE
Fixing `dotnet ef database update`

### DIFF
--- a/samples/ChatSample/Data/ApplicationDbContextFactory.cs
+++ b/samples/ChatSample/Data/ApplicationDbContextFactory.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.Configuration;
+
+namespace ChatSample.Data
+{
+    public class ApplicationDbContextFactory : IDbContextFactory<ApplicationDbContext>
+    {
+        public ApplicationDbContext Create(string[] args)
+        {
+            var configurationBuilder = new ConfigurationBuilder()
+                .SetBasePath(Path.Combine(Directory.GetCurrentDirectory()))
+                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true);
+
+            var optionsBuilder = new DbContextOptionsBuilder<ApplicationDbContext>();
+            optionsBuilder.UseSqlServer(configurationBuilder.Build().GetConnectionString("DefaultConnection"));
+
+            return new ApplicationDbContext(optionsBuilder.Options);
+        }
+    }
+}

--- a/samples/ChatSample/Startup.cs
+++ b/samples/ChatSample/Startup.cs
@@ -56,18 +56,18 @@ namespace ChatSample
 
             // To use Redis scaleout uncomment .AddRedis and uncomment Redis related lines below for presence
             services.AddSignalR()
-                 .AddRedis()
+                 //.AddRedis()
                 ;
             services.AddAuthentication();
 
 
-            //services.AddSingleton(typeof(DefaultHubLifetimeManager<>), typeof(DefaultHubLifetimeManager<>));
-            //services.AddSingleton(typeof(HubLifetimeManager<>), typeof(DefaultPresenceHublifetimeMenager<>));
-            //services.AddSingleton(typeof(IUserTracker<>), typeof(InMemoryUserTracker<>));
+            services.AddSingleton(typeof(DefaultHubLifetimeManager<>), typeof(DefaultHubLifetimeManager<>));
+            services.AddSingleton(typeof(HubLifetimeManager<>), typeof(DefaultPresenceHublifetimeMenager<>));
+            services.AddSingleton(typeof(IUserTracker<>), typeof(InMemoryUserTracker<>));
 
-            services.AddSingleton(typeof(RedisHubLifetimeManager<>), typeof(RedisHubLifetimeManager<>));
-            services.AddSingleton(typeof(HubLifetimeManager<>), typeof(RedisPresenceHublifetimeMenager<>));
-            services.AddSingleton(typeof(IUserTracker<>), typeof(RedisUserTracker<>));
+            //services.AddSingleton(typeof(RedisHubLifetimeManager<>), typeof(RedisHubLifetimeManager<>));
+            //services.AddSingleton(typeof(HubLifetimeManager<>), typeof(RedisPresenceHublifetimeMenager<>));
+            //services.AddSingleton(typeof(IUserTracker<>), typeof(RedisUserTracker<>));
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.


### PR DESCRIPTION
Currently it is impossible to create database for the chat sample - `dotnet ef` commands fail with: "No parameterless constructor was found on 'ApplicationDbContext'. Either add a parameterless constructor to 'Application
DbContext' or add an implementation of 'IDbContextFactory<ApplicationDbContext>' in the same assembly as 'ApplicationDbC
ontext'." - adding IDbContextFactory implementation to fix this

Also disabling Redis presence in favor of in-memory presence