### PR TITLE
Removed EndOfMessage from Message

### DIFF
--- a/samples/SocialWeather/PersistentConnectionLifeTimeManager.cs
+++ b/samples/SocialWeather/PersistentConnectionLifeTimeManager.cs
@@ -45,7 +45,7 @@ namespace SocialWeather
                         ? MessageType.Binary
                         : MessageType.Text;
 
-                connection.Transport.Output.TryWrite(new Message(ms.ToArray(), format, endOfMessage: true));
+                connection.Transport.Output.TryWrite(new Message(ms.ToArray(), format));
             }
         }
 

--- a/samples/SocketsSample/EndPoints/MessagesEndPoint.cs
+++ b/samples/SocketsSample/EndPoints/MessagesEndPoint.cs
@@ -29,7 +29,7 @@ namespace SocketsSample.EndPoints
                         // We can avoid the copy here but we'll deal with that later
                         var text = Encoding.UTF8.GetString(message.Payload);
                         text = $"{connection.ConnectionId}: {text}";
-                        await Broadcast(Encoding.UTF8.GetBytes(text), message.Type, message.EndOfMessage);
+                        await Broadcast(Encoding.UTF8.GetBytes(text), message.Type);
                     }
                 }
             }
@@ -43,10 +43,10 @@ namespace SocketsSample.EndPoints
 
         private Task Broadcast(string text)
         {
-            return Broadcast(Encoding.UTF8.GetBytes(text), MessageType.Text, endOfMessage: true);
+            return Broadcast(Encoding.UTF8.GetBytes(text), MessageType.Text);
         }
 
-        private Task Broadcast(byte[] payload, MessageType format, bool endOfMessage)
+        private Task Broadcast(byte[] payload, MessageType format)
         {
             var tasks = new List<Task>(Connections.Count);
 
@@ -54,8 +54,7 @@ namespace SocketsSample.EndPoints
             {
                 tasks.Add(c.Transport.Output.WriteAsync(new Message(
                     payload,
-                    format,
-                    endOfMessage)));
+                    format)));
             }
 
             return Task.WhenAll(tasks);

--- a/specs/TransportProtocols.md
+++ b/specs/TransportProtocols.md
@@ -10,7 +10,6 @@ A transport is required to have the following attributes:
 1. Frame-based - Messages have fixed length (as opposed to streaming, where data is just pushed throughout the connection)
 1. Frame Metadata - Able to encode one piece of Frame Metadata
     * `Type` - Either `Binary` or `Text`.
-1. Able to handle partial messages from the Server application (i.e. where `EndOfMessage` is `false`). The transport can opt to implement this by buffering, since only WebSockets natively supports this functionality.
 1. Binary-safe - Able to transmit arbitrary binary data, regardless of content
 1. Text-safe - Able to transmit arbitrary text data, preserving the content. Line-endings must be preserved **but may be converted to a different format**. For example `\r\n` may be converted to `\n`. This is due to quirks in some transports (Server Sent Events). If the exact line-ending needs to be preserved, the data should be sent as a `Binary` message.
 
@@ -30,7 +29,7 @@ For the Long-Polling and Server-Sent events transports, there are two additional
 
 The WebSockets transport is unique in that it is full duplex, and a persistent connection that can be established in a single operation. As a result, the client is not required to use the `OPTIONS [endpoint-base]` request to establish a connection in advance. It also includes all the necessary metadata in it's own frame metadata.
 
-The WebSocket transport is activated by making a WebSocket connection to `[endpoint-base]`. The **optional** `connectionId` query string value is used to identify the connection to attach to. If there is no `connectionId` query string value, a new connection is established. If the parameter is specified but there is no connection with the specified ID value, a `404 Not Found` response is returned. Upon receiving this request, the connection is established and the server responds with a WebSocket upgrade (`101 Switching Protocols`) immediately ready for frames to be sent/received. The WebSocket OpCode field is used to indicate the type of the frame (Text or Binary) and the WebSocket "FIN" flag is used to indicate the end of a message.
+The WebSocket transport is activated by making a WebSocket connection to `[endpoint-base]`. The **optional** `connectionId` query string value is used to identify the connection to attach to. If there is no `connectionId` query string value, a new connection is established. If the parameter is specified but there is no connection with the specified ID value, a `404 Not Found` response is returned. Upon receiving this request, the connection is established and the server responds with a WebSocket upgrade (`101 Switching Protocols`) immediately ready for frames to be sent/received. The WebSocket OpCode field is used to indicate the type of the frame (Text or Binary).
 
 Establishing a second WebSocket connection when there is already a WebSocket connection associated with the Endpoints connection is not permitted and will fail with a `409 Conflict` status code.
 

--- a/src/Microsoft.AspNetCore.SignalR.Redis/RedisHubLifetimeManager.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Redis/RedisHubLifetimeManager.cs
@@ -301,7 +301,7 @@ namespace Microsoft.AspNetCore.SignalR.Redis
         {
             var protocol = connection.Metadata.Get<IHubProtocol>(HubConnectionMetadataNames.HubProtocol);
             var data = await protocol.WriteToArrayAsync(hubMessage);
-            var message = new Message(data, protocol.MessageType, endOfMessage: true);
+            var message = new Message(data, protocol.MessageType);
 
             while (await connection.Transport.Output.WaitToWriteAsync())
             {

--- a/src/Microsoft.AspNetCore.SignalR/DefaultHubLifetimeManager.cs
+++ b/src/Microsoft.AspNetCore.SignalR/DefaultHubLifetimeManager.cs
@@ -110,7 +110,7 @@ namespace Microsoft.AspNetCore.SignalR
         {
             var protocol = connection.Metadata.Get<IHubProtocol>(HubConnectionMetadataNames.HubProtocol);
             var payload = await protocol.WriteToArrayAsync(hubMessage);
-            var message = new Message(payload, protocol.MessageType, endOfMessage: true);
+            var message = new Message(payload, protocol.MessageType);
 
             while (await connection.Transport.Output.WaitToWriteAsync())
             {

--- a/src/Microsoft.AspNetCore.SignalR/HubEndPoint.cs
+++ b/src/Microsoft.AspNetCore.SignalR/HubEndPoint.cs
@@ -229,7 +229,7 @@ namespace Microsoft.AspNetCore.SignalR
         private async Task SendMessageAsync(ConnectionContext connection, IHubProtocol protocol, HubMessage hubMessage)
         {
             var payload = await protocol.WriteToArrayAsync(hubMessage);
-            var message = new Message(payload, protocol.MessageType, endOfMessage: true);
+            var message = new Message(payload, protocol.MessageType);
 
             while (await connection.Transport.Output.WaitToWriteAsync())
             {

--- a/src/Microsoft.AspNetCore.Sockets.Client/SendUtils.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client/SendUtils.cs
@@ -119,7 +119,7 @@ namespace Microsoft.AspNetCore.Sockets.Client
                 logger.LogDebug("Writing '{0}' message to the server", message.Type);
 
                 var payload = message.Payload ?? Array.Empty<byte>();
-                if (!MessageFormatter.TryWriteMessage(new Message(payload, message.Type, endOfMessage: true), output, format))
+                if (!MessageFormatter.TryWriteMessage(new Message(payload, message.Type), output, format))
                 {
                     // We didn't get any more memory!
                     throw new InvalidOperationException("Unable to write message to pipeline");

--- a/src/Microsoft.AspNetCore.Sockets.Client/WebSocketsTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client/WebSocketsTransport.cs
@@ -115,13 +115,13 @@ namespace Microsoft.AspNetCore.Sockets.Client
                             offset += incomingMessage[i].Count;
                         }
 
-                        message = new Message(messageBuffer, messageType, receiveResult.EndOfMessage);
+                        message = new Message(messageBuffer, messageType);
                     }
                     else
                     {
                         var buffer = new byte[incomingMessage[0].Count];
                         Buffer.BlockCopy(incomingMessage[0].Array, incomingMessage[0].Offset, buffer, 0, incomingMessage[0].Count);
-                        message = new Message(buffer, messageType, receiveResult.EndOfMessage);
+                        message = new Message(buffer, messageType);
                     }
 
                     _logger.LogInformation("Passing message to application. Payload size: {0}", message.Payload.Length);

--- a/src/Microsoft.AspNetCore.Sockets.Common/Internal/Formatters/MessageFormatter.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Common/Internal/Formatters/MessageFormatter.cs
@@ -16,14 +16,6 @@ namespace Microsoft.AspNetCore.Sockets.Internal.Formatters
 
         public static bool TryWriteMessage(Message message, IOutput output, MessageFormat format)
         {
-            if (!message.EndOfMessage)
-            {
-                // This is a truely exceptional condition since we EXPECT callers to have already
-                // buffered incomplete messages and synthesized the correct, complete message before
-                // giving it to us. Hence we throw, instead of returning false.
-                throw new ArgumentException("Cannot format message where endOfMessage is false using this format", nameof(message));
-            }
-
             return format == MessageFormat.Text ?
                 TextMessageFormatter.TryWriteMessage(message, output) :
                 BinaryMessageFormatter.TryWriteMessage(message, output);

--- a/src/Microsoft.AspNetCore.Sockets.Common/Internal/Formatters/ServerSentEventsMessageFormatter.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Common/Internal/Formatters/ServerSentEventsMessageFormatter.cs
@@ -23,14 +23,6 @@ namespace Microsoft.AspNetCore.Sockets.Internal.Formatters
 
         public static bool TryWriteMessage(Message message, IOutput output)
         {
-            if (!message.EndOfMessage)
-            {
-                // This is a truely exceptional condition since we EXPECT callers to have already
-                // buffered incomplete messages and synthesized the correct, complete message before
-                // giving it to us. Hence we throw, instead of returning false.
-                throw new InvalidOperationException("Cannot format message where endOfMessage is false using this format");
-            }
-
             var typeIndicator = GetTypeIndicator(message.Type);
 
             // Write the Data Prefix

--- a/src/Microsoft.AspNetCore.Sockets.Common/Message.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Common/Message.cs
@@ -7,7 +7,6 @@ namespace Microsoft.AspNetCore.Sockets
 {
     public struct Message
     {
-        public bool EndOfMessage { get; }
         public MessageType Type { get; }
 
         // REVIEW: We need a better primitive to use here. Memory<byte> would be good,
@@ -16,12 +15,6 @@ namespace Microsoft.AspNetCore.Sockets
         public byte[] Payload { get; }
 
         public Message(byte[] payload, MessageType type)
-            : this(payload, type, endOfMessage: true)
-        {
-
-        }
-
-        public Message(byte[] payload, MessageType type, bool endOfMessage)
         {
             if (payload == null)
             {
@@ -29,7 +22,6 @@ namespace Microsoft.AspNetCore.Sockets
             }
 
             Type = type;
-            EndOfMessage = endOfMessage;
             Payload = payload;
         }
     }

--- a/src/Microsoft.AspNetCore.Sockets.Http/Transports/WebSocketsTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Http/Transports/WebSocketsTransport.cs
@@ -161,13 +161,13 @@ namespace Microsoft.AspNetCore.Sockets.Transports
                         offset += incomingMessage[i].Count;
                     }
 
-                    message = new Message(messageBuffer, messageType, receiveResult.EndOfMessage);
+                    message = new Message(messageBuffer, messageType);
                 }
                 else
                 {
                     var buffer = new byte[incomingMessage[0].Count];
                     Buffer.BlockCopy(incomingMessage[0].Array, incomingMessage[0].Offset, buffer, 0, incomingMessage[0].Count);
-                    message = new Message(buffer, messageType, receiveResult.EndOfMessage);
+                    message = new Message(buffer, messageType);
                 }
 
                 _logger.LogInformation("Passing message to application. Payload size: {length}", message.Payload.Length);
@@ -199,11 +199,11 @@ namespace Microsoft.AspNetCore.Sockets.Transports
 
                             if (_logger.IsEnabled(LogLevel.Debug))
                             {
-                                _logger.LogDebug("Sending Type: {messageType}, size: {size}, EndOfMessage: {endOfMessage}", 
-                                    message.Type, message.EndOfMessage, message.Payload.Length);
+                                _logger.LogDebug("Sending Type: {messageType}, size: {size}", 
+                                    message.Type, message.Payload.Length);
                             }
 
-                            await ws.SendAsync(new ArraySegment<byte>(message.Payload), messageType, message.EndOfMessage, CancellationToken.None);
+                            await ws.SendAsync(new ArraySegment<byte>(message.Payload), messageType, endOfMessage: true, cancellationToken: CancellationToken.None);
                         }
                         catch (Exception ex)
                         {

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/TestConnection.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/TestConnection.cs
@@ -52,7 +52,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                 throw new InvalidOperationException("Connection must be started before SendAsync can be called");
             }
 
-            var message = new Message(data, type, endOfMessage: true);
+            var message = new Message(data, type);
             while (await _sentMessages.Out.WaitToWriteAsync(cancellationToken))
             {
                 if (_sentMessages.Out.TryWrite(message))

--- a/test/Microsoft.AspNetCore.SignalR.Tests/TestClient.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/TestClient.cs
@@ -110,7 +110,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             var invocationId = GetInvocationId();
             var payload = await _protocol.WriteToArrayAsync(new InvocationMessage(invocationId, nonBlocking: false, target: methodName, arguments: args));
 
-            await Application.Output.WriteAsync(new Message(payload, _protocol.MessageType, endOfMessage: true));
+            await Application.Output.WriteAsync(new Message(payload, _protocol.MessageType));
 
             return invocationId;
         }

--- a/test/Microsoft.AspNetCore.Sockets.Common.Tests/Internal/Formatters/BinaryMessageFormatterTests.cs
+++ b/test/Microsoft.AspNetCore.Sockets.Common.Tests/Internal/Formatters/BinaryMessageFormatterTests.cs
@@ -93,16 +93,5 @@ namespace Microsoft.AspNetCore.Sockets.Tests.Internal.Formatters
 
             Assert.Equal(encoded, output.ToArray().Slice(offset).ToArray());
         }
-
-        [Fact]
-        public void WriteInvalidMessages()
-        {
-            var message = new Message(new byte[0], MessageType.Binary, endOfMessage: false);
-            var output = new ArrayOutput(chunkSize: 8); // Use small chunks to test Advance/Enlarge and partial payload writing
-            var ex = Assert.Throws<ArgumentException>(() =>
-                MessageFormatter.TryWriteMessage(message, output, MessageFormat.Binary));
-            Assert.Equal($"Cannot format message where endOfMessage is false using this format{Environment.NewLine}Parameter name: message", ex.Message);
-            Assert.Equal("message", ex.ParamName);
-        }
     }
 }

--- a/test/Microsoft.AspNetCore.Sockets.Common.Tests/Internal/Formatters/ServerSentEventsMessageFormatterTests.cs
+++ b/test/Microsoft.AspNetCore.Sockets.Common.Tests/Internal/Formatters/ServerSentEventsMessageFormatterTests.cs
@@ -10,16 +10,6 @@ namespace Microsoft.AspNetCore.Sockets.Tests.Internal.Formatters
 {
     public class ServerSentEventsMessageFormatterTests
     {
-        [Fact]
-        public void WriteInvalidMessages()
-        {
-            var message = new Message(new byte[0], MessageType.Binary, endOfMessage: false);
-            var output = new ArrayOutput(chunkSize: 8); // Use small chunks to test Advance/Enlarge and partial payload writing
-            var ex = Assert.Throws<InvalidOperationException>(() =>
-                ServerSentEventsMessageFormatter.TryWriteMessage(message, output));
-            Assert.Equal("Cannot format message where endOfMessage is false using this format", ex.Message);
-        }
-
         [Theory]
         [InlineData("data: T\r\n\r\n", MessageType.Text, "")]
         [InlineData("data: T\r\ndata: Hello, World\r\n\r\n", MessageType.Text, "Hello, World")]

--- a/test/Microsoft.AspNetCore.Sockets.Common.Tests/Internal/Formatters/TextMessageFormatterTests.cs
+++ b/test/Microsoft.AspNetCore.Sockets.Common.Tests/Internal/Formatters/TextMessageFormatterTests.cs
@@ -66,16 +66,5 @@ namespace Microsoft.AspNetCore.Sockets.Tests.Internal.Formatters
 
             Assert.Equal(encoded, Encoding.UTF8.GetString(output.ToArray()));
         }
-
-        [Fact]
-        public void WriteInvalidMessages()
-        {
-            var message = new Message(new byte[0], MessageType.Binary, endOfMessage: false);
-            var output = new ArrayOutput(chunkSize: 8); // Use small chunks to test Advance/Enlarge and partial payload writing
-            var ex = Assert.Throws<ArgumentException>(() =>
-                MessageFormatter.TryWriteMessage(message, output, MessageFormat.Text));
-            Assert.Equal($"Cannot format message where endOfMessage is false using this format{Environment.NewLine}Parameter name: message", ex.Message);
-            Assert.Equal("message", ex.ParamName);
-        }
     }
 }

--- a/test/Microsoft.AspNetCore.Sockets.Common.Tests/MessageTestUtils.cs
+++ b/test/Microsoft.AspNetCore.Sockets.Common.Tests/MessageTestUtils.cs
@@ -11,14 +11,12 @@ namespace Microsoft.AspNetCore.Sockets.Tests
     {
         public static void AssertMessage(Message message, MessageType messageType, byte[] payload)
         {
-            Assert.True(message.EndOfMessage);
             Assert.Equal(messageType, message.Type);
             Assert.Equal(payload, message.Payload);
         }
 
         public static void AssertMessage(Message message, MessageType messageType, string payload)
         {
-            Assert.True(message.EndOfMessage);
             Assert.Equal(messageType, message.Type);
             Assert.Equal(payload, Encoding.UTF8.GetString(message.Payload));
         }
@@ -27,16 +25,14 @@ namespace Microsoft.AspNetCore.Sockets.Tests
         {
             return new Message(
                 payload,
-                type,
-                endOfMessage: true);
+                type);
         }
 
         public static Message CreateMessage(string payload, MessageType type)
         {
             return new Message(
                 Encoding.UTF8.GetBytes(payload),
-                type,
-                endOfMessage: true);
+                type);
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Sockets.Tests/HttpConnectionDispatcherTests.cs
+++ b/test/Microsoft.AspNetCore.Sockets.Tests/HttpConnectionDispatcherTests.cs
@@ -458,7 +458,7 @@ namespace Microsoft.AspNetCore.Sockets.Tests
             var buffer = Encoding.UTF8.GetBytes("Hello World");
 
             // Write to the transport so the poll yields
-            await state.Connection.Transport.Output.WriteAsync(new Message(buffer, MessageType.Text, endOfMessage: true));
+            await state.Connection.Transport.Output.WriteAsync(new Message(buffer, MessageType.Text));
 
             await task;
 
@@ -490,7 +490,7 @@ namespace Microsoft.AspNetCore.Sockets.Tests
             var buffer = Encoding.UTF8.GetBytes("Hello World");
 
             // Write to the application
-            await state.Application.Output.WriteAsync(new Message(buffer, MessageType.Text, endOfMessage: true));
+            await state.Application.Output.WriteAsync(new Message(buffer, MessageType.Text));
 
             await task;
 
@@ -521,7 +521,7 @@ namespace Microsoft.AspNetCore.Sockets.Tests
             var buffer = Encoding.UTF8.GetBytes("Hello World");
 
             // Write to the application
-            await state.Application.Output.WriteAsync(new Message(buffer, MessageType.Text, endOfMessage: true));
+            await state.Application.Output.WriteAsync(new Message(buffer, MessageType.Text));
 
             await task;
 

--- a/test/Microsoft.AspNetCore.Sockets.Tests/LongPollingTests.cs
+++ b/test/Microsoft.AspNetCore.Sockets.Tests/LongPollingTests.cs
@@ -42,8 +42,7 @@ namespace Microsoft.AspNetCore.Sockets.Tests
 
             await channel.Out.WriteAsync(new Message(
                 Encoding.UTF8.GetBytes("Hello World"),
-                MessageType.Text,
-                endOfMessage: true));
+                MessageType.Text));
 
             Assert.True(channel.Out.TryComplete());
 
@@ -70,16 +69,13 @@ namespace Microsoft.AspNetCore.Sockets.Tests
 
             await channel.Out.WriteAsync(new Message(
                 Encoding.UTF8.GetBytes("Hello"),
-                MessageType.Text,
-                endOfMessage: true));
+                MessageType.Text));
             await channel.Out.WriteAsync(new Message(
                 Encoding.UTF8.GetBytes(" "),
-                MessageType.Text,
-                endOfMessage: true));
+                MessageType.Text));
             await channel.Out.WriteAsync(new Message(
                 Encoding.UTF8.GetBytes("World"),
-                MessageType.Text,
-                endOfMessage: true));
+                MessageType.Text));
 
             Assert.True(channel.Out.TryComplete());
 

--- a/test/Microsoft.AspNetCore.Sockets.Tests/ServerSentEventsTests.cs
+++ b/test/Microsoft.AspNetCore.Sockets.Tests/ServerSentEventsTests.cs
@@ -62,8 +62,7 @@ namespace Microsoft.AspNetCore.Sockets.Tests
 
             await channel.Out.WriteAsync(new Message(
                 Encoding.UTF8.GetBytes(message),
-                MessageType.Text,
-                endOfMessage: true));
+                MessageType.Text));
 
             Assert.True(channel.Out.TryComplete());
 


### PR DESCRIPTION
- The webSockets transport no longer supports partial payloads so
this feature is now gone.