### PR TITLE
Add NETStandardImplicitPackageVersion to dependencies.props

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -8,6 +8,7 @@
     <InternalAspNetCoreSdkVersion>2.1.0-*</InternalAspNetCoreSdkVersion>
     <JsonNetVersion>10.0.1</JsonNetVersion>
     <MoqVersion>4.7.1</MoqVersion>
+    <NETStandardImplicitPackageVersion>2.0.0-*</NETStandardImplicitPackageVersion>
     <NETStandardLibraryNETFrameworkVersion>2.0.0-*</NETStandardLibraryNETFrameworkVersion>
     <RedisVersion>1.2.3</RedisVersion>
     <RuntimeFrameworkVersion Condition="'$(TargetFramework)'=='netcoreapp2.0'">2.0.0-*</RuntimeFrameworkVersion>


### PR DESCRIPTION
This seems to fix the following error with the latest CLI

```
16:40:13.711     1>C:\github\signalr\src\Microsoft.AspNetCore.Sockets.Client\Microsoft.AspNetCore.Sockets.Client.csproj : error NU1605: Detected package downgrade: NETStandard.Library from 2.0.0-preview2-25401-01 to 1.6.1. Reference the package directly from the project to select a different version. \r [C:\github\signalr\.build\KoreBuild.proj]
C:\github\signalr\src\Microsoft.AspNetCore.Sockets.Client\Microsoft.AspNetCore.Sockets.Client.csproj : error NU1605:  Microsoft.AspNetCore.Sockets.Client (>= 1.0.0-preview2-t0049d3b4a) -> Microsoft.Extensions.Logging.Abstractions (>= 2.0.0-preview2-25712) -> NETStandard.Library (>= 2.0.0-preview2-25401-01) \r [C:\github\signalr\.build\KoreBuild.proj]
C:\github\signalr\src\Microsoft.AspNetCore.Sockets.Client\Microsoft.AspNetCore.Sockets.Client.csproj : error NU1605:  Microsoft.AspNetCore.Sockets.Client (>= 1.0.0-preview2-t0049d3b4a) -> NETStandard.Library (>= 1.6.1) [C:\github\signalr\.build\KoreBuild.proj]
```