### PR TITLE
Fix long polling graceful shutdown

### DIFF
--- a/test/Microsoft.AspNetCore.SignalR.Tests/EndToEndTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/EndToEndTests.cs
@@ -104,12 +104,13 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                         if (e != null)
                         {
                             receiveTcs.TrySetException(e);
+                            closeTcs.TrySetException(e);
                         }
                         else
                         {
                             receiveTcs.TrySetResult(null);
+                            closeTcs.TrySetResult(null);
                         }
-                        closeTcs.TrySetResult(null);
                     };
 
                     logger.LogInformation("Starting connection to {url}", url);


### PR DESCRIPTION
- If a message was sent and the application was ended in the same
poll request, the connection would be closed by the time the next poll
came in which resulted in a 404. This change waits until the transport writes
all data before closing it.
- Also fixed a test so that the exception started to show client side.

#469