### PR TITLE
Make the http end points more resty

### DIFF
--- a/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/Transports.ts
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/Transports.ts
@@ -22,7 +22,7 @@ export class WebSocketTransport implements ITransport {
     connect(url: string, queryString: string = ""): Promise<void> {
         return new Promise<void>((resolve, reject) => {
             url = url.replace(/^http/, "ws");
-            let connectUrl = url + "/ws?" + queryString;
+            let connectUrl = url + (queryString == "" ? "" : "?" + queryString);
 
             let webSocket = new WebSocket(connectUrl);
 
@@ -94,10 +94,10 @@ export class ServerSentEventsTransport implements ITransport {
 
         this.queryString = queryString;
         this.url = url;
-        let tmp = `${this.url}/sse?${this.queryString}`;
 
         return new Promise<void>((resolve, reject) => {
-            let eventSource = new EventSource(`${this.url}/sse?${this.queryString}`);
+            let connectUrl = url + (queryString == "" ? "" : "?" + queryString);
+            let eventSource = new EventSource(connectUrl);
 
             try {
                 eventSource.onmessage = (e: MessageEvent) => {
@@ -139,7 +139,8 @@ export class ServerSentEventsTransport implements ITransport {
     }
 
     async send(data: any): Promise<void> {
-        return send(this.httpClient, `${this.url}/send?${this.queryString}`, data);
+        let sendUrl = this.url + (this.queryString == "" ? "" : "?" + this.queryString);
+        return send(this.httpClient, sendUrl, data);
     }
 
     stop(): void {
@@ -168,7 +169,8 @@ export class LongPollingTransport implements ITransport {
         this.url = url;
         this.queryString = queryString;
         this.shouldPoll = true;
-        this.poll(url + "/poll?" + this.queryString)
+        let connectUrl = url + (queryString == "" ? "" : "?" + queryString);
+        this.poll(connectUrl);
         return Promise.resolve();
     }
 
@@ -231,7 +233,8 @@ export class LongPollingTransport implements ITransport {
     }
 
     async send(data: any): Promise<void> {
-        return send(this.httpClient, `${this.url}/send?${this.queryString}`, data);
+        let sendUrl = this.url + (this.queryString == "" ? "" : "?" + this.queryString);
+        return send(this.httpClient, sendUrl, data);
     }
 
     stop(): void {

--- a/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/Transports.ts
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/Transports.ts
@@ -22,7 +22,7 @@ export class WebSocketTransport implements ITransport {
     connect(url: string, queryString: string = ""): Promise<void> {
         return new Promise<void>((resolve, reject) => {
             url = url.replace(/^http/, "ws");
-            let connectUrl = url + (queryString ? "" : "?" + queryString);
+            let connectUrl = url + (queryString ? "?" + queryString : "");
 
             let webSocket = new WebSocket(connectUrl);
 
@@ -95,7 +95,7 @@ export class ServerSentEventsTransport implements ITransport {
 
         this.queryString = queryString;
         this.url = url;
-        this.fullUrl = url + (queryString ? "" : "?" + queryString);
+        this.fullUrl = url + (queryString ? "?" + queryString : "");
 
         return new Promise<void>((resolve, reject) => {
             let eventSource = new EventSource(this.fullUrl);
@@ -170,7 +170,7 @@ export class LongPollingTransport implements ITransport {
         this.url = url;
         this.queryString = queryString;
         this.shouldPoll = true;
-        this.fullUrl = url + (queryString ? "" : "?" + queryString);
+        this.fullUrl = url + (queryString ? "?" + queryString : "");
         this.poll(this.fullUrl);
         return Promise.resolve();
     }

--- a/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/Transports.ts
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/Transports.ts
@@ -22,7 +22,7 @@ export class WebSocketTransport implements ITransport {
     connect(url: string, queryString: string = ""): Promise<void> {
         return new Promise<void>((resolve, reject) => {
             url = url.replace(/^http/, "ws");
-            let connectUrl = url + (queryString == "" ? "" : "?" + queryString);
+            let connectUrl = url + (queryString ? "" : "?" + queryString);
 
             let webSocket = new WebSocket(connectUrl);
 
@@ -81,6 +81,7 @@ export class ServerSentEventsTransport implements ITransport {
     private eventSource: EventSource;
     private url: string;
     private queryString: string;
+    private fullUrl: string;
     private httpClient: IHttpClient;
 
     constructor(httpClient: IHttpClient) {
@@ -94,10 +95,10 @@ export class ServerSentEventsTransport implements ITransport {
 
         this.queryString = queryString;
         this.url = url;
+        this.fullUrl = url + (queryString ? "" : "?" + queryString);
 
         return new Promise<void>((resolve, reject) => {
-            let connectUrl = url + (queryString == "" ? "" : "?" + queryString);
-            let eventSource = new EventSource(connectUrl);
+            let eventSource = new EventSource(this.fullUrl);
 
             try {
                 eventSource.onmessage = (e: MessageEvent) => {
@@ -139,8 +140,7 @@ export class ServerSentEventsTransport implements ITransport {
     }
 
     async send(data: any): Promise<void> {
-        let sendUrl = this.url + (this.queryString == "" ? "" : "?" + this.queryString);
-        return send(this.httpClient, sendUrl, data);
+        return send(this.httpClient, this.fullUrl, data);
     }
 
     stop(): void {
@@ -157,6 +157,7 @@ export class ServerSentEventsTransport implements ITransport {
 export class LongPollingTransport implements ITransport {
     private url: string;
     private queryString: string;
+    private fullUrl: string;
     private httpClient: IHttpClient;
     private pollXhr: XMLHttpRequest;
     private shouldPoll: boolean;
@@ -169,8 +170,8 @@ export class LongPollingTransport implements ITransport {
         this.url = url;
         this.queryString = queryString;
         this.shouldPoll = true;
-        let connectUrl = url + (queryString == "" ? "" : "?" + queryString);
-        this.poll(connectUrl);
+        this.fullUrl = url + (queryString ? "" : "?" + queryString);
+        this.poll(this.fullUrl);
         return Promise.resolve();
     }
 
@@ -233,8 +234,7 @@ export class LongPollingTransport implements ITransport {
     }
 
     async send(data: any): Promise<void> {
-        let sendUrl = this.url + (this.queryString == "" ? "" : "?" + this.queryString);
-        return send(this.httpClient, sendUrl, data);
+        return send(this.httpClient, this.fullUrl, data);
     }
 
     stop(): void {

--- a/samples/ClientSample/ClientSample.csproj
+++ b/samples/ClientSample/ClientSample.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\..\build\dependencies.props" />
 
@@ -6,6 +6,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <!-- Don't create a NuGet package -->
     <IsPackable>false</IsPackable>
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/SocketsSample/wwwroot/ws.html
+++ b/samples/SocketsSample/wwwroot/ws.html
@@ -5,7 +5,7 @@
     <title></title>
     <script>
         document.addEventListener('DOMContentLoaded', () => {
-            var ws = new WebSocket(`ws://${document.location.host}/chat/ws`);
+            var ws = new WebSocket(`ws://${document.location.host}/chat`);
 
             ws.onopen = function () {
                 console.log('Opened!');

--- a/specs/TransportProtocols.md
+++ b/specs/TransportProtocols.md
@@ -30,7 +30,7 @@ For the Long-Polling and Server-Sent events transports, there are two additional
 
 The WebSockets transport is unique in that it is full duplex, and a persistent connection that can be established in a single operation. As a result, the client is not required to use the `[endpoint-base]/negotiate` endpoint to establish a connection in advance. It also includes all the necessary metadata in it's own frame metadata.
 
-The WebSocket transport is activated by making a WebSocket connection to `[endpoint-base]/ws`. The **optional** `connectionId` query string value is used to identify the connection to attach to. If there is no `connectionId` query string value, a new connection is established. If the parameter is specified but there is no connection with the specified ID value, a `404 Not Found` response is returned. Upon receiving this request, the connection is established and the server responds with a WebSocket upgrade (`101 Switching Protocols`) immediately ready for frames to be sent/received. The WebSocket OpCode field is used to indicate the type of the frame (Text or Binary) and the WebSocket "FIN" flag is used to indicate the end of a message.
+The WebSocket transport is activated by making a WebSocket connection to `[endpoint-base]`. The **optional** `connectionId` query string value is used to identify the connection to attach to. If there is no `connectionId` query string value, a new connection is established. If the parameter is specified but there is no connection with the specified ID value, a `404 Not Found` response is returned. Upon receiving this request, the connection is established and the server responds with a WebSocket upgrade (`101 Switching Protocols`) immediately ready for frames to be sent/received. The WebSocket OpCode field is used to indicate the type of the frame (Text or Binary) and the WebSocket "FIN" flag is used to indicate the end of a message.
 
 Establishing a second WebSocket connection when there is already a WebSocket connection associated with the Endpoints connection is not permitted and will fail with a `409 Conflict` status code.
 
@@ -42,7 +42,7 @@ HTTP Post is a half-transport, it is only able to send messages from the Client 
 
 This transport requires that a connection be established using the `[endpoint-base]/negotiate` end point.
 
-The HTTP POST request is made to the URL `[endpoint-base]/send`. The **mandatory** `connectionId` query string value is used to identify the connection to send to. If there is no `connectionId` query string value, a `400 Bad Request` response is returned. The content consists of frames in the same format as the Long Polling transport. It is up to the client which of the Text or Binary protocol they use, and the server is able to detect which they use either via the `Content-Type` (see the Long Polling transport section) or via the first byte (`T` for the Text-based protocol, `B` for the binary protocol). Upon receipt of the **entire** request, the server will process and deliver all the messages, responding with `202 Accepted` if all the messages are successfully processed. If a client makes another request to `/send` while an existing one is outstanding, the new request is immediately terminated by the server with the `409 Conflict` status code.
+The HTTP POST request is made to the URL `[endpoint-base]`. The **mandatory** `connectionId` query string value is used to identify the connection to send to. If there is no `connectionId` query string value, a `400 Bad Request` response is returned. The content consists of frames in the same format as the Long Polling transport. It is up to the client which of the Text or Binary protocol they use, and the server is able to detect which they use either via the `Content-Type` (see the Long Polling transport section) or via the first byte (`T` for the Text-based protocol, `B` for the binary protocol). Upon receipt of the **entire** request, the server will process and deliver all the messages, responding with `202 Accepted` if all the messages are successfully processed. If a client makes another request to `/` while an existing one is outstanding, the new request is immediately terminated by the server with the `409 Conflict` status code.
 
 If the client transmits a `Close` or `Error` frame, the server will ignore and discard any frames following that frame and immediately return `202 Accepted`. Any further attempts to send to that connection will receive a `404 Not Found` response, as the connection will have been terminated.
 
@@ -72,7 +72,7 @@ foo: boz
 
 In the first event, the value of `baz` would be `boz\nbiz\nflarg`, due to the concatenation behavior above. Full details can be found in the spec linked above.
 
-In this transport, the client establishes an SSE connection to `[endpoint-base]/[connection-id]/sse`, and the server responds with an HTTP response with a `Content-Type` of `text/event-stream`. The **mandatory** `connectionId` query string value is used to identify the connection to send to. If there is no `connectionId` query string value, a `400 Bad Request` response is returned, if there is no connection with the specified ID, a `404 Not Found` response is returned. Each SSE event represents a single frame from client to server. The transport uses unnamed events, which means only the `data` field is available. Thus we use the first line of the `data` field for frame metadata. The frame body starts on the **second** line of the `data` field value. The first line has the following format (Identifiers in square brackets `[]` indicate fields defined below):
+In this transport, the client establishes an SSE connection to `[endpoint-base]`, and the server responds with an HTTP response with a `Content-Type` of `text/event-stream`. The **mandatory** `connectionId` query string value is used to identify the connection to send to. If there is no `connectionId` query string value, a `400 Bad Request` response is returned, if there is no connection with the specified ID, a `404 Not Found` response is returned. Each SSE event represents a single frame from client to server. The transport uses unnamed events, which means only the `data` field is available. Thus we use the first line of the `data` field for frame metadata. The frame body starts on the **second** line of the `data` field value. The first line has the following format (Identifiers in square brackets `[]` indicate fields defined below):
 
 ```
 [Type]
@@ -117,16 +117,17 @@ Long Polling requires that the client poll the server for new messages. Unlike t
 
 Since there is such a long round-trip-time for messages, given that the client must issue a request before the server can transmit a message back, Long Polling responses contain batches of multiple messages. Also, in order to support browsers which do not support XHR2, which provides the ability to read binary data, there are two different modes for the polling transport.
 
-A Poll is established by sending an HTTP GET request to `[endpoint-base]/poll` with the following query string parameters
+A Poll is established by sending an HTTP GET request to `[endpoint-base]` with the following query string parameters
 
 * `connectionId` (Required) - The Connection ID of the destination connection.
-* `supportsBinary` (Optional: default `false`) - A boolean indicating if the client supports raw binary data in responses
 
-When messages are available, the server responds with a body in one of the two formats below (depending upon the value of `supportsBinary`). The response may be chunked, as per the chunked encoding part of the HTTP spec.
+Adding the `Accept` header with value `application/vnd.microsoft.aspnetcore.endpoint-messages.v1+binary` indicates if the client supports raw binary data in responses.
+
+When messages are available, the server responds with a body in one of the two formats below (depending upon the value of the `Accept` header). The response may be chunked, as per the chunked encoding part of the HTTP spec.
 
 If the `connectionId` parameter is missing, a `400 Bad Request` response is returned. If there is no connection with the ID specified in `connectionId`, a `404 Not Found` response is returned.
 
-### Text-based encoding (`supportsBinary` = `false` or not present)
+### Text-based encoding
 
 The body will be formatted as below and encoded in UTF-8. The `Content-Type` response header is set to `application/vnd.microsoft.aspnetcore.endpoint-messages.v1+text`. Identifiers in square brackets `[]` indicate fields defined below, and parenthesis `()` indicate grouping.
 
@@ -164,7 +165,7 @@ Note that the final frame still ends with the `;` terminator, and that since the
 
 This transport will buffer incomplete frames sent by the server until the full message is available and then send the message in a single frame.
 
-### Binary encoding (`supportsBinary` = `true`)
+### Binary encoding
 
 In JavaScript/Browser clients, this encoding requires XHR2 (or similar HTTP request functionality which allows binary data) and TypedArray support.
 

--- a/src/Microsoft.AspNetCore.Sockets.Client/LongPollingTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client/LongPollingTransport.cs
@@ -6,7 +6,6 @@ using System.Buffers;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Sockets.Internal.Formatters;
@@ -45,9 +44,9 @@ namespace Microsoft.AspNetCore.Sockets.Client
             _application = application;
 
             // Start sending and polling (ask for binary if the server supports it)
-            var pollUrl = Utils.AppendQueryString(Utils.AppendPath(url, "poll"), "supportsBinary=true");
+            var pollUrl = Utils.AppendQueryString(url, "supportsBinary=true");
             _poller = Poll(pollUrl, _transportCts.Token);
-            _sender = SendUtils.SendMessages(Utils.AppendPath(url, "send"), _application, _httpClient, _transportCts, _logger);
+            _sender = SendUtils.SendMessages(url, _application, _httpClient, _transportCts, _logger);
 
             Running = Task.WhenAll(_sender, _poller).ContinueWith(t =>
             {

--- a/src/Microsoft.AspNetCore.Sockets.Client/LongPollingTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client/LongPollingTransport.cs
@@ -6,6 +6,7 @@ using System.Buffers;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Sockets.Internal.Formatters;
@@ -44,8 +45,7 @@ namespace Microsoft.AspNetCore.Sockets.Client
             _application = application;
 
             // Start sending and polling (ask for binary if the server supports it)
-            var pollUrl = Utils.AppendQueryString(url, "supportsBinary=true");
-            _poller = Poll(pollUrl, _transportCts.Token);
+            _poller = Poll(url, _transportCts.Token);
             _sender = SendUtils.SendMessages(url, _application, _httpClient, _transportCts, _logger);
 
             Running = Task.WhenAll(_sender, _poller).ContinueWith(t =>
@@ -86,6 +86,7 @@ namespace Microsoft.AspNetCore.Sockets.Client
                 {
                     var request = new HttpRequestMessage(HttpMethod.Get, pollUrl);
                     request.Headers.UserAgent.Add(SendUtils.DefaultUserAgentHeader);
+                    request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(MessageFormatter.BinaryContentType));
 
                     var response = await _httpClient.SendAsync(request, cancellationToken);
                     response.EnsureSuccessStatusCode();

--- a/src/Microsoft.AspNetCore.Sockets.Client/ServerSentEventsTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client/ServerSentEventsTransport.cs
@@ -44,8 +44,8 @@ namespace Microsoft.AspNetCore.Sockets.Client
             _logger.LogInformation("Starting {transportName}", nameof(ServerSentEventsTransport));
 
             _application = application;
-            var sseUrl = Utils.AppendPath(url, "sse");
-            var sendUrl = Utils.AppendPath(url, "send");
+            var sseUrl = url;
+            var sendUrl = url;
             var sendTask = SendUtils.SendMessages(sendUrl, _application, _httpClient, _transportCts, _logger);
             var receiveTask = OpenConnection(_application, sseUrl, _transportCts.Token);
 

--- a/src/Microsoft.AspNetCore.Sockets.Client/ServerSentEventsTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client/ServerSentEventsTransport.cs
@@ -44,10 +44,8 @@ namespace Microsoft.AspNetCore.Sockets.Client
             _logger.LogInformation("Starting {transportName}", nameof(ServerSentEventsTransport));
 
             _application = application;
-            var sseUrl = url;
-            var sendUrl = url;
-            var sendTask = SendUtils.SendMessages(sendUrl, _application, _httpClient, _transportCts, _logger);
-            var receiveTask = OpenConnection(_application, sseUrl, _transportCts.Token);
+            var sendTask = SendUtils.SendMessages(url, _application, _httpClient, _transportCts, _logger);
+            var receiveTask = OpenConnection(_application, url, _transportCts.Token);
 
             Running = Task.WhenAll(sendTask, receiveTask).ContinueWith(t =>
             {

--- a/src/Microsoft.AspNetCore.Sockets.Client/WebSocketsTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client/WebSocketsTransport.cs
@@ -182,8 +182,6 @@ namespace Microsoft.AspNetCore.Sockets.Client
                 uriBuilder.Scheme = "wss";
             }
 
-            uriBuilder.Path += "/ws";
-
             await _webSocket.ConnectAsync(uriBuilder.Uri, _cancellationToken);
         }
 

--- a/src/Microsoft.AspNetCore.Sockets/Transports/LongPollingTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets/Transports/LongPollingTransport.cs
@@ -37,10 +37,10 @@ namespace Microsoft.AspNetCore.Sockets.Transports
                     return;
                 }
 
-                // REVIEW: We could also use the 'Accept' header, in theory...
-                var messageFormat = string.Equals(context.Request.Query["supportsBinary"], "true", StringComparison.OrdinalIgnoreCase) ?
-                    MessageFormat.Binary :
-                    MessageFormat.Text;
+                var headers = context.Request.GetTypedHeaders();
+                var messageFormat = headers.Accept?.Contains(new Net.Http.Headers.MediaTypeHeaderValue(MessageFormatter.BinaryContentType)) == true ?
+                MessageFormat.Binary :
+                MessageFormat.Text;
                 context.Response.ContentType = MessageFormatter.GetContentType(messageFormat);
 
                 var writer = context.Response.Body.AsPipelineWriter();

--- a/src/Microsoft.AspNetCore.Sockets/Transports/WebSocketsTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets/Transports/WebSocketsTransport.cs
@@ -50,11 +50,6 @@ namespace Microsoft.AspNetCore.Sockets.Transports
         public async Task ProcessRequestAsync(HttpContext context, CancellationToken token)
         {
             var feature = context.Features.Get<IHttpWebSocketConnectionFeature>();
-            if (feature == null || !feature.IsWebSocketRequest)
-            {
-                _logger.LogWarning("Unable to handle WebSocket request, there is no WebSocket feature available.");
-                return;
-            }
 
             using (var ws = await feature.AcceptWebSocketConnectionAsync(_emptyContext))
             {

--- a/src/Microsoft.AspNetCore.Sockets/Transports/WebSocketsTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets/Transports/WebSocketsTransport.cs
@@ -51,6 +51,8 @@ namespace Microsoft.AspNetCore.Sockets.Transports
         {
             var feature = context.Features.Get<IHttpWebSocketConnectionFeature>();
 
+            Debug.Assert(feature != null, $"The {nameof(IHttpWebSocketConnectionFeature)} feature is missing!");
+
             using (var ws = await feature.AcceptWebSocketConnectionAsync(_emptyContext))
             {
                 _logger.LogInformation("Socket opened.");

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/ConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/ConnectionTests.cs
@@ -298,7 +298,8 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
                 .Returns<HttpRequestMessage, CancellationToken>(async (request, cancellationToken) =>
                 {
                     await Task.Yield();
-                    if (request.RequestUri.AbsolutePath.EndsWith("/poll"))
+                    if (!request.RequestUri.AbsolutePath.EndsWith("/negotiate") &&
+                        request.Method == HttpMethod.Get)
                     {
                         return new HttpResponseMessage(HttpStatusCode.InternalServerError) { Content = new StringContent(string.Empty) };
                     }
@@ -479,7 +480,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
                 .Returns<HttpRequestMessage, CancellationToken>(async (request, cancellationToken) =>
                 {
                     await Task.Yield();
-                    if (request.RequestUri.AbsolutePath.EndsWith("/send"))
+                    if (request.Method == HttpMethod.Post)
                     {
                         sendTcs.SetResult(await request.Content.ReadAsByteArrayAsync());
                     }
@@ -525,7 +526,8 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
                     await Task.Yield();
 
                     var content = string.Empty;
-                    if (request.RequestUri.AbsolutePath.EndsWith("/poll"))
+                    if (!request.RequestUri.AbsolutePath.EndsWith("/negotiate") &&
+                        request.Method == HttpMethod.Get)
                     {
                         content = "T2:T:42;";
                     }
@@ -555,7 +557,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
                 .Returns<HttpRequestMessage, CancellationToken>(async (request, cancellationToken) =>
                 {
                     await Task.Yield();
-                    if (request.RequestUri.AbsolutePath.EndsWith("/send"))
+                    if (request.Method == HttpMethod.Post)
                     {
                         return ResponseUtils.CreateResponse(HttpStatusCode.InternalServerError);
                     }
@@ -586,7 +588,9 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
                     await Task.Yield();
 
                     var content = string.Empty;
-                    if (request.RequestUri.AbsolutePath.EndsWith("/poll"))
+
+                    if (!request.RequestUri.AbsolutePath.EndsWith("/negotiate") &&
+                        request.Method == HttpMethod.Get)
                     {
                         content = "T2:T:42;";
                     }
@@ -632,7 +636,8 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
                 .Returns<HttpRequestMessage, CancellationToken>(async (request, cancellationToken) =>
                 {
                     await Task.Yield();
-                    if (request.RequestUri.AbsolutePath.EndsWith("/poll"))
+                    if (!request.RequestUri.AbsolutePath.EndsWith("/negotiate") &&
+                        request.Method == HttpMethod.Get)
                     {
                         return new HttpResponseMessage(HttpStatusCode.InternalServerError) { Content = new StringContent(string.Empty) };
                     }

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/LongPollingTransportTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/LongPollingTransportTests.cs
@@ -313,7 +313,7 @@ namespace Microsoft.AspNetCore.Client.Tests
 
                     // Check the provided request
                     Assert.Equal(2, sentRequests.Count);
-                    Assert.Equal("?supportsBinary=true", sentRequests[0].RequestUri.Query);
+                    Assert.Contains(MessageFormatter.BinaryContentType, sentRequests[0].Headers.Accept.FirstOrDefault()?.ToString());
 
                     // Check the messages received
                     Assert.Equal(2, messages.Count);

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/LongPollingTransportTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/LongPollingTransportTests.cs
@@ -137,7 +137,7 @@ namespace Microsoft.AspNetCore.Client.Tests
                 .Returns<HttpRequestMessage, CancellationToken>(async (request, cancellationToken) =>
                 {
                     await Task.Yield();
-                    var statusCode = request.RequestUri.AbsolutePath.EndsWith("send")
+                    var statusCode = request.Method == HttpMethod.Post
                         ? HttpStatusCode.InternalServerError
                         : HttpStatusCode.OK;
                     return ResponseUtils.CreateResponse(statusCode);
@@ -340,7 +340,7 @@ namespace Microsoft.AspNetCore.Client.Tests
                 .Returns<HttpRequestMessage, CancellationToken>(async (request, cancellationToken) =>
                 {
                     await Task.Yield();
-                    if (request.RequestUri.LocalPath.EndsWith("send"))
+                    if (request.Method == HttpMethod.Post)
                     {
                         // Build a new request object, but convert the entire payload to string
                         sentRequests.Add(await request.Content.ReadAsByteArrayAsync());

--- a/test/Microsoft.AspNetCore.SignalR.Tests/EndToEndTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/EndToEndTests.cs
@@ -52,7 +52,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                 const string message = "Hello, World!";
                 using (var ws = new ClientWebSocket())
                 {
-                    string socketUrl = _serverFixture.WebSocketsUrl + "/echo/ws";
+                    string socketUrl = _serverFixture.WebSocketsUrl + "/echo";
 
                     logger.LogInformation("Connecting WebSocket to {socketUrl}", socketUrl);
                     await ws.ConnectAsync(new Uri(socketUrl), CancellationToken.None).OrTimeout();

--- a/test/Microsoft.AspNetCore.Sockets.Tests/HttpConnectionDispatcherTests.cs
+++ b/test/Microsoft.AspNetCore.Sockets.Tests/HttpConnectionDispatcherTests.cs
@@ -69,7 +69,7 @@ namespace Microsoft.AspNetCore.Sockets.Tests
                 services.AddEndPoint<TestEndPoint>();
                 services.AddOptions();
                 context.RequestServices = services.BuildServiceProvider();
-                context.Request.Path = "/";
+                context.Request.Path = "/foo";
                 context.Request.Method = "GET";
                 var values = new Dictionary<string, StringValues>();
                 values["id"] = "unknown";
@@ -77,7 +77,7 @@ namespace Microsoft.AspNetCore.Sockets.Tests
                 context.Request.Query = qs;
                 SetTransport(context, transportType);
 
-                await dispatcher.ExecuteAsync<TestEndPoint>("", context);
+                await dispatcher.ExecuteAsync<TestEndPoint>("/foo", context);
 
                 Assert.Equal(StatusCodes.Status404NotFound, context.Response.StatusCode);
                 await strm.FlushAsync();
@@ -101,14 +101,14 @@ namespace Microsoft.AspNetCore.Sockets.Tests
                 services.AddEndPoint<TestEndPoint>();
                 services.AddOptions();
                 context.RequestServices = services.BuildServiceProvider();
-                context.Request.Path = "/";
+                context.Request.Path = "/foo";
                 context.Request.Method = "POST";
                 var values = new Dictionary<string, StringValues>();
                 values["id"] = "unknown";
                 var qs = new QueryCollection(values);
                 context.Request.Query = qs;
 
-                await dispatcher.ExecuteAsync<TestEndPoint>("", context);
+                await dispatcher.ExecuteAsync<TestEndPoint>("/foo", context);
 
                 Assert.Equal(StatusCodes.Status404NotFound, context.Response.StatusCode);
                 await strm.FlushAsync();
@@ -131,12 +131,12 @@ namespace Microsoft.AspNetCore.Sockets.Tests
                 services.AddOptions();
                 services.AddEndPoint<TestEndPoint>();
                 context.RequestServices = services.BuildServiceProvider();
-                context.Request.Path = "/";
+                context.Request.Path = "/foo";
                 context.Request.Method = "GET";
 
                 SetTransport(context, transportType);
 
-                await dispatcher.ExecuteAsync<TestEndPoint>("", context);
+                await dispatcher.ExecuteAsync<TestEndPoint>("/foo", context);
 
                 Assert.Equal(StatusCodes.Status400BadRequest, context.Response.StatusCode);
                 await strm.FlushAsync();
@@ -157,10 +157,10 @@ namespace Microsoft.AspNetCore.Sockets.Tests
                 services.AddOptions();
                 services.AddEndPoint<TestEndPoint>();
                 context.RequestServices = services.BuildServiceProvider();
-                context.Request.Path = "/";
+                context.Request.Path = "/foo";
                 context.Request.Method = "POST";
 
-                await dispatcher.ExecuteAsync<TestEndPoint>("", context);
+                await dispatcher.ExecuteAsync<TestEndPoint>("/foo", context);
 
                 Assert.Equal(StatusCodes.Status400BadRequest, context.Response.StatusCode);
                 await strm.FlushAsync();
@@ -181,13 +181,13 @@ namespace Microsoft.AspNetCore.Sockets.Tests
                 services.AddOptions();
                 services.AddEndPoint<TestEndPoint>();
                 context.RequestServices = services.BuildServiceProvider();
-                context.Request.Path = "/";
+                context.Request.Path = "/foo";
                 context.Request.Method = "POST";
                 context.Request.QueryString = new QueryString($"?id={connectionState.Connection.ConnectionId}");
                 context.Request.ContentType = "text/plain";
                 context.Response.Body = strm;
 
-                await dispatcher.ExecuteAsync<TestEndPoint>("", context);
+                await dispatcher.ExecuteAsync<TestEndPoint>("/foo", context);
 
                 Assert.Equal(StatusCodes.Status400BadRequest, context.Response.StatusCode);
                 await strm.FlushAsync();
@@ -237,10 +237,10 @@ namespace Microsoft.AspNetCore.Sockets.Tests
 
             var dispatcher = new HttpConnectionDispatcher(manager, new LoggerFactory());
 
-            var context = MakeRequest<ImmediatelyCompleteEndPoint>("/", state);
+            var context = MakeRequest<ImmediatelyCompleteEndPoint>("/foo", state);
             SetTransport(context, TransportType.ServerSentEvents);
 
-            await dispatcher.ExecuteAsync<ImmediatelyCompleteEndPoint>("", context);
+            await dispatcher.ExecuteAsync<ImmediatelyCompleteEndPoint>("/foo", context);
 
             Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
 
@@ -257,10 +257,10 @@ namespace Microsoft.AspNetCore.Sockets.Tests
 
             var dispatcher = new HttpConnectionDispatcher(manager, new LoggerFactory());
 
-            var context = MakeRequest<SynchronusExceptionEndPoint>("/", state);
+            var context = MakeRequest<SynchronusExceptionEndPoint>("/foo", state);
             SetTransport(context, TransportType.ServerSentEvents);
 
-            await dispatcher.ExecuteAsync<SynchronusExceptionEndPoint>("", context);
+            await dispatcher.ExecuteAsync<SynchronusExceptionEndPoint>("/foo", context);
 
             Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
 
@@ -277,9 +277,9 @@ namespace Microsoft.AspNetCore.Sockets.Tests
 
             var dispatcher = new HttpConnectionDispatcher(manager, new LoggerFactory());
 
-            var context = MakeRequest<SynchronusExceptionEndPoint>("/", state);
+            var context = MakeRequest<SynchronusExceptionEndPoint>("/foo", state);
 
-            await dispatcher.ExecuteAsync<SynchronusExceptionEndPoint>("", context);
+            await dispatcher.ExecuteAsync<SynchronusExceptionEndPoint>("/foo", context);
 
             Assert.Equal(StatusCodes.Status204NoContent, context.Response.StatusCode);
 
@@ -296,9 +296,9 @@ namespace Microsoft.AspNetCore.Sockets.Tests
 
             var dispatcher = new HttpConnectionDispatcher(manager, new LoggerFactory());
 
-            var context = MakeRequest<ImmediatelyCompleteEndPoint>("/", state);
+            var context = MakeRequest<ImmediatelyCompleteEndPoint>("/foo", state);
 
-            await dispatcher.ExecuteAsync<ImmediatelyCompleteEndPoint>("", context);
+            await dispatcher.ExecuteAsync<ImmediatelyCompleteEndPoint>("/foo", context);
 
             Assert.Equal(StatusCodes.Status204NoContent, context.Response.StatusCode);
 
@@ -315,10 +315,10 @@ namespace Microsoft.AspNetCore.Sockets.Tests
 
             var dispatcher = new HttpConnectionDispatcher(manager, new LoggerFactory());
 
-            var context = MakeRequest<ImmediatelyCompleteEndPoint>("/", state);
+            var context = MakeRequest<ImmediatelyCompleteEndPoint>("/foo", state);
             SetTransport(context, TransportType.WebSockets);
 
-            var task = dispatcher.ExecuteAsync<ImmediatelyCompleteEndPoint>("", context);
+            var task = dispatcher.ExecuteAsync<ImmediatelyCompleteEndPoint>("/foo", context);
 
             await task.OrTimeout();
         }
@@ -333,15 +333,15 @@ namespace Microsoft.AspNetCore.Sockets.Tests
 
             var dispatcher = new HttpConnectionDispatcher(manager, new LoggerFactory());
 
-            var context1 = MakeRequest<TestEndPoint>("/", state);
-            var context2 = MakeRequest<TestEndPoint>("/", state);
+            var context1 = MakeRequest<TestEndPoint>("/foo", state);
+            var context2 = MakeRequest<TestEndPoint>("/foo", state);
 
             SetTransport(context1, transportType);
             SetTransport(context2, transportType);
 
-            var request1 = dispatcher.ExecuteAsync<TestEndPoint>("", context1);
+            var request1 = dispatcher.ExecuteAsync<TestEndPoint>("/foo", context1);
 
-            await dispatcher.ExecuteAsync<TestEndPoint>("", context2);
+            await dispatcher.ExecuteAsync<TestEndPoint>("/foo", context2);
 
             Assert.Equal(StatusCodes.Status409Conflict, context2.Response.StatusCode);
 
@@ -369,11 +369,11 @@ namespace Microsoft.AspNetCore.Sockets.Tests
 
             var dispatcher = new HttpConnectionDispatcher(manager, new LoggerFactory());
 
-            var context1 = MakeRequest<TestEndPoint>("/", state);
-            var context2 = MakeRequest<TestEndPoint>("/", state);
+            var context1 = MakeRequest<TestEndPoint>("/foo", state);
+            var context2 = MakeRequest<TestEndPoint>("/foo", state);
 
-            var request1 = dispatcher.ExecuteAsync<TestEndPoint>("", context1);
-            var request2 = dispatcher.ExecuteAsync<TestEndPoint>("", context2);
+            var request1 = dispatcher.ExecuteAsync<TestEndPoint>("/foo", context1);
+            var request2 = dispatcher.ExecuteAsync<TestEndPoint>("/foo", context2);
 
             await request1;
 
@@ -398,10 +398,10 @@ namespace Microsoft.AspNetCore.Sockets.Tests
 
             var dispatcher = new HttpConnectionDispatcher(manager, new LoggerFactory());
 
-            var context = MakeRequest<TestEndPoint>("/", state);
+            var context = MakeRequest<TestEndPoint>("/foo", state);
             SetTransport(context, transportType);
 
-            await dispatcher.ExecuteAsync<TestEndPoint>("", context);
+            await dispatcher.ExecuteAsync<TestEndPoint>("/foo", context);
 
             Assert.Equal(StatusCodes.Status404NotFound, context.Response.StatusCode);
         }
@@ -414,9 +414,9 @@ namespace Microsoft.AspNetCore.Sockets.Tests
 
             var dispatcher = new HttpConnectionDispatcher(manager, new LoggerFactory());
 
-            var context = MakeRequest<TestEndPoint>("/", state);
+            var context = MakeRequest<TestEndPoint>("/foo", state);
 
-            var task = dispatcher.ExecuteAsync<TestEndPoint>("", context);
+            var task = dispatcher.ExecuteAsync<TestEndPoint>("/foo", context);
 
             var buffer = Encoding.UTF8.GetBytes("Hello World");
 
@@ -439,10 +439,10 @@ namespace Microsoft.AspNetCore.Sockets.Tests
 
             var dispatcher = new HttpConnectionDispatcher(manager, new LoggerFactory());
 
-            var context = MakeRequest<BlockingEndPoint>("/", state);
+            var context = MakeRequest<BlockingEndPoint>("/foo", state);
             SetTransport(context, TransportType.ServerSentEvents);
 
-            var task = dispatcher.ExecuteAsync<BlockingEndPoint>("", context);
+            var task = dispatcher.ExecuteAsync<BlockingEndPoint>("/foo", context);
 
             var buffer = Encoding.UTF8.GetBytes("Hello World");
 
@@ -465,9 +465,9 @@ namespace Microsoft.AspNetCore.Sockets.Tests
 
             var dispatcher = new HttpConnectionDispatcher(manager, new LoggerFactory());
 
-            var context = MakeRequest<BlockingEndPoint>("/", state);
+            var context = MakeRequest<BlockingEndPoint>("/foo", state);
 
-            var task = dispatcher.ExecuteAsync<BlockingEndPoint>("", context);
+            var task = dispatcher.ExecuteAsync<BlockingEndPoint>("/foo", context);
 
             var buffer = Encoding.UTF8.GetBytes("Hello World");
 
@@ -490,10 +490,10 @@ namespace Microsoft.AspNetCore.Sockets.Tests
 
             var dispatcher = new HttpConnectionDispatcher(manager, new LoggerFactory());
 
-            var context1 = MakeRequest<BlockingEndPoint>("/", state);
-            var task1 = dispatcher.ExecuteAsync<BlockingEndPoint>("", context1);
-            var context2 = MakeRequest<BlockingEndPoint>("/", state);
-            var task2 = dispatcher.ExecuteAsync<BlockingEndPoint>("", context2);
+            var context1 = MakeRequest<BlockingEndPoint>("/foo", state);
+            var task1 = dispatcher.ExecuteAsync<BlockingEndPoint>("/foo", context1);
+            var context2 = MakeRequest<BlockingEndPoint>("/foo", state);
+            var task2 = dispatcher.ExecuteAsync<BlockingEndPoint>("/foo", context2);
 
             // Task 1 should finish when request 2 arrives
             await task1.OrTimeout();
@@ -566,7 +566,7 @@ namespace Microsoft.AspNetCore.Sockets.Tests
             services.AddLogging();
 
             context.RequestServices = services.BuildServiceProvider();
-            context.Request.Path = "/";
+            context.Request.Path = "/foo";
             context.Request.Method = "GET";
             var values = new Dictionary<string, StringValues>();
             values["id"] = state.Connection.ConnectionId;
@@ -577,7 +577,7 @@ namespace Microsoft.AspNetCore.Sockets.Tests
             context.Features.Set<IHttpAuthenticationFeature>(authFeature);
 
             // would hang if EndPoint was running
-            await dispatcher.ExecuteAsync<BlockingEndPoint>("", context).OrTimeout();
+            await dispatcher.ExecuteAsync<BlockingEndPoint>("/foo", context).OrTimeout();
 
             Assert.Equal(StatusCodes.Status401Unauthorized, context.Response.StatusCode);
         }
@@ -605,7 +605,7 @@ namespace Microsoft.AspNetCore.Sockets.Tests
             services.AddLogging();
 
             context.RequestServices = services.BuildServiceProvider();
-            context.Request.Path = "/";
+            context.Request.Path = "/foo";
             context.Request.Method = "GET";
             var values = new Dictionary<string, StringValues>();
             values["id"] = state.Connection.ConnectionId;
@@ -619,7 +619,7 @@ namespace Microsoft.AspNetCore.Sockets.Tests
             // "authorize" user
             context.User = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(ClaimTypes.NameIdentifier, "name") }));
 
-            var endPointTask = dispatcher.ExecuteAsync<BlockingEndPoint>("", context);
+            var endPointTask = dispatcher.ExecuteAsync<BlockingEndPoint>("/foo", context);
             await state.Connection.Transport.Output.WriteAsync(new Message(Encoding.UTF8.GetBytes("Hello, World"), MessageType.Text)).OrTimeout();
 
             await endPointTask.OrTimeout();
@@ -650,7 +650,7 @@ namespace Microsoft.AspNetCore.Sockets.Tests
             services.AddLogging();
 
             context.RequestServices = services.BuildServiceProvider();
-            context.Request.Path = "/";
+            context.Request.Path = "/foo";
             context.Request.Method = "GET";
             var values = new Dictionary<string, StringValues>();
             values["id"] = state.Connection.ConnectionId;
@@ -665,14 +665,14 @@ namespace Microsoft.AspNetCore.Sockets.Tests
             context.User = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(ClaimTypes.NameIdentifier, "name") }));
 
             // would hang if EndPoint was running
-            await dispatcher.ExecuteAsync<BlockingEndPoint>("", context).OrTimeout();
+            await dispatcher.ExecuteAsync<BlockingEndPoint>("/foo", context).OrTimeout();
 
             Assert.Equal(StatusCodes.Status401Unauthorized, context.Response.StatusCode);
 
             // fully "authorize" user
             context.User.AddIdentity(new ClaimsIdentity(new[] { new Claim(ClaimTypes.StreetAddress, "12345 123rd St. NW") }));
 
-            var endPointTask = dispatcher.ExecuteAsync<BlockingEndPoint>("", context);
+            var endPointTask = dispatcher.ExecuteAsync<BlockingEndPoint>("/foo", context);
             await state.Connection.Transport.Output.WriteAsync(new Message(Encoding.UTF8.GetBytes("Hello, World"), MessageType.Text)).OrTimeout();
 
             await endPointTask.OrTimeout();
@@ -704,7 +704,7 @@ namespace Microsoft.AspNetCore.Sockets.Tests
             services.AddLogging();
 
             context.RequestServices = services.BuildServiceProvider();
-            context.Request.Path = "/";
+            context.Request.Path = "/foo";
             context.Request.Method = "GET";
             var values = new Dictionary<string, StringValues>();
             values["id"] = state.Connection.ConnectionId;
@@ -718,7 +718,7 @@ namespace Microsoft.AspNetCore.Sockets.Tests
             // "authorize" user
             context.User = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(ClaimTypes.NameIdentifier, "name") }));
 
-            var endPointTask = dispatcher.ExecuteAsync<BlockingEndPoint>("", context);
+            var endPointTask = dispatcher.ExecuteAsync<BlockingEndPoint>("/foo", context);
             await state.Connection.Transport.Output.WriteAsync(new Message(Encoding.UTF8.GetBytes("Hello, World"), MessageType.Text)).OrTimeout();
 
             await endPointTask.OrTimeout();
@@ -751,7 +751,7 @@ namespace Microsoft.AspNetCore.Sockets.Tests
             services.AddLogging();
 
             context.RequestServices = services.BuildServiceProvider();
-            context.Request.Path = "/";
+            context.Request.Path = "/foo";
             context.Request.Method = "GET";
             var values = new Dictionary<string, StringValues>();
             values["id"] = state.Connection.ConnectionId;
@@ -766,7 +766,7 @@ namespace Microsoft.AspNetCore.Sockets.Tests
             context.User = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(ClaimTypes.NameIdentifier, "name") }));
 
             // would block if EndPoint was executed
-            await dispatcher.ExecuteAsync<BlockingEndPoint>("", context).OrTimeout();
+            await dispatcher.ExecuteAsync<BlockingEndPoint>("/foo", context).OrTimeout();
 
             Assert.Equal(StatusCodes.Status401Unauthorized, context.Response.StatusCode);
         }
@@ -836,13 +836,13 @@ namespace Microsoft.AspNetCore.Sockets.Tests
 
                 SetTransport(context, transportType);
                 context.RequestServices = services.BuildServiceProvider();
-                context.Request.Path = "/";
+                context.Request.Path = "/foo";
                 context.Request.Method = "GET";
                 var values = new Dictionary<string, StringValues>();
                 values["id"] = state.Connection.ConnectionId;
                 var qs = new QueryCollection(values);
                 context.Request.Query = qs;
-                await dispatcher.ExecuteAsync<ImmediatelyCompleteEndPoint>("", context);
+                await dispatcher.ExecuteAsync<ImmediatelyCompleteEndPoint>("/foo", context);
                 Assert.Equal(status, context.Response.StatusCode);
                 await strm.FlushAsync();
 
@@ -861,7 +861,7 @@ namespace Microsoft.AspNetCore.Sockets.Tests
 
             var dispatcher = new HttpConnectionDispatcher(manager, new LoggerFactory());
 
-            var context = MakeRequest<TestEndPoint>("/", state, format);
+            var context = MakeRequest<TestEndPoint>("/foo", state, format);
             context.Request.Method = "POST";
             context.Request.ContentType = contentType;
             var endPoint = context.RequestServices.GetRequiredService<TestEndPoint>();
@@ -872,7 +872,7 @@ namespace Microsoft.AspNetCore.Sockets.Tests
             var messages = new List<Message>();
             using (context.Request.Body = new MemoryStream(buffer, writable: false))
             {
-                await dispatcher.ExecuteAsync<TestEndPoint>("", context).OrTimeout();
+                await dispatcher.ExecuteAsync<TestEndPoint>("/foo", context).OrTimeout();
             }
 
             while (state.Connection.Transport.Input.TryRead(out var message))

--- a/test/Microsoft.AspNetCore.Sockets.Tests/LongPollingTests.cs
+++ b/test/Microsoft.AspNetCore.Sockets.Tests/LongPollingTests.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Threading.Tasks.Channels;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Sockets.Internal.Formatters;
 using Microsoft.AspNetCore.Sockets.Transports;
 using Microsoft.Extensions.Logging;
 using Xunit;
@@ -61,7 +62,7 @@ namespace Microsoft.AspNetCore.Sockets.Tests
             var context = new DefaultHttpContext();
             if (format == MessageFormat.Binary)
             {
-                context.Request.QueryString = QueryString.Create("supportsBinary", "true");
+                context.Request.Headers["Accept"] = MessageFormatter.BinaryContentType;
             }
             var poll = new LongPollingTransport(channel, new LoggerFactory());
             var ms = new MemoryStream();


### PR DESCRIPTION
# Resty end points

## Negotiation

```
OPTIONS /{path}
```

## Long polling

```
GET /{path}
```

## Server Sent Events

```
GET /{path}
Accept: text/event-stream
```

## HTTP Send

```
POST /{path}
```

## WebSockets

```
GET /{path}
Upgrade: websocket
Connection: Upgrade
```