### PR TITLE
Change Group Add and Remove API

### DIFF
--- a/samples/ChatSample/PresenceHubLifetimeManager.cs
+++ b/samples/ChatSample/PresenceHubLifetimeManager.cs
@@ -157,14 +157,14 @@ namespace ChatSample
             return _wrappedHubLifetimeManager.InvokeUserAsync(userId, methodName, args);
         }
 
-        public override Task AddGroupAsync(ConnectionContext connection, string groupName)
+        public override Task AddGroupAsync(string connectionId, string groupName)
         {
-            return _wrappedHubLifetimeManager.AddGroupAsync(connection, groupName);
+            return _wrappedHubLifetimeManager.AddGroupAsync(connectionId, groupName);
         }
 
-        public override Task RemoveGroupAsync(ConnectionContext connection, string groupName)
+        public override Task RemoveGroupAsync(string connectionId, string groupName)
         {
-            return _wrappedHubLifetimeManager.RemoveGroupAsync(connection, groupName);
+            return _wrappedHubLifetimeManager.RemoveGroupAsync(connectionId, groupName);
         }
     }
 }

--- a/samples/SocketsSample/Hubs/Chat.cs
+++ b/samples/SocketsSample/Hubs/Chat.cs
@@ -31,14 +31,14 @@ namespace SocketsSample.Hubs
 
         public async Task JoinGroup(string groupName)
         {
-            await Clients.Group(groupName).InvokeAsync("Send", $"{Context.ConnectionId} joined {groupName}");
+            await Groups.AddAsync(Context.ConnectionId, groupName);
 
-            await Groups.AddAsync(groupName);
+            await Clients.Group(groupName).InvokeAsync("Send", $"{Context.ConnectionId} joined {groupName}");
         }
 
         public async Task LeaveGroup(string groupName)
         {
-            await Groups.RemoveAsync(groupName);
+            await Groups.RemoveAsync(Context.ConnectionId, groupName);
 
             await Clients.Group(groupName).InvokeAsync("Send", $"{Context.ConnectionId} left {groupName}");
         }

--- a/src/Microsoft.AspNetCore.SignalR.Redis/RedisHubLifetimeManager.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Redis/RedisHubLifetimeManager.cs
@@ -200,17 +200,17 @@ namespace Microsoft.AspNetCore.SignalR.Redis
                 // in RemoveGroupAsync
                 foreach (var group in groupNames.ToArray())
                 {
-                    tasks.Add(RemoveGroupAsync(connection, group));
+                    tasks.Add(RemoveGroupAsync(connection.ConnectionId, group));
                 }
             }
 
             return Task.WhenAll(tasks);
         }
 
-        public override async Task AddGroupAsync(ConnectionContext connection, string groupName)
+        public override async Task AddGroupAsync(string connectionId, string groupName)
         {
             var groupChannel = typeof(THub).FullName + ".group." + groupName;
-
+            var connection = _connections[connectionId];
             var groupNames = connection.Metadata.GetOrAdd(HubConnectionMetadataNames.Groups, _ => new HashSet<string>());
 
             lock (groupNames)
@@ -258,7 +258,7 @@ namespace Microsoft.AspNetCore.SignalR.Redis
             }
         }
 
-        public override async Task RemoveGroupAsync(ConnectionContext connection, string groupName)
+        public override async Task RemoveGroupAsync(string connectionId, string groupName)
         {
             var groupChannel = typeof(THub).FullName + ".group." + groupName;
 
@@ -268,6 +268,7 @@ namespace Microsoft.AspNetCore.SignalR.Redis
                 return;
             }
 
+            var connection = _connections[connectionId];
             var groupNames = connection.Metadata.Get<HashSet<string>>(HubConnectionMetadataNames.Groups);
             if (groupNames != null)
             {

--- a/src/Microsoft.AspNetCore.SignalR.Redis/RedisHubLifetimeManager.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Redis/RedisHubLifetimeManager.cs
@@ -211,7 +211,7 @@ namespace Microsoft.AspNetCore.SignalR.Redis
         {
             var groupChannel = typeof(THub).FullName + ".group." + groupName;
             var connection = _connections[connectionId];
-            if(connection != null)
+            if (connection != null)
             {
                 var groupNames = connection.Metadata.GetOrAdd(HubConnectionMetadataNames.Groups, _ => new HashSet<string>());
 
@@ -272,7 +272,7 @@ namespace Microsoft.AspNetCore.SignalR.Redis
             }
 
             var connection = _connections[connectionId];
-            if(connection != null)
+            if (connection != null)
             {
                 var groupNames = connection.Metadata.Get<HashSet<string>>(HubConnectionMetadataNames.Groups);
                 if (groupNames != null)

--- a/src/Microsoft.AspNetCore.SignalR/DefaultHubLifetimeManager.cs
+++ b/src/Microsoft.AspNetCore.SignalR/DefaultHubLifetimeManager.cs
@@ -20,8 +20,9 @@ namespace Microsoft.AspNetCore.SignalR
         private long _nextInvocationId = 0;
         private readonly ConnectionList _connections = new ConnectionList();
 
-        public override Task AddGroupAsync(ConnectionContext connection, string groupName)
+        public override Task AddGroupAsync(string connectionId, string groupName)
         {
+            var connection = _connections[connectionId];
             var groups = connection.Metadata.GetOrAdd(HubConnectionMetadataNames.Groups, _ => new HashSet<string>());
 
             lock (groups)
@@ -32,8 +33,9 @@ namespace Microsoft.AspNetCore.SignalR
             return Task.CompletedTask;
         }
 
-        public override Task RemoveGroupAsync(ConnectionContext connection, string groupName)
+        public override Task RemoveGroupAsync(string connectionId, string groupName)
         {
+            var connection = _connections[connectionId];
             var groups = connection.Metadata.Get<HashSet<string>>(HubConnectionMetadataNames.Groups);
 
             if (groups == null)

--- a/src/Microsoft.AspNetCore.SignalR/DefaultHubLifetimeManager.cs
+++ b/src/Microsoft.AspNetCore.SignalR/DefaultHubLifetimeManager.cs
@@ -23,11 +23,13 @@ namespace Microsoft.AspNetCore.SignalR
         public override Task AddGroupAsync(string connectionId, string groupName)
         {
             var connection = _connections[connectionId];
-            var groups = connection.Metadata.GetOrAdd(HubConnectionMetadataNames.Groups, _ => new HashSet<string>());
-
-            lock (groups)
+            if (connection != null)
             {
-                groups.Add(groupName);
+                var groups = connection.Metadata.GetOrAdd(HubConnectionMetadataNames.Groups, _ => new HashSet<string>());
+                lock (groups)
+                {
+                    groups.Add(groupName);
+                }
             }
 
             return Task.CompletedTask;
@@ -36,16 +38,19 @@ namespace Microsoft.AspNetCore.SignalR
         public override Task RemoveGroupAsync(string connectionId, string groupName)
         {
             var connection = _connections[connectionId];
-            var groups = connection.Metadata.Get<HashSet<string>>(HubConnectionMetadataNames.Groups);
-
-            if (groups == null)
+            if (connection != null)
             {
-                return Task.CompletedTask;
-            }
+                var groups = connection.Metadata.Get<HashSet<string>>(HubConnectionMetadataNames.Groups);
 
-            lock (groups)
-            {
-                groups.Remove(groupName);
+                if (groups == null)
+                {
+                    return Task.CompletedTask;
+                }
+
+                lock (groups)
+                {
+                    groups.Remove(groupName);
+                }
             }
 
             return Task.CompletedTask;

--- a/src/Microsoft.AspNetCore.SignalR/DefaultHubLifetimeManager.cs
+++ b/src/Microsoft.AspNetCore.SignalR/DefaultHubLifetimeManager.cs
@@ -23,13 +23,15 @@ namespace Microsoft.AspNetCore.SignalR
         public override Task AddGroupAsync(string connectionId, string groupName)
         {
             var connection = _connections[connectionId];
-            if (connection != null)
+            if (connection == null)
             {
-                var groups = connection.Metadata.GetOrAdd(HubConnectionMetadataNames.Groups, _ => new HashSet<string>());
-                lock (groups)
-                {
-                    groups.Add(groupName);
-                }
+                return Task.CompletedTask;
+            }
+
+            var groups = connection.Metadata.GetOrAdd(HubConnectionMetadataNames.Groups, _ => new HashSet<string>());
+            lock (groups)
+            {
+                groups.Add(groupName);
             }
 
             return Task.CompletedTask;
@@ -38,19 +40,21 @@ namespace Microsoft.AspNetCore.SignalR
         public override Task RemoveGroupAsync(string connectionId, string groupName)
         {
             var connection = _connections[connectionId];
-            if (connection != null)
+            if (connection == null)
             {
-                var groups = connection.Metadata.Get<HashSet<string>>(HubConnectionMetadataNames.Groups);
+                return Task.CompletedTask;
+            }
 
-                if (groups == null)
-                {
-                    return Task.CompletedTask;
-                }
+            var groups = connection.Metadata.Get<HashSet<string>>(HubConnectionMetadataNames.Groups);
 
-                lock (groups)
-                {
-                    groups.Remove(groupName);
-                }
+            if (groups == null)
+            {
+                return Task.CompletedTask;
+            }
+
+            lock (groups)
+            {
+                groups.Remove(groupName);
             }
 
             return Task.CompletedTask;

--- a/src/Microsoft.AspNetCore.SignalR/HubLifetimeManager.cs
+++ b/src/Microsoft.AspNetCore.SignalR/HubLifetimeManager.cs
@@ -20,9 +20,9 @@ namespace Microsoft.AspNetCore.SignalR
 
         public abstract Task InvokeUserAsync(string userId, string methodName, object[] args);
 
-        public abstract Task AddGroupAsync(ConnectionContext connection, string groupName);
+        public abstract Task AddGroupAsync(string connectionId, string groupName);
 
-        public abstract Task RemoveGroupAsync(ConnectionContext connection, string groupName);
+        public abstract Task RemoveGroupAsync(string connnectionId, string groupName);
     }
 
 }

--- a/src/Microsoft.AspNetCore.SignalR/IGroupManager.cs
+++ b/src/Microsoft.AspNetCore.SignalR/IGroupManager.cs
@@ -7,7 +7,7 @@ namespace Microsoft.AspNetCore.SignalR
 {
     public interface IGroupManager
     {
-        Task AddAsync(string groupName);
-        Task RemoveAsync(string groupName);
+        Task AddAsync(string connectionId, string groupName);
+        Task RemoveAsync(string connectionId, string groupName);
     }
 }

--- a/src/Microsoft.AspNetCore.SignalR/Proxies.cs
+++ b/src/Microsoft.AspNetCore.SignalR/Proxies.cs
@@ -86,12 +86,12 @@ namespace Microsoft.AspNetCore.SignalR
 
         public Task AddAsync(string groupName)
         {
-            return _lifetimeManager.AddGroupAsync(_connection, groupName);
+            return _lifetimeManager.AddGroupAsync(_connection.ConnectionId, groupName);
         }
 
         public Task RemoveAsync(string groupName)
         {
-            return _lifetimeManager.RemoveGroupAsync(_connection, groupName);
+            return _lifetimeManager.RemoveGroupAsync(_connection.ConnectionId, groupName);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.SignalR/Proxies.cs
+++ b/src/Microsoft.AspNetCore.SignalR/Proxies.cs
@@ -84,14 +84,14 @@ namespace Microsoft.AspNetCore.SignalR
             _lifetimeManager = lifetimeManager;
         }
 
-        public Task AddAsync(string groupName)
+        public Task AddAsync(string connectionId, string groupName)
         {
-            return _lifetimeManager.AddGroupAsync(_connection.ConnectionId, groupName);
+            return _lifetimeManager.AddGroupAsync(connectionId, groupName);
         }
 
-        public Task RemoveAsync(string groupName)
+        public Task RemoveAsync(string connectionId, string groupName)
         {
-            return _lifetimeManager.RemoveGroupAsync(_connection.ConnectionId, groupName);
+            return _lifetimeManager.RemoveGroupAsync(connectionId, groupName);
         }
     }
 }

--- a/test/Microsoft.AspNetCore.SignalR.Tests/HubEndpointTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/HubEndpointTests.cs
@@ -649,7 +649,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
         {
             public Task GroupRemoveMethod(string groupName)
             {
-                return Groups.RemoveAsync(groupName);
+                return Groups.RemoveAsync(Context.ConnectionId, groupName);
             }
 
             public Task ClientSendMethod(string userId, string message)
@@ -664,7 +664,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
 
             public Task GroupAddMethod(string groupName)
             {
-                return Groups.AddAsync(groupName);
+                return Groups.AddAsync(Context.ConnectionId, groupName);
             }
 
             public Task GroupSendMethod(string groupName, string message)


### PR DESCRIPTION
Changing the Group add and remove API to accept a connectionId instead of a `ConnectionContext`. This lets you remove any connection from a group.