### PR TITLE
Expose IGroupManager on IHubContext

### DIFF
--- a/samples/ChatSample/PresenceHubLifetimeManager.cs
+++ b/samples/ChatSample/PresenceHubLifetimeManager.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
-using Microsoft.AspNetCore.Sockets;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.AspNetCore.SignalR.Redis;
@@ -113,7 +112,7 @@ namespace ChatSample
 
                     hub.Clients = _hubContext.Clients;
                     hub.Context = new HubCallerContext(connection);
-                    hub.Groups = new GroupManager<THub>(this);
+                    hub.Groups = _hubContext.Groups;
 
                     try
                     {

--- a/src/Microsoft.AspNetCore.SignalR/HubContext.cs
+++ b/src/Microsoft.AspNetCore.SignalR/HubContext.cs
@@ -6,17 +6,19 @@ namespace Microsoft.AspNetCore.SignalR
     public class HubContext<THub> : IHubContext<THub>, IHubClients where THub : Hub
     {
         private readonly HubLifetimeManager<THub> _lifetimeManager;
-        private readonly AllClientProxy<THub> _all;
 
         public HubContext(HubLifetimeManager<THub> lifetimeManager)
         {
             _lifetimeManager = lifetimeManager;
-            _all = new AllClientProxy<THub>(_lifetimeManager);
+            All = new AllClientProxy<THub>(_lifetimeManager);
+            Groups = new GroupManager<THub>(lifetimeManager);
         }
 
         public IHubClients Clients => this;
 
-        public virtual IClientProxy All => _all;
+        public virtual IClientProxy All { get; }
+
+        public virtual IGroupManager Groups { get; }
 
         public virtual IClientProxy Client(string connectionId)
         {

--- a/src/Microsoft.AspNetCore.SignalR/HubEndPoint.cs
+++ b/src/Microsoft.AspNetCore.SignalR/HubEndPoint.cs
@@ -363,7 +363,7 @@ namespace Microsoft.AspNetCore.SignalR
         {
             hub.Clients = _hubContext.Clients;
             hub.Context = new HubCallerContext(connection);
-            hub.Groups = new GroupManager<THub>(_lifetimeManager);
+            hub.Groups = _hubContext.Groups;
         }
 
         private bool IsChannel(Type type, out Type payloadType)

--- a/src/Microsoft.AspNetCore.SignalR/IHubContext.cs
+++ b/src/Microsoft.AspNetCore.SignalR/IHubContext.cs
@@ -8,8 +8,10 @@ using System.Threading.Tasks;
 
 namespace Microsoft.AspNetCore.SignalR
 {
-    public interface IHubContext<THub> where THub: Hub
+    public interface IHubContext<THub> where THub : Hub
     {
         IHubClients Clients { get; }
+
+        IGroupManager Groups { get; }
     }
 }

--- a/src/Microsoft.AspNetCore.SignalR/Proxies.cs
+++ b/src/Microsoft.AspNetCore.SignalR/Proxies.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Sockets;
 
 namespace Microsoft.AspNetCore.SignalR
 {


### PR DESCRIPTION
- Adding groups is no longer coupled to the incoming connection
so we should expose it outside of the hub itself.