### PR TITLE
Changed the handler to be Func<object[], Task>

### DIFF
--- a/samples/ClientSample/RawSample.cs
+++ b/samples/ClientSample/RawSample.cs
@@ -40,7 +40,7 @@ namespace ClientSample
             try
             {
                 var cts = new CancellationTokenSource();
-                connection.Received += data => Console.WriteLine($"{Encoding.UTF8.GetString(data)}");
+                connection.Received += data => Console.Out.WriteLineAsync($"{Encoding.UTF8.GetString(data)}");
                 connection.Closed += e => cts.Cancel();
 
                 await connection.StartAsync();

--- a/src/Microsoft.AspNetCore.SignalR.Client/HubConnection.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client/HubConnection.cs
@@ -354,7 +354,7 @@ namespace Microsoft.AspNetCore.SignalR.Client
             }
         }
 
-        public struct InvocationHandler
+        private struct InvocationHandler
         {
             public Func<object[], Task> Handler { get; }
             public Type[] ParameterTypes { get; }

--- a/src/Microsoft.AspNetCore.SignalR.Client/HubConnectionExtensions.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client/HubConnectionExtensions.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Threading.Tasks.Channels;
+using static Microsoft.AspNetCore.SignalR.Client.HubConnection;
 
 namespace Microsoft.AspNetCore.SignalR.Client
 {
@@ -87,6 +88,11 @@ namespace Microsoft.AspNetCore.SignalR.Client
             _ = RunChannel();
 
             return outputChannel.In;
+        }
+
+        private static void On(this HubConnection hubConnetion, string methodName, Type[] parameterTypes, Action<object[]> handler)
+        {
+            hubConnetion.On(methodName, parameterTypes, (parameters) => { handler(parameters); return Task.CompletedTask; });
         }
 
         public static void On(this HubConnection hubConnection, string methodName, Action handler)

--- a/src/Microsoft.AspNetCore.SignalR.Client/HubConnectionExtensions.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client/HubConnectionExtensions.cs
@@ -92,7 +92,11 @@ namespace Microsoft.AspNetCore.SignalR.Client
 
         private static void On(this HubConnection hubConnetion, string methodName, Type[] parameterTypes, Action<object[]> handler)
         {
-            hubConnetion.On(methodName, parameterTypes, (parameters) => { handler(parameters); return Task.CompletedTask; });
+            hubConnetion.On(methodName, parameterTypes, (parameters) => 
+            {
+                handler(parameters);
+                return Task.CompletedTask;
+            });
         }
 
         public static void On(this HubConnection hubConnection, string methodName, Action handler)

--- a/src/Microsoft.AspNetCore.Sockets.Abstractions/IConnection.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Abstractions/IConnection.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.Sockets.Client
         Task DisposeAsync();
 
         event Action Connected;
-        event Action<byte[]> Received;
+        event Func<byte[], Task> Received;
         event Action<Exception> Closed;
     }
 }

--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/HttpConnection.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/HttpConnection.cs
@@ -284,7 +284,7 @@ namespace Microsoft.AspNetCore.Sockets.Client
                     if (Input.TryRead(out var buffer))
                     {
                         _logger.LogDebug("Scheduling raising Received event.");
-                        var _ = _eventQueue.Enqueue(() =>
+                        _ = _eventQueue.Enqueue(() =>
                         {
                             _logger.LogDebug("Raising Received event.");
 

--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/HttpConnection.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/HttpConnection.cs
@@ -288,6 +288,8 @@ namespace Microsoft.AspNetCore.Sockets.Client
                         {
                             _logger.LogDebug("Raising Received event.");
 
+                            // Making a copy of the Received handler to ensure that its not null
+                            // Can't use the ? operator because we specifically want to check if the handler is null
                             var receivedHandler = Received;
                             if (receivedHandler != null)
                             {

--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/HttpConnection.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/HttpConnection.cs
@@ -284,11 +284,11 @@ namespace Microsoft.AspNetCore.Sockets.Client
                     if (Input.TryRead(out var buffer))
                     {
                         _logger.LogDebug("Scheduling raising Received event.");
-                        var ignore = _eventQueue.Enqueue(async () =>
+                        var _ = _eventQueue.Enqueue(() =>
                         {
                             _logger.LogDebug("Raising Received event.");
 
-                            await Received?.Invoke(buffer);
+                            return Received?.Invoke(buffer);
                         });
                     }
                     else

--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/HttpConnection.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/HttpConnection.cs
@@ -288,7 +288,13 @@ namespace Microsoft.AspNetCore.Sockets.Client
                         {
                             _logger.LogDebug("Raising Received event.");
 
-                            return Received?.Invoke(buffer);
+                            var receivedHandler = Received;
+                            if (receivedHandler != null)
+                            {
+                                return receivedHandler(buffer);
+                            }
+
+                            return Task.CompletedTask;
                         });
                     }
                     else

--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/HttpConnection.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/HttpConnection.cs
@@ -35,7 +35,7 @@ namespace Microsoft.AspNetCore.Sockets.Client
         public Uri Url { get; }
 
         public event Action Connected;
-        public event Action<byte[]> Received;
+        public event Func<byte[], Task> Received;
         public event Action<Exception> Closed;
 
         public HttpConnection(Uri url)
@@ -284,13 +284,11 @@ namespace Microsoft.AspNetCore.Sockets.Client
                     if (Input.TryRead(out var buffer))
                     {
                         _logger.LogDebug("Scheduling raising Received event.");
-                        var ignore = _eventQueue.Enqueue(() =>
+                        var ignore = _eventQueue.Enqueue(async () =>
                         {
                             _logger.LogDebug("Raising Received event.");
 
-                            Received?.Invoke(buffer);
-
-                            return Task.CompletedTask;
+                            await Received?.Invoke(buffer);
                         });
                     }
                     else

--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/Internal/TaskQueue.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/Internal/TaskQueue.cs
@@ -49,7 +49,8 @@ namespace Microsoft.AspNetCore.Sockets.Client.Internal
                     {
                         return t;
                     }
-                    return taskFunc(s1);
+
+                    return taskFunc(s1) ?? Task.CompletedTask;
                 },
                 state).Unwrap();
                 _lastQueuedTask = newTask;

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/ConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/ConnectionTests.cs
@@ -408,7 +408,6 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
                 };
 
             await connection.StartAsync();
-<<<<<<< HEAD
             channel.Out.TryWrite(Array.Empty<byte>());
 
             // Ensure that the Received callback has been called before attempting the second write
@@ -417,16 +416,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
 
             // Ensure that SignalR isn't blocked by the receive callback
             Assert.False(channel.In.TryRead(out var message));
-=======
-            channel.Output.TryWrite(Array.Empty<byte>());
 
-            // Ensure that the Received callback has been called before attempting the second write
-            await callbackInvokedTcs.Task.OrTimeout();
-            channel.Output.TryWrite(Array.Empty<byte>());
-
-            // Ensure that SignalR isn't blocked by the receive callback
-            Assert.False(channel.Input.TryRead(out var message));
->>>>>>> Fix test
             closedTcs.SetResult(null);
 
             await connection.DisposeAsync();

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/ConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/ConnectionTests.cs
@@ -11,14 +11,20 @@ using System.Threading.Tasks.Channels;
 using Microsoft.AspNetCore.Client.Tests;
 using Microsoft.AspNetCore.SignalR.Tests.Common;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Testing;
 using Moq;
 using Moq.Protected;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.AspNetCore.Sockets.Client.Tests
 {
-    public class ConnectionTests
+    public class ConnectionTests : LoggedTest
     {
+        public ConnectionTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         [Fact]
         public void CannotCreateConnectionWithNullUrl()
         {
@@ -351,7 +357,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
 
             var connection = new HttpConnection(new Uri("http://fakeuri.org/"), new TestTransportFactory(mockTransport.Object), loggerFactory: null, httpMessageHandler: mockHttpHandler.Object);
             var receivedInvoked = false;
-            connection.Received += (m) => 
+            connection.Received += m => 
             {
                 receivedInvoked = true;
                 return Task.CompletedTask;
@@ -365,16 +371,16 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
         [Fact]
         public async Task EventsAreNotRunningOnMainLoop()
         {
-            var mockHttpHandler = new Mock<HttpMessageHandler>();
-            mockHttpHandler.Protected()
-                .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
-                .Returns<HttpRequestMessage, CancellationToken>(async (request, cancellationToken) =>
-                {
-                    await Task.Yield();
-                    return request.Method == HttpMethod.Options
-                        ? ResponseUtils.CreateResponse(HttpStatusCode.OK, ResponseUtils.CreateNegotiationResponse())
-                        : ResponseUtils.CreateResponse(HttpStatusCode.OK);
-                });
+                var mockHttpHandler = new Mock<HttpMessageHandler>();
+                mockHttpHandler.Protected()
+                    .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                    .Returns<HttpRequestMessage, CancellationToken>(async (request, cancellationToken) =>
+                    {
+                        await Task.Yield();
+                        return request.Method == HttpMethod.Options
+                            ? ResponseUtils.CreateResponse(HttpStatusCode.OK, ResponseUtils.CreateNegotiationResponse())
+                            : ResponseUtils.CreateResponse(HttpStatusCode.OK);
+                    });
 
             var mockTransport = new Mock<ITransport>();
             Channel<byte[], SendMessage> channel = null;

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/ConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/ConnectionTests.cs
@@ -382,7 +382,6 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
             Channel<byte[], SendMessage> channel = null;
             mockTransport.Setup(t => t.StartAsync(It.IsAny<Uri>(), It.IsAny<Channel<byte[], SendMessage>>()))
                 .Returns<Uri, Channel<byte[], SendMessage>>((url, c) =>
-
                 {
                     channel = c;
                     return Task.CompletedTask;
@@ -391,7 +390,6 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
                 .Returns(() =>
                 {
                     channel.Out.TryComplete();
-
                     return Task.CompletedTask;
                 });
 

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/ConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/ConnectionTests.cs
@@ -351,7 +351,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
 
             var connection = new HttpConnection(new Uri("http://fakeuri.org/"), new TestTransportFactory(mockTransport.Object), loggerFactory: null, httpMessageHandler: mockHttpHandler.Object);
             var receivedInvoked = false;
-            connection.Received += (m) => receivedInvoked = true;
+            connection.Received += (m) => { receivedInvoked = true; return Task.CompletedTask; };
 
             await connection.StartAsync();
             await connection.DisposeAsync();
@@ -388,30 +388,29 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
                 });
 
 
+            var callbackInvokedTcs = new TaskCompletionSource<object>();
             var closedTcs = new TaskCompletionSource<object>();
-            var allowDisposeTcs = new TaskCompletionSource<object>();
-            int receivedInvocationCount = 0;
 
             var connection = new HttpConnection(new Uri("http://fakeuri.org/"), new TestTransportFactory(mockTransport.Object), loggerFactory: null, httpMessageHandler: mockHttpHandler.Object);
             connection.Received +=
-                async (m) =>
+                async m =>
                 {
-                    if (Interlocked.Increment(ref receivedInvocationCount) == 2)
-                    {
-                        allowDisposeTcs.TrySetResult(null);
-                    }
+                    callbackInvokedTcs.SetResult(null);
                     await closedTcs.Task;
                 };
-            connection.Closed += e => closedTcs.SetResult(null);
 
             await connection.StartAsync();
             channel.Out.TryWrite(Array.Empty<byte>());
+
+            // Ensure that the Received callback has been called before attempting the second write
+            await callbackInvokedTcs.Task.OrTimeout();
             channel.Out.TryWrite(Array.Empty<byte>());
-            await allowDisposeTcs.Task.OrTimeout();
+
+            // Ensure that SignalR isn't blocked by the receive callback
+            Assert.False(channel.In.TryRead(out var message));
+            closedTcs.SetResult(null);
+
             await connection.DisposeAsync();
-            Assert.Equal(2, receivedInvocationCount);
-            // if the events were running on the main loop they would deadlock
-            await closedTcs.Task.OrTimeout();
         }
 
         [Fact]
@@ -593,7 +592,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
             try
             {
                 var receiveTcs = new TaskCompletionSource<string>();
-                connection.Received += (data) => receiveTcs.TrySetResult(Encoding.UTF8.GetString(data));
+                connection.Received += (data) => { receiveTcs.TrySetResult(Encoding.UTF8.GetString(data)); return Task.CompletedTask; };
                 connection.Closed += e =>
                     {
                         if (e != null)

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/ConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/ConnectionTests.cs
@@ -351,7 +351,11 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
 
             var connection = new HttpConnection(new Uri("http://fakeuri.org/"), new TestTransportFactory(mockTransport.Object), loggerFactory: null, httpMessageHandler: mockHttpHandler.Object);
             var receivedInvoked = false;
-            connection.Received += (m) => { receivedInvoked = true; return Task.CompletedTask; };
+            connection.Received += (m) => 
+            {
+                receivedInvoked = true;
+                return Task.CompletedTask;
+            };
 
             await connection.StartAsync();
             await connection.DisposeAsync();
@@ -592,7 +596,12 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
             try
             {
                 var receiveTcs = new TaskCompletionSource<string>();
-                connection.Received += (data) => { receiveTcs.TrySetResult(Encoding.UTF8.GetString(data)); return Task.CompletedTask; };
+                connection.Received += (data) => 
+                {
+                    receiveTcs.TrySetResult(Encoding.UTF8.GetString(data));
+                    return Task.CompletedTask;
+                };
+
                 connection.Closed += e =>
                     {
                         if (e != null)

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/ConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/ConnectionTests.cs
@@ -353,7 +353,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
 
             var connection = new HttpConnection(new Uri("http://fakeuri.org/"), new TestTransportFactory(mockTransport.Object), loggerFactory: null, httpMessageHandler: mockHttpHandler.Object);
             var receivedInvoked = false;
-            connection.Received += m => 
+            connection.Received += m =>
             {
                 receivedInvoked = true;
                 return Task.CompletedTask;
@@ -367,16 +367,16 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
         [Fact]
         public async Task EventsAreNotRunningOnMainLoop()
         {
-                var mockHttpHandler = new Mock<HttpMessageHandler>();
-                mockHttpHandler.Protected()
-                    .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
-                    .Returns<HttpRequestMessage, CancellationToken>(async (request, cancellationToken) =>
-                    {
-                        await Task.Yield();
-                        return request.Method == HttpMethod.Options
-                            ? ResponseUtils.CreateResponse(HttpStatusCode.OK, ResponseUtils.CreateNegotiationResponse())
-                            : ResponseUtils.CreateResponse(HttpStatusCode.OK);
-                    });
+            var mockHttpHandler = new Mock<HttpMessageHandler>();
+            mockHttpHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                .Returns<HttpRequestMessage, CancellationToken>(async (request, cancellationToken) =>
+                {
+                    await Task.Yield();
+                    return request.Method == HttpMethod.Options
+                        ? ResponseUtils.CreateResponse(HttpStatusCode.OK, ResponseUtils.CreateNegotiationResponse())
+                        : ResponseUtils.CreateResponse(HttpStatusCode.OK);
+                });
 
             var mockTransport = new Mock<ITransport>();
             Channel<byte[], SendMessage> channel = null;
@@ -601,7 +601,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
             try
             {
                 var receiveTcs = new TaskCompletionSource<string>();
-                connection.Received += (data) => 
+                connection.Received += data =>
                 {
                     receiveTcs.TrySetResult(Encoding.UTF8.GetString(data));
                     return Task.CompletedTask;

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/ConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/ConnectionTests.cs
@@ -19,12 +19,8 @@ using Xunit.Abstractions;
 
 namespace Microsoft.AspNetCore.Sockets.Client.Tests
 {
-    public class ConnectionTests : LoggedTest
+    public class ConnectionTests
     {
-        public ConnectionTests(ITestOutputHelper output) : base(output)
-        {
-        }
-
         [Fact]
         public void CannotCreateConnectionWithNullUrl()
         {
@@ -386,6 +382,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
             Channel<byte[], SendMessage> channel = null;
             mockTransport.Setup(t => t.StartAsync(It.IsAny<Uri>(), It.IsAny<Channel<byte[], SendMessage>>()))
                 .Returns<Uri, Channel<byte[], SendMessage>>((url, c) =>
+
                 {
                     channel = c;
                     return Task.CompletedTask;
@@ -394,6 +391,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
                 .Returns(() =>
                 {
                     channel.Out.TryComplete();
+
                     return Task.CompletedTask;
                 });
 
@@ -410,6 +408,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
                 };
 
             await connection.StartAsync();
+<<<<<<< HEAD
             channel.Out.TryWrite(Array.Empty<byte>());
 
             // Ensure that the Received callback has been called before attempting the second write
@@ -418,6 +417,16 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
 
             // Ensure that SignalR isn't blocked by the receive callback
             Assert.False(channel.In.TryRead(out var message));
+=======
+            channel.Output.TryWrite(Array.Empty<byte>());
+
+            // Ensure that the Received callback has been called before attempting the second write
+            await callbackInvokedTcs.Task.OrTimeout();
+            channel.Output.TryWrite(Array.Empty<byte>());
+
+            // Ensure that SignalR isn't blocked by the receive callback
+            Assert.False(channel.Input.TryRead(out var message));
+>>>>>>> Fix test
             closedTcs.SetResult(null);
 
             await connection.DisposeAsync();

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionExtensionsTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionExtensionsTests.cs
@@ -148,7 +148,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                 await connection.ReceiveJsonMessage(
                     new
                     {
-                    invocationId = "1",
+                        invocationId = "1",
                         type = 1,
                         target = "Foo",
                         arguments = new object[] { 42, "42" }

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/TestConnection.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/TestConnection.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
         private Task _receiveLoop;
 
         public event Action Connected;
-        public event Action<byte[]> Received;
+        public event Func<byte[], Task> Received;
         public event Action<Exception> Closed;
 
         public Task Started => _started.Task;
@@ -102,7 +102,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                     {
                         while (_receivedMessages.In.TryRead(out var message))
                         {
-                            Received?.Invoke(message);
+                            await Received?.Invoke(message);
                         }
                     }
                 }

--- a/test/Microsoft.AspNetCore.SignalR.Tests/EndToEndTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/EndToEndTests.cs
@@ -96,6 +96,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                     {
                         logger.LogInformation("Received {length} byte message", data.Length);
                         receiveTcs.TrySetResult(Encoding.UTF8.GetString(data));
+                        return Task.CompletedTask;
                     };
                     connection.Closed += e =>
                     {
@@ -163,6 +164,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                     {
                         logger.LogInformation("Received {length} byte message", data.Length);
                         receiveTcs.TrySetResult(data);
+                        return Task.CompletedTask;
                     };
 
                     logger.LogInformation("Starting connection to {url}", url);


### PR DESCRIPTION
Addresses issue: https://github.com/aspnet/SignalR/issues/546

Changed the receive event on IConnection to be a `Func<object[], Task>`. 
The overload of HubConnection's On method that takes an action is now available as an extension method on HubConnection now. 