### PR TITLE
Closing transports with error if hubs cannot be created

### DIFF
--- a/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/Transports.ts
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/Transports.ts
@@ -125,7 +125,7 @@ export class ServerSentEventsTransport implements ITransport {
 
                     // don't report an error if the transport did not start successfully
                     if (this.eventSource && this.onClosed) {
-                        this.onClosed(new Error(e.message));
+                        this.onClosed(new Error(e.message || "Error occurred"));
                     }
                 }
 

--- a/client-ts/Microsoft.AspNetCore.SignalR.Test.Server/Startup.cs
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Test.Server/Startup.cs
@@ -25,10 +25,8 @@ namespace Microsoft.AspNetCore.SignalR.Test.Server
 
             app.UseFileServer();
             app.UseSockets(options => options.MapEndPoint<EchoEndPoint>("echo"));
-            app.UseSignalR(routes =>
-            {
-                routes.MapHub<TestHub>("testhub");
-            });
+            app.UseSignalR(options => options.MapHub<TestHub>("testhub"));
+            app.UseSignalR(options => options.MapHub<UncreatableHub>("uncreatable"));
         }
     }
 }

--- a/client-ts/Microsoft.AspNetCore.SignalR.Test.Server/UncreatableHub.cs
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Test.Server/UncreatableHub.cs
@@ -1,0 +1,14 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNetCore.SignalR.Test.Server
+{
+    public class UncreatableHub: Hub
+    {
+        public UncreatableHub(object obj)
+        {
+        }
+    }
+}

--- a/client-ts/Microsoft.AspNetCore.SignalR.Test.Server/wwwroot/js/hubConnectionTests.js
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Test.Server/wwwroot/js/hubConnectionTests.js
@@ -142,5 +142,21 @@ describe('hubConnection', () => {
                     });
             });
         });
+
+        it(`over ${signalR.TransportType[transportType]} closed with error if hub cannot be created`, done =>{
+            let errorRegex = {
+                WebSockets: "1011", // Message is browser specific (e.g. 'Websocket closed with status code: 1011')
+                LongPolling: "Status: 500",
+                ServerSentEvents: "Error occurred"
+            };
+
+            let hubConnection = new signalR.HubConnection(`http://${document.location.host}/uncreatable`, 'formatType=json&format=text');
+
+            hubConnection.onClosed = error => {
+                expect(error).toMatch(errorRegex[signalR.TransportType[transportType]]);
+                done();
+            }
+            hubConnection.start(transportType)
+        });
     });
 });

--- a/src/Microsoft.AspNetCore.Sockets.Client/ServerSentEventsTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client/ServerSentEventsTransport.cs
@@ -114,6 +114,7 @@ namespace Microsoft.AspNetCore.Sockets.Client
             finally
             {
                 _transportCts.Cancel();
+                stream.Dispose();
             }
         }
 

--- a/src/Microsoft.AspNetCore.Sockets.Client/WebSocketsTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client/WebSocketsTransport.cs
@@ -84,7 +84,11 @@ namespace Microsoft.AspNetCore.Sockets.Client
                         {
                             _logger.LogInformation("Websocket closed by the server. Close status {0}", receiveResult.CloseStatus);
 
-                            _application.Output.Complete();
+                            _application.Output.Complete(
+                                receiveResult.CloseStatus == WebSocketCloseStatus.NormalClosure
+                                ? null
+                                : new InvalidOperationException(
+                                    $"Websocket closed with error: {receiveResult.CloseStatus}."));
                             return;
                         }
 

--- a/src/Microsoft.AspNetCore.Sockets.Http/HttpConnectionDispatcher.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Http/HttpConnectionDispatcher.cs
@@ -202,7 +202,7 @@ namespace Microsoft.AspNetCore.Sockets
 
                 var pollAgain = true;
 
-                // If the application ended before the transport task then we need to potentially need to end the 
+                // If the application ended before the transport task then we need to potentially need to end the
                 // connection
                 if (resultTask == state.ApplicationTask)
                 {

--- a/src/Microsoft.AspNetCore.Sockets.Http/Transports/LongPollingTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Http/Transports/LongPollingTransport.cs
@@ -32,6 +32,7 @@ namespace Microsoft.AspNetCore.Sockets.Transports
             {
                 if (!await _application.WaitToReadAsync(token))
                 {
+                    await _application.Completion;
                     _logger.LogInformation("Terminating Long Polling connection by sending 204 response.");
                     context.Response.StatusCode = StatusCodes.Status204NoContent;
                     return;
@@ -81,6 +82,11 @@ namespace Microsoft.AspNetCore.Sockets.Transports
                 // Don't count this as cancellation, this is normal as the poll can end due to the browesr closing.
                 // The background thread will eventually dispose this connection if it's inactive
                 _logger.LogDebug("Client disconnected from Long Polling endpoint.");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Long Polling transport was terminated due to an error");
+                throw;
             }
         }
     }

--- a/src/Microsoft.AspNetCore.Sockets.Http/Transports/ServerSentEventsTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Http/Transports/ServerSentEventsTransport.cs
@@ -65,6 +65,8 @@ namespace Microsoft.AspNetCore.Sockets.Transports
                         await output.FlushAsync();
                     }
                 }
+
+                await _application.Completion;
             }
             catch (OperationCanceledException)
             {

--- a/test/Microsoft.AspNetCore.SignalR.Tests/ServerFixture.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/ServerFixture.cs
@@ -47,6 +47,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             public void Configure(IApplicationBuilder app, IHostingEnvironment env)
             {
                 app.UseSockets(options => options.MapEndPoint<EchoEndPoint>("echo"));
+                app.UseSignalR(options => options.MapHub<UncreatableHub>("uncreatable"));
             }
         }
 

--- a/test/Microsoft.AspNetCore.SignalR.Tests/UncreatableHub.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/UncreatableHub.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.SignalR.Tests
+{
+    public class UncreatableHub: Hub
+    {
+        public UncreatableHub(object obj)
+        {
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Sockets.Tests/HttpConnectionDispatcherTests.cs
+++ b/test/Microsoft.AspNetCore.Sockets.Tests/HttpConnectionDispatcherTests.cs
@@ -291,29 +291,6 @@ namespace Microsoft.AspNetCore.Sockets.Tests
         }
 
         [Fact]
-        public async Task SynchronusExceptionEndsLongPollingConnection()
-        {
-            var manager = CreateConnectionManager();
-            var state = manager.CreateConnection();
-
-            var dispatcher = new HttpConnectionDispatcher(manager, new LoggerFactory());
-            var context = MakeRequest("/foo", state);
-
-            var services = new ServiceCollection();
-            services.AddEndPoint<SynchronusExceptionEndPoint>();
-            var builder = new SocketBuilder(services.BuildServiceProvider());
-            builder.UseEndPoint<SynchronusExceptionEndPoint>();
-            var app = builder.Build();
-            await dispatcher.ExecuteAsync(context, new HttpSocketOptions(), app);
-
-            Assert.Equal(StatusCodes.Status204NoContent, context.Response.StatusCode);
-
-            ConnectionState removed;
-            bool exists = manager.TryGetConnection(state.Connection.ConnectionId, out removed);
-            Assert.False(exists);
-        }
-
-        [Fact]
         public async Task CompletedEndPointEndsLongPollingConnection()
         {
             var manager = CreateConnectionManager();


### PR DESCRIPTION
- Preventing from closing long polling transport with 204 in case of
error
- Reporting an error to the client if WebSocket was not closed normally

Note in case of ServerSentEvents it is not possible on the client to
tell the difference between when the server closed event stream due to
an exception or because the client left OnConnectedAsync. In both cases
the client sees only that the stream was closed.

Part of: #163