### PR TITLE
Decouple IConnection.ts and HubConnection.ts from http

### DIFF
--- a/client-ts/Microsoft.AspNetCore.SignalR.Client.TS.Tests/HubConnection.spec.ts
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Client.TS.Tests/HubConnection.spec.ts
@@ -211,7 +211,7 @@ describe("HubConnection", () => {
 });
 
 class TestConnection implements IConnection {
-    start(transportType: TransportType | ITransport): Promise<void> {
+    start(): Promise<void> {
         return Promise.resolve();
     };
 

--- a/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/HubConnection.ts
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/HubConnection.ts
@@ -1,10 +1,9 @@
 import { ConnectionClosed } from "./Common"
 import { IConnection } from "./IConnection"
-import { Connection } from "./Connection"
 import { TransportType } from "./Transports"
 import { Subject, Observable } from "./Observable"
-export { Connection } from "./Connection"
 export { TransportType } from "./Transports"
+export { HttpConnection } from "./HttpConnection"
 import { IHubProtocol, MessageType, HubMessage, CompletionMessage, ResultMessage, InvocationMessage } from "./IHubProtocol";
 import { JsonHubProtocol } from "./JsonHubProtocol";
 
@@ -16,14 +15,8 @@ export class HubConnection {
     private connectionClosedCallback: ConnectionClosed;
     private protocol: IHubProtocol;
 
-    static create(url: string, queryString?: string): HubConnection {
-        return new this(new Connection(url, queryString))
-    }
-
-    constructor(connection: IConnection);
-    constructor(url: string, queryString?: string);
-    constructor(connectionOrUrl: IConnection | string, queryString?: string) {
-        this.connection = typeof connectionOrUrl === "string" ? new Connection(connectionOrUrl, queryString) : connectionOrUrl;
+    constructor(connection: IConnection) {
+        this.connection = connection;
         this.connection.onDataReceived = data => {
             this.onDataReceived(data);
         };
@@ -96,8 +89,8 @@ export class HubConnection {
         }
     }
 
-    start(transportType?: TransportType): Promise<void> {
-        return this.connection.start(transportType);
+    start(): Promise<void> {
+        return this.connection.start();
     }
 
     stop(): void {

--- a/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/IConnection.ts
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/IConnection.ts
@@ -2,7 +2,7 @@ import { DataReceived, ConnectionClosed } from "./Common"
 import { TransportType, ITransport } from  "./Transports"
 
 export interface IConnection {
-    start(transportType: TransportType | ITransport): Promise<void>;
+    start(): Promise<void>;
     send(data: any): Promise<void>;
     stop(): void;
 

--- a/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/IHttpConnectionOptions.ts
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/IHttpConnectionOptions.ts
@@ -1,0 +1,7 @@
+import { IHttpClient } from "./HttpClient"
+import { TransportType, ITransport } from "./Transports"
+
+export interface IHttpConnectionOptions {
+    httpClient?: IHttpClient;
+    transport?: TransportType | ITransport;
+}

--- a/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/ISignalROptions.ts
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/ISignalROptions.ts
@@ -1,5 +1,0 @@
-import {IHttpClient} from "./HttpClient"
-
-export interface ISignalROptions {
-    httpClient?: IHttpClient;
-}

--- a/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/index.ts
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/index.ts
@@ -1,5 +1,5 @@
 export * from "./Common"
-export * from "./Connection"
+export * from "./HttpConnection"
 export * from "./HttpClient"
 export * from "./HubConnection"
 export * from "./Transports"

--- a/samples/ChatSample/Views/Home/Index.cshtml
+++ b/samples/ChatSample/Views/Home/Index.cshtml
@@ -17,7 +17,8 @@
 <script src="lib/signalr-client/signalr-client.js"></script>
 <script>
 let transportType = signalR.TransportType[getParameterByName('transport')] || signalR.TransportType.WebSockets;
-let connection = new signalR.HubConnection(`http://${document.location.host}/chat`, 'formatType=json&format=text');
+let http = new signalR.HttpConnection(`http://${document.location.host}/chat`, { transport: transportType });
+let connection = new signalR.HubConnection(http);
 
 connection.onClosed = e => {
     if (e) {
@@ -59,7 +60,7 @@ connection.on('Send', (userName, message) => {
     document.getElementById('messages').appendChild(child);
 });
 
-connection.start(transportType).catch(err => appendLine(err, 'red'));
+connection.start().catch(err => appendLine(err, 'red'));
 
 document.getElementById('sendmessage').addEventListener('submit', event => {
     let data = document.getElementById('new-message').value;

--- a/samples/SocketsSample/wwwroot/hubs.html
+++ b/samples/SocketsSample/wwwroot/hubs.html
@@ -81,7 +81,7 @@ let transportType = signalR.TransportType[getParameterByName('transport')] || si
 
 document.getElementById('head1').innerHTML = signalR.TransportType[transportType];
 
-let connection = new signalR.HubConnection(`http://${document.location.host}/hubs`, 'formatType=json&format=text');
+let connection = new signalR.HubConnection(new signalR.HttpConnection(`http://${document.location.host}/hubs`, 'formatType=json&format=text'));
 connection.on('Send', msg => {
     addLine('message-list', msg);
 });

--- a/samples/SocketsSample/wwwroot/hubs.html
+++ b/samples/SocketsSample/wwwroot/hubs.html
@@ -97,7 +97,7 @@ connection.onClosed = e => {
 }
 
 click('connect', event => {
-    connection.start(transportType)
+    connection.start()
         .then(() => {
             isConnected = true;
             addLine('message-list', 'Connected successfully', 'green');

--- a/samples/SocketsSample/wwwroot/hubs.html
+++ b/samples/SocketsSample/wwwroot/hubs.html
@@ -81,7 +81,8 @@ let transportType = signalR.TransportType[getParameterByName('transport')] || si
 
 document.getElementById('head1').innerHTML = signalR.TransportType[transportType];
 
-let connection = new signalR.HubConnection(new signalR.HttpConnection(`http://${document.location.host}/hubs`, 'formatType=json&format=text'));
+let http = new signalR.HttpConnection(`http://${document.location.host}/hubs`, { transport: transportType });
+let connection = new signalR.HubConnection(http);
 connection.on('Send', msg => {
     addLine('message-list', msg);
 });

--- a/samples/SocketsSample/wwwroot/sockets.html
+++ b/samples/SocketsSample/wwwroot/sockets.html
@@ -22,7 +22,7 @@
             document.getElementById('transportName').innerHTML = signalR.TransportType[transportType];
 
             let url = `http://${document.location.host}/chat`
-            let connection = new signalR.HttpConnection(url);
+            let connection = new signalR.HttpConnection(url, { transport: transportType });
 
             connection.onDataReceived = data => {
                 let child = document.createElement('li');
@@ -36,7 +36,7 @@
                 event.preventDefault();
             });
 
-            connection.start(transportType).then(() => {
+            connection.start().then(() => {
                 console.log("Opened");
             }, () => {
                 console.log("Error opening connection");

--- a/samples/SocketsSample/wwwroot/sockets.html
+++ b/samples/SocketsSample/wwwroot/sockets.html
@@ -22,7 +22,7 @@
             document.getElementById('transportName').innerHTML = signalR.TransportType[transportType];
 
             let url = `http://${document.location.host}/chat`
-            let connection = new signalR.Connection(url);
+            let connection = new signalR.HttpConnection(url);
 
             connection.onDataReceived = data => {
                 let child = document.createElement('li');

--- a/samples/SocketsSample/wwwroot/streaming.html
+++ b/samples/SocketsSample/wwwroot/streaming.html
@@ -53,7 +53,8 @@
             });
 
             click('connectButton', function () {
-                connection = new signalR.HubConnection(new signalR.HttpConnection(url, 'formatType=json&format=text'));
+                let http = new signalR.HttpConnection(url, { transport: transportType });
+                connection = new signalR.HubConnection(http);
 
                 connection.onClosed = function () {
                     channelButton.disabled = true;
@@ -64,7 +65,7 @@
                     addLine('resultsList', 'disconnected', 'green');
                 };
 
-                connection.start(transportType)
+                connection.start()
                     .then(function () {
                         channelButton.disabled = false;
                         observableButton.disabled = false;

--- a/samples/SocketsSample/wwwroot/streaming.html
+++ b/samples/SocketsSample/wwwroot/streaming.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html>
 <head>
     <meta charset="utf-8" />
@@ -53,7 +53,7 @@
             });
 
             click('connectButton', function () {
-                connection = new signalR.HubConnection(url, 'formatType=json&format=text');
+                connection = new signalR.HubConnection(new signalR.HttpConnection(url, 'formatType=json&format=text'));
 
                 connection.onClosed = function () {
                     channelButton.disabled = true;


### PR DESCRIPTION
- Removed TransportType from start
- Renamed Connection.ts to HttpConnection.ts

The creation of the SignalR client is a bit uglier but I plan to fix that in both C# and JS (and other clients) with some sort of builder pattern.