### PR TITLE
Preserve Order and remove task queue in Redis

### DIFF
--- a/samples/ChatSample/Views/Home/Index.cshtml
+++ b/samples/ChatSample/Views/Home/Index.cshtml
@@ -81,7 +81,7 @@ function addUserOnline(user) {
         return;
     }
     var userLi = document.createElement('li');
-    userLi.innerText = `user.Name (${user.ConnectionId})`;
+    userLi.innerText = `${user.Name} (${user.ConnectionId})`;
     userLi.id = user.ConnectionId;
     document.getElementById('users').appendChild(userLi);
 }


### PR DESCRIPTION
We shouldn't need the task queues anymore, its an artifact from when we had `connection.Channel.Output.WriteAsync(...)`. Also added `PreserveAsyncOrder` to the redis connection so messages are received in order