### PR TITLE
Added a Uri,HttpMessageHandler ctor for HttpConnection

### DIFF
--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/HttpConnection.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/HttpConnection.cs
@@ -39,11 +39,11 @@ namespace Microsoft.AspNetCore.Sockets.Client
         public event Action<Exception> Closed;
 
         public HttpConnection(Uri url)
-            : this(url, TransportType.WebSockets)
+            : this(url, TransportType.All)
         { }
 
         public HttpConnection(Uri url, HttpMessageHandler httpMessageHandler)
-            : this(url, TransportType.WebSockets, loggerFactory: null, httpMessageHandler: httpMessageHandler)
+            : this(url, TransportType.All, loggerFactory: null, httpMessageHandler: httpMessageHandler)
         { }
 
         public HttpConnection(Uri url, TransportType transportType)
@@ -52,7 +52,7 @@ namespace Microsoft.AspNetCore.Sockets.Client
         }
 
         public HttpConnection(Uri url, ILoggerFactory loggerFactory)
-            : this(url, TransportType.WebSockets, loggerFactory, httpMessageHandler: null)
+            : this(url, TransportType.All, loggerFactory, httpMessageHandler: null)
         {
         }
 

--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/HttpConnection.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/HttpConnection.cs
@@ -42,6 +42,10 @@ namespace Microsoft.AspNetCore.Sockets.Client
             : this(url, TransportType.WebSockets)
         { }
 
+        public HttpConnection(Uri url, HttpMessageHandler httpMessageHandler)
+            : this(url, TransportType.WebSockets, loggerFactory: null, httpMessageHandler: httpMessageHandler)
+        { }
+
         public HttpConnection(Uri url, TransportType transportType)
                     : this(url, transportType, loggerFactory: null)
         {


### PR DESCRIPTION
Addresses: https://github.com/aspnet/SignalR/issues/588
The only bad thing is that the default transport is WebSockets instead of `TransportType.All`. 
PR https://github.com/aspnet/SignalR/pull/575 will have to be updated after its unblocked. 