### PR TITLE
Clean up GroupManager

### DIFF
--- a/samples/ChatSample/PresenceHubLifetimeManager.cs
+++ b/samples/ChatSample/PresenceHubLifetimeManager.cs
@@ -113,7 +113,7 @@ namespace ChatSample
 
                     hub.Clients = _hubContext.Clients;
                     hub.Context = new HubCallerContext(connection);
-                    hub.Groups = new GroupManager<THub>(connection, this);
+                    hub.Groups = new GroupManager<THub>(this);
 
                     try
                     {

--- a/src/Microsoft.AspNetCore.SignalR/HubEndPoint.cs
+++ b/src/Microsoft.AspNetCore.SignalR/HubEndPoint.cs
@@ -312,7 +312,7 @@ namespace Microsoft.AspNetCore.SignalR
         {
             hub.Clients = _hubContext.Clients;
             hub.Context = new HubCallerContext(connection);
-            hub.Groups = new GroupManager<THub>(connection, _lifetimeManager);
+            hub.Groups = new GroupManager<THub>(_lifetimeManager);
         }
 
         private bool IsChannel(Type type, out Type payloadType)

--- a/src/Microsoft.AspNetCore.SignalR/Proxies.cs
+++ b/src/Microsoft.AspNetCore.SignalR/Proxies.cs
@@ -75,12 +75,10 @@ namespace Microsoft.AspNetCore.SignalR
 
     public class GroupManager<THub> : IGroupManager
     {
-        private readonly ConnectionContext _connection;
         private readonly HubLifetimeManager<THub> _lifetimeManager;
 
-        public GroupManager(ConnectionContext connection, HubLifetimeManager<THub> lifetimeManager)
+        public GroupManager(HubLifetimeManager<THub> lifetimeManager)
         {
-            _connection = connection;
             _lifetimeManager = lifetimeManager;
         }
 


### PR DESCRIPTION
Removing the connection from the `GroupManager`. No longer necessary after the Group API changes