### PR TITLE
Passing Transport.All as a default C# client transport

### DIFF
--- a/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/HttpConnection.ts
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/HttpConnection.ts
@@ -45,7 +45,7 @@ export class HttpConnection implements IConnection {
 
     private async startInternal(): Promise<void> {
         try {
-            let negotiatePayload = await this.httpClient.options(this.url);  
+            let negotiatePayload = await this.httpClient.options(this.url);
             let negotiateResponse: INegotiateResponse = JSON.parse(negotiatePayload);
             this.connectionId = negotiateResponse.connectionId;
 

--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/HttpConnection.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/HttpConnection.cs
@@ -39,7 +39,7 @@ namespace Microsoft.AspNetCore.Sockets.Client
         public event Action<Exception> Closed;
 
         public HttpConnection(Uri url)
-            : this(url, TransportType.WebSockets)
+            : this(url, TransportType.All)
         { }
 
         public HttpConnection(Uri url, TransportType transportType)
@@ -48,7 +48,7 @@ namespace Microsoft.AspNetCore.Sockets.Client
         }
 
         public HttpConnection(Uri url, ILoggerFactory loggerFactory)
-            : this(url, TransportType.WebSockets, loggerFactory, httpMessageHandler: null)
+            : this(url, TransportType.All, loggerFactory, httpMessageHandler: null)
         {
         }
 

--- a/test/Microsoft.AspNetCore.SignalR.Tests/EndToEndTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/EndToEndTests.cs
@@ -75,6 +75,15 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             }
         }
 
+        [Fact]
+        public async Task CanStartConnectionUsingDefaultTransport()
+        {
+            var url = _serverFixture.BaseUrl + "/echo";
+            var connection = new HttpConnection(new Uri(url));
+            await connection.StartAsync().OrTimeout();
+            await connection.DisposeAsync().OrTimeout();
+        }
+
         [ConditionalTheory]
         [OSSkipCondition(OperatingSystems.Windows, WindowsVersions.Win7, WindowsVersions.Win2008R2, SkipReason = "No WebSockets Client for this platform")]
         [MemberData(nameof(TransportTypes))]


### PR DESCRIPTION
It will make the client pick WebSockets where available and
ServerSentEvents where not (e.g. Win7)