### PR TITLE
Discover hub methods at startup time

### DIFF
--- a/src/Microsoft.AspNetCore.SignalR/SignalRSocketBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.SignalR/SignalRSocketBuilderExtensions.cs
@@ -10,9 +10,9 @@ namespace Microsoft.AspNetCore.SignalR
     {
         public static ISocketBuilder UseHub<THub>(this ISocketBuilder socketBuilder) where THub : Hub<IClientProxy>
         {
+            var endpoint = socketBuilder.ApplicationServices.GetRequiredService<HubEndPoint<THub>>();
             return socketBuilder.Run(connection =>
             {
-                var endpoint = socketBuilder.ApplicationServices.GetRequiredService<HubEndPoint<THub>>();
                 return endpoint.OnConnectedAsync(connection);
             });
         }

--- a/test/Microsoft.AspNetCore.SignalR.Tests/MapSignalRTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/MapSignalRTests.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Microsoft.AspNetCore.SignalR.Tests
+{
+    public class MapSignalRTests
+    {
+        [Fact]
+        public void MapSignalRFailsForInvalidHub()
+        {
+            var ex = Assert.Throws<NotSupportedException>(() =>
+            {
+                var builder = new WebHostBuilder()
+                        .UseKestrel()
+                        .ConfigureServices(services =>
+                        {
+                            services.AddSignalR();
+                        })
+                        .Configure(app =>
+                        {
+                            app.UseSignalR(options => options.MapHub<InvalidHub>("overloads"));
+                        })
+                        .Build();
+            });
+
+            Assert.Equal("Duplicate definitions of 'OverloadedMethod'. Overloading is not supported.", ex.Message);
+        }
+
+        private class InvalidHub : Hub
+        {
+            public void OverloadedMethod(int num)
+            {
+            }
+
+            public void OverloadedMethod(string message)
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Errors will show up earlier as a result instead of cryptic
first connect errors.