### PR TITLE
Pawelka/transfer mode

### DIFF
--- a/src/Microsoft.AspNetCore.SignalR.Client/HubConnection.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client/HubConnection.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using System.Threading.Tasks.Channels;
 using Microsoft.AspNetCore.SignalR.Internal;
 using Microsoft.AspNetCore.SignalR.Internal.Protocol;
+using Microsoft.AspNetCore.Sockets;
 using Microsoft.AspNetCore.Sockets.Client;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -77,6 +78,11 @@ namespace Microsoft.AspNetCore.SignalR.Client
 
         public async Task StartAsync()
         {
+            var transferMode = _protocol.Type == ProtocolType.Binary
+                ? TransferMode.Binary
+                : TransferMode.Text;
+
+            _connection.Features.Set<ITransferModeFeature>(new TransferModeFeature { TransferMode = transferMode });
             await _connection.StartAsync();
 
             using (var memoryStream = new MemoryStream())

--- a/src/Microsoft.AspNetCore.SignalR.Client/Microsoft.AspNetCore.SignalR.Client.csproj
+++ b/src/Microsoft.AspNetCore.SignalR.Client/Microsoft.AspNetCore.SignalR.Client.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.AspNetCore.SignalR.Common\Microsoft.AspNetCore.SignalR.Common.csproj" />
     <ProjectReference Include="..\Microsoft.AspNetCore.Sockets.Abstractions\Microsoft.AspNetCore.Sockets.Abstractions.csproj" />
+    <ProjectReference Include="..\Microsoft.AspNetCore.Sockets.Common.Http\Microsoft.AspNetCore.Sockets.Common.Http.csproj" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 

--- a/src/Microsoft.AspNetCore.SignalR.Common/Internal/Formatters/TextMessageFormatter.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Common/Internal/Formatters/TextMessageFormatter.cs
@@ -18,10 +18,7 @@ namespace Microsoft.AspNetCore.Sockets.Internal.Formatters
 
         public static void WriteMessage(ReadOnlySpan<byte> payload, Stream output)
         {
-            // Calculate the length, it's the number of characters for text messages, but number of base64 characters for binary
-
             // Write the length as a string
-
             // Super inefficient...
             var lengthString = payload.Length.ToString(CultureInfo.InvariantCulture);
             var buffer = ArrayPool<byte>.Shared.Rent(Int32OverflowLength);

--- a/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/IHubProtocol.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/IHubProtocol.cs
@@ -11,6 +11,8 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
     {
         string Name { get; }
 
+        ProtocolType Type { get; }
+
         bool TryParseMessages(ReadOnlyBuffer<byte> input, IInvocationBinder binder, out IList<HubMessage> messages);
 
         void WriteMessage(HubMessage message, Stream output);

--- a/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/JsonHubProtocol.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/JsonHubProtocol.cs
@@ -46,6 +46,8 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
 
         public string Name => "json";
 
+        public ProtocolType Type => ProtocolType.Text;
+
         public bool TryParseMessages(ReadOnlyBuffer<byte> input, IInvocationBinder binder, out IList<HubMessage> messages)
         {
             messages = new List<HubMessage>();

--- a/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/MessagePackHubProtocol.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/MessagePackHubProtocol.cs
@@ -18,6 +18,8 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
 
         public string Name => "messagepack";
 
+        public ProtocolType Type => ProtocolType.Binary;
+
         public bool TryParseMessages(ReadOnlyBuffer<byte> input, IInvocationBinder binder, out IList<HubMessage> messages)
         {
             messages = new List<HubMessage>();

--- a/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/ProtocolType.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/ProtocolType.cs
@@ -1,12 +1,11 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Threading.Tasks.Channels;
-
-namespace Microsoft.AspNetCore.Sockets.Features
+namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
 {
-    public interface IConnectionTransportFeature
+    public enum ProtocolType
     {
-        Channel<byte[]> Transport { get; set; }
+        Binary,
+        Text
     }
 }

--- a/src/Microsoft.AspNetCore.SignalR/DataEncoderFeature.cs
+++ b/src/Microsoft.AspNetCore.SignalR/DataEncoderFeature.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Text;
+
+namespace Microsoft.AspNetCore.SignalR
+{
+    public interface IDataEncoderFeature
+    {
+        IDataEncoder Encoder { get; set; }
+    }
+
+    public class DataEncoderFeature : IDataEncoderFeature
+    {
+        public IDataEncoder Encoder { get; set; }
+    }
+
+    public interface IDataEncoder
+    {
+        byte[] Encode(byte[] message);
+    }
+
+    public class PassThroughEncoder : IDataEncoder
+    {
+        public byte[] Encode(byte[] message)
+        {
+            return message;
+        }
+    }
+
+    public class Base64Encoder : IDataEncoder
+    {
+        public byte[] Encode(byte[] message)
+        {
+            return Encoding.UTF8.GetBytes(Convert.ToBase64String(message));
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.SignalR/DefaultHubLifetimeManager.cs
+++ b/src/Microsoft.AspNetCore.SignalR/DefaultHubLifetimeManager.cs
@@ -127,6 +127,9 @@ namespace Microsoft.AspNetCore.SignalR
         private async Task WriteAsync(HubConnectionContext connection, HubMessage hubMessage)
         {
             var payload = connection.Protocol.WriteToArray(hubMessage);
+            var encoder = connection.Features.Get<IDataEncoderFeature>()?.Encoder
+                ?? throw new InvalidOperationException("Encoder not set");
+            payload = encoder.Encode(payload);
 
             while (await connection.Output.WaitToWriteAsync())
             {

--- a/src/Microsoft.AspNetCore.SignalR/Features/IHubFeature.cs
+++ b/src/Microsoft.AspNetCore.SignalR/Features/IHubFeature.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
 using Microsoft.AspNetCore.SignalR.Internal.Protocol;
 
 namespace Microsoft.AspNetCore.SignalR.Features

--- a/src/Microsoft.AspNetCore.SignalR/HubEndPoint.cs
+++ b/src/Microsoft.AspNetCore.SignalR/HubEndPoint.cs
@@ -112,7 +112,7 @@ namespace Microsoft.AspNetCore.SignalR
                             ? TransferMode.Binary
                             : TransferMode.Text;
 
-                        connection.Features.Set(new TransferModeFeature { });
+                        connection.Features.Set<ITransferModeFeature>(new TransferModeFeature { TransferMode = transferMode });
                         return;
                     }
                 }

--- a/src/Microsoft.AspNetCore.SignalR/HubEndPoint.cs
+++ b/src/Microsoft.AspNetCore.SignalR/HubEndPoint.cs
@@ -91,7 +91,7 @@ namespace Microsoft.AspNetCore.SignalR
                 // Nothing should be writing to the HubConnectionContext
                 output.Out.TryComplete();
 
-                // This should unwind once we complete the output 
+                // This should unwind once we complete the output
                 await writingOutputTask;
             }
         }
@@ -108,7 +108,11 @@ namespace Microsoft.AspNetCore.SignalR
                         // Other components, outside the Hub, may need to know what protocol is in use
                         // for a particular connection, so we store it here.
                         connection.Protocol = _protocolResolver.GetProtocol(negotiationMessage.Protocol, connection);
+                        var transferMode = connection.Protocol.Type == ProtocolType.Binary
+                            ? TransferMode.Binary
+                            : TransferMode.Text;
 
+                        connection.Features.Set(new TransferModeFeature { });
                         return;
                     }
                 }

--- a/src/Microsoft.AspNetCore.SignalR/Microsoft.AspNetCore.SignalR.csproj
+++ b/src/Microsoft.AspNetCore.SignalR/Microsoft.AspNetCore.SignalR.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.AspNetCore.Sockets.Abstractions\Microsoft.AspNetCore.Sockets.Abstractions.csproj" />
     <ProjectReference Include="..\Microsoft.AspNetCore.SignalR.Common\Microsoft.AspNetCore.SignalR.Common.csproj" />
+    <ProjectReference Include="..\Microsoft.AspNetCore.Sockets.Common.Http\Microsoft.AspNetCore.Sockets.Common.Http.csproj" />
     <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(AspNetCoreVersion)" />

--- a/src/Microsoft.AspNetCore.Sockets.Abstractions/IConnection.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Abstractions/IConnection.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http.Features;
 
 namespace Microsoft.AspNetCore.Sockets.Client
 {
@@ -16,5 +17,7 @@ namespace Microsoft.AspNetCore.Sockets.Client
         event Func<Task> Connected;
         event Func<byte[], Task> Received;
         event Func<Exception, Task> Closed;
+
+        IFeatureCollection Features { get; }
     }
 }

--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/ITransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/ITransport.cs
@@ -9,7 +9,8 @@ namespace Microsoft.AspNetCore.Sockets.Client
 {
     public interface ITransport
     {
-        Task StartAsync(Uri url, Channel<byte[], SendMessage> application);
+        Task StartAsync(Uri url, Channel<byte[], SendMessage> application, TransferMode requestedTransferMode);
         Task StopAsync();
+        TransferMode? Mode { get; }
     }
 }

--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/LongPollingTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/LongPollingTransport.cs
@@ -24,6 +24,8 @@ namespace Microsoft.AspNetCore.Sockets.Client
 
         public Task Running { get; private set; } = Task.CompletedTask;
 
+        public TransferMode? Mode { get; private set; }
+
         public LongPollingTransport(HttpClient httpClient)
             : this(httpClient, null)
         { }
@@ -34,11 +36,12 @@ namespace Microsoft.AspNetCore.Sockets.Client
             _logger = (loggerFactory ?? NullLoggerFactory.Instance).CreateLogger<LongPollingTransport>();
         }
 
-        public Task StartAsync(Uri url, Channel<byte[], SendMessage> application)
+        public Task StartAsync(Uri url, Channel<byte[], SendMessage> application, TransferMode requestedTransferMode)
         {
             _logger.LogInformation("Starting {0}", nameof(LongPollingTransport));
 
             _application = application;
+            Mode = requestedTransferMode;
 
             // Start sending and polling (ask for binary if the server supports it)
             _poller = Poll(url, _transportCts.Token);

--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/ServerSentEventsTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/ServerSentEventsTransport.cs
@@ -40,11 +40,13 @@ namespace Microsoft.AspNetCore.Sockets.Client
             _logger = (loggerFactory ?? NullLoggerFactory.Instance).CreateLogger<ServerSentEventsTransport>();
         }
 
-        public Task StartAsync(Uri url, Channel<byte[], SendMessage> application)
+        public Task StartAsync(Uri url, Channel<byte[], SendMessage> application, TransferMode requestedTransferMode)
         {
             _logger.LogInformation("Starting {transportName}", nameof(ServerSentEventsTransport));
 
             _application = application;
+            Mode = TransferMode.Text; // SSE transport supports only text mode
+
             var sendTask = SendUtils.SendMessages(url, _application, _httpClient, _transportCts, _logger);
             var receiveTask = OpenConnection(_application, url, _transportCts.Token);
 
@@ -61,6 +63,8 @@ namespace Microsoft.AspNetCore.Sockets.Client
 
             return Task.CompletedTask;
         }
+
+        public TransferMode? Mode { get; private set; }
 
         private async Task OpenConnection(Channel<byte[], SendMessage> application, Uri url, CancellationToken cancellationToken)
         {

--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/ServerSentEventsTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/ServerSentEventsTransport.cs
@@ -22,7 +22,6 @@ namespace Microsoft.AspNetCore.Sockets.Client
         private readonly ServerSentEventsMessageParser _parser = new ServerSentEventsMessageParser();
 
         private Channel<byte[], SendMessage> _application;
-        private IPipeReader _pipeReader;
 
         public Task Running { get; private set; } = Task.CompletedTask;
 
@@ -137,7 +136,6 @@ namespace Microsoft.AspNetCore.Sockets.Client
             _logger.LogInformation("Transport {transportName} is stopping", nameof(ServerSentEventsTransport));
             _transportCts.Cancel();
             _application.Out.TryComplete();
-            _pipeReader.CancelPendingRead();
             await Running;
         }
     }

--- a/src/Microsoft.AspNetCore.Sockets.Common.Http/ITransferModeFeature.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Common.Http/ITransferModeFeature.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+// TODO: Where shouold this live?
+
+namespace Microsoft.AspNetCore.Sockets
+{
+    public interface ITransferModeFeature
+    {
+        TransferMode TransferMode { get; set; }
+    }
+
+    public class TransferModeFeature : ITransferModeFeature
+    {
+        public TransferMode TransferMode { get; set; }
+    }
+}

--- a/src/Microsoft.AspNetCore.Sockets.Common.Http/TransferMode.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Common.Http/TransferMode.cs
@@ -1,12 +1,11 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Threading.Tasks.Channels;
-
-namespace Microsoft.AspNetCore.Sockets.Features
+namespace Microsoft.AspNetCore.Sockets
 {
-    public interface IConnectionTransportFeature
+    public enum TransferMode
     {
-        Channel<byte[]> Transport { get; set; }
+        Binary = 0x01,
+        Text   = 0x02
     }
 }

--- a/src/Microsoft.AspNetCore.Sockets.Http/HttpConnectionDispatcher.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Http/HttpConnectionDispatcher.cs
@@ -85,6 +85,7 @@ namespace Microsoft.AspNetCore.Sockets
                 // TODO: We need to handle conversion for binary protocols. We may need to give the transport a different
                 // channel/adapter to be able to do Binary <--> Text conversion
 
+                connection.Metadata["TransportCapabilities"] = TransferMode.Text;
                 // We only need to provide the Input channel since writing to the application is handled through /send.
                 var sse = new ServerSentEventsTransport(connection.Application.In, connection, _loggerFactory);
 
@@ -108,6 +109,7 @@ namespace Microsoft.AspNetCore.Sockets
                     return;
                 }
 
+                connection.Metadata["TransportCapabilities"] = TransferMode.Text | TransferMode.Binary;
                 var ws = new WebSocketsTransport(options.WebSockets, connection.Application, connection, _loggerFactory);
 
                 await DoPersistentConnection(socketDelegate, ws, context, connection);
@@ -426,6 +428,7 @@ namespace Microsoft.AspNetCore.Sockets
             if (transport == null)
             {
                 connection.Metadata[ConnectionMetadataNames.Transport] = transportType;
+                connection.Metadata["TransportCapabilities"] = TransferMode.Text | TransferMode.Binary;
             }
             else if (transport != transportType)
             {

--- a/src/Microsoft.AspNetCore.Sockets.Http/Internal/Transports/ServerSentEventsTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Http/Internal/Transports/ServerSentEventsTransport.cs
@@ -51,14 +51,6 @@ namespace Microsoft.AspNetCore.Sockets.Internal.Transports
                     while (_application.TryRead(out var buffer))
                     {
                         _logger.SSEWritingMessage(_connection.ConnectionId, buffer.Length);
-
-                        var transferModeFeature = _connection.Features.Get<ITransferModeFeature>();
-                        if (transferModeFeature != null && transferModeFeature.TransferMode == TransferMode.Binary)
-                        {
-                            var base64String = Convert.ToBase64String(buffer);
-                            buffer = Encoding.UTF8.GetBytes(base64String);
-                        }
-
                         ServerSentEventsMessageFormatter.WriteMessage(buffer, ms);
                     }
 

--- a/src/Microsoft.AspNetCore.Sockets.Http/Internal/Transports/WebSocketsTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Http/Internal/Transports/WebSocketsTransport.cs
@@ -18,9 +18,9 @@ namespace Microsoft.AspNetCore.Sockets.Internal.Transports
         private readonly WebSocketOptions _options;
         private readonly ILogger _logger;
         private readonly Channel<byte[]> _application;
-        private readonly string _connectionId;
+        private readonly ConnectionContext _connection;
 
-        public WebSocketsTransport(WebSocketOptions options, Channel<byte[]> application, string connectionId, ILoggerFactory loggerFactory)
+        public WebSocketsTransport(WebSocketOptions options, Channel<byte[]> application, ConnectionContext connection, ILoggerFactory loggerFactory)
         {
             if (options == null)
             {
@@ -39,7 +39,7 @@ namespace Microsoft.AspNetCore.Sockets.Internal.Transports
 
             _options = options;
             _application = application;
-            _connectionId = connectionId;
+            _connection = connection;
             _logger = loggerFactory.CreateLogger<WebSocketsTransport>();
         }
 
@@ -49,11 +49,11 @@ namespace Microsoft.AspNetCore.Sockets.Internal.Transports
 
             using (var ws = await context.WebSockets.AcceptWebSocketAsync())
             {
-                _logger.SocketOpened(_connectionId);
+                _logger.SocketOpened(_connection.ConnectionId);
 
                 await ProcessSocketAsync(ws);
             }
-            _logger.SocketClosed(_connectionId);
+            _logger.SocketClosed(_connection.ConnectionId);
         }
 
         public async Task ProcessSocketAsync(WebSocket socket)
@@ -72,12 +72,12 @@ namespace Microsoft.AspNetCore.Sockets.Internal.Transports
             if (trigger == receiving)
             {
                 task = sending;
-                _logger.WaitingForSend(_connectionId);
+                _logger.WaitingForSend(_connection.ConnectionId);
             }
             else
             {
                 task = receiving;
-                _logger.WaitingForClose(_connectionId);
+                _logger.WaitingForClose(_connection.ConnectionId);
             }
 
             // We're done writing
@@ -89,7 +89,7 @@ namespace Microsoft.AspNetCore.Sockets.Internal.Transports
 
             if (resultTask != task)
             {
-                _logger.CloseTimedOut(_connectionId);
+                _logger.CloseTimedOut(_connection.ConnectionId);
                 socket.Abort();
             }
             else
@@ -123,7 +123,7 @@ namespace Microsoft.AspNetCore.Sockets.Internal.Transports
                         return receiveResult;
                     }
 
-                    _logger.MessageReceived(_connectionId, receiveResult.MessageType, receiveResult.Count, receiveResult.EndOfMessage);
+                    _logger.MessageReceived(_connection.ConnectionId, receiveResult.MessageType, receiveResult.Count, receiveResult.EndOfMessage);
 
                     var truncBuffer = new ArraySegment<byte>(buffer.Array, 0, receiveResult.Count);
                     incomingMessage.Add(truncBuffer);
@@ -153,7 +153,7 @@ namespace Microsoft.AspNetCore.Sockets.Internal.Transports
                     Buffer.BlockCopy(incomingMessage[0].Array, incomingMessage[0].Offset, messageBuffer, 0, incomingMessage[0].Count);
                 }
 
-                _logger.MessageToApplication(_connectionId, messageBuffer.Length);
+                _logger.MessageToApplication(_connection.ConnectionId, messageBuffer.Length);
                 while (await _application.Out.WaitToWriteAsync())
                 {
                     if (_application.Out.TryWrite(messageBuffer))
@@ -176,22 +176,31 @@ namespace Microsoft.AspNetCore.Sockets.Internal.Transports
                     {
                         try
                         {
-                            _logger.SendPayload(_connectionId, buffer.Length);
+                            _logger.SendPayload(_connection.ConnectionId, buffer.Length);
 
                             if (WebSocketCanSend(ws))
                             {
-                                await ws.SendAsync(new ArraySegment<byte>(buffer), _options.WebSocketMessageType, endOfMessage: true, cancellationToken: CancellationToken.None);
+                                var messageType = _options.WebSocketMessageType;
+                                var transferModeFeature = _connection.Features.Get<ITransferModeFeature>();
+                                if (transferModeFeature != null)
+                                {
+                                    messageType = transferModeFeature.TransferMode == TransferMode.Binary
+                                        ? WebSocketMessageType.Binary
+                                        : WebSocketMessageType.Text;
+                                }
+
+                                await ws.SendAsync(new ArraySegment<byte>(buffer), messageType, endOfMessage: true, cancellationToken: CancellationToken.None);
                             }
                         }
                         catch (WebSocketException socketException) when (!WebSocketCanSend(ws))
                         {
                             // this can happen when we send the CloseFrame to the client and try to write afterwards
-                            _logger.SendFailed(_connectionId, socketException);
+                            _logger.SendFailed(_connection.ConnectionId, socketException);
                             break;
                         }
                         catch (Exception ex)
                         {
-                            _logger.ErrorWritingFrame(_connectionId, ex);
+                            _logger.ErrorWritingFrame(_connection.ConnectionId, ex);
                             break;
                         }
                     }

--- a/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/HubConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/HubConnectionTests.cs
@@ -120,12 +120,13 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
 
         [Theory]
         [MemberData(nameof(HubProtocols))]
+        //TODO: should be across transports
         public async Task CanInvokeClientMethodFromServer(IHubProtocol protocol)
         {
             var loggerFactory = CreateLogger();
             const string originalMessage = "SignalR";
 
-            var httpConnection = new HttpConnection(new Uri("http://test/hubs"), TransportType.LongPolling, loggerFactory, _testServer.CreateHandler());
+            var httpConnection = new HttpConnection(new Uri("http://test/hubs"), TransportType.ServerSentEvents, loggerFactory, _testServer.CreateHandler());
             var connection = new HubConnection(httpConnection, protocol, loggerFactory);
             try
             {
@@ -194,7 +195,8 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
         public static IEnumerable<object[]> HubProtocols() =>
             new[]
             {
-                new object[] { new JsonHubProtocol(new JsonSerializer()) },
+                // TODO: Revert
+                // new object[] { new JsonHubProtocol(new JsonSerializer()) },
                 new object[] { new MessagePackHubProtocol() },
             };
 

--- a/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/HubConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/HubConnectionTests.cs
@@ -213,7 +213,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
             {
                 builder.AddConsole();
                 builder.AddFilter<ConsoleLoggerProvider>(level => level >= (_verbose ? LogLevel.Trace : LogLevel.Error));
-                builder.AddDebug();
+                // builder.AddDebug();
             });
 
             return serviceCollection.BuildServiceProvider().GetRequiredService<ILoggerFactory>();

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/ConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/ConnectionTests.cs
@@ -154,7 +154,8 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
             releaseDisposeTcs.SetResult(null);
             await disposeTask.OrTimeout();
 
-            transport.Verify(t => t.StartAsync(It.IsAny<Uri>(), It.IsAny<Channel<byte[], SendMessage>>()), Times.Never);
+            transport.Verify(t => t.StartAsync(
+                It.IsAny<Uri>(), It.IsAny<Channel<byte[], SendMessage>>(), It.IsAny<TransferMode>()), Times.Never);
         }
 
         [Fact]
@@ -241,7 +242,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
                 });
 
             var mockTransport = new Mock<ITransport>();
-            mockTransport.Setup(t => t.StartAsync(It.IsAny<Uri>(), It.IsAny<Channel<byte[], SendMessage>>()))
+            mockTransport.Setup(t => t.StartAsync(It.IsAny<Uri>(), It.IsAny<Channel<byte[], SendMessage>>(), It.IsAny<TransferMode>()))
                 .Returns(Task.FromException(new InvalidOperationException("Transport failed to start")));
 
 
@@ -350,7 +351,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
 
             var mockTransport = new Mock<ITransport>();
             Channel<byte[], SendMessage> channel = null;
-            mockTransport.Setup(t => t.StartAsync(It.IsAny<Uri>(), It.IsAny<Channel<byte[], SendMessage>>()))
+            mockTransport.Setup(t => t.StartAsync(It.IsAny<Uri>(), It.IsAny<Channel<byte[], SendMessage>>(), It.IsAny<TransferMode>()))
                 .Returns<Uri, Channel<byte[], SendMessage>>((url, c) =>
                 {
                     channel = c;
@@ -396,7 +397,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
 
             var mockTransport = new Mock<ITransport>();
             Channel<byte[], SendMessage> channel = null;
-            mockTransport.Setup(t => t.StartAsync(It.IsAny<Uri>(), It.IsAny<Channel<byte[], SendMessage>>()))
+            mockTransport.Setup(t => t.StartAsync(It.IsAny<Uri>(), It.IsAny<Channel<byte[], SendMessage>>(), It.IsAny<TransferMode>()))
                 .Returns<Uri, Channel<byte[], SendMessage>>((url, c) =>
                 {
                     channel = c;

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.cs
@@ -183,6 +183,8 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
 
             public string Name { get => "MockHubProtocol"; }
 
+            public ProtocolType Type => throw new NotImplementedException();
+
             public bool TryParseMessages(ReadOnlyBuffer<byte> input, IInvocationBinder binder, out IList<HubMessage> messages)
             {
                 messages = new List<HubMessage>();

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/LongPollingTransportTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/LongPollingTransportTests.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Threading.Tasks.Channels;
 using Microsoft.AspNetCore.SignalR.Tests.Common;
+using Microsoft.AspNetCore.Sockets;
 using Microsoft.AspNetCore.Sockets.Client;
 using Microsoft.AspNetCore.Sockets.Internal;
 using Microsoft.Extensions.Logging;
@@ -44,7 +45,7 @@ namespace Microsoft.AspNetCore.Client.Tests
                     var connectionToTransport = Channel.CreateUnbounded<SendMessage>();
                     var transportToConnection = Channel.CreateUnbounded<byte[]>();
                     var channelConnection = new ChannelConnection<SendMessage, byte[]>(connectionToTransport, transportToConnection);
-                    await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection);
+                    await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection, TransferMode.Text);
 
                     transportActiveTask = longPollingTransport.Running;
 
@@ -80,7 +81,7 @@ namespace Microsoft.AspNetCore.Client.Tests
                     var connectionToTransport = Channel.CreateUnbounded<SendMessage>();
                     var transportToConnection = Channel.CreateUnbounded<byte[]>();
                     var channelConnection = ChannelConnection.Create(connectionToTransport, transportToConnection);
-                    await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection);
+                    await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection, TransferMode.Text);
 
                     await longPollingTransport.Running.OrTimeout();
                     Assert.True(transportToConnection.In.Completion.IsCompleted);
@@ -133,7 +134,7 @@ namespace Microsoft.AspNetCore.Client.Tests
                     var connectionToTransport = Channel.CreateUnbounded<SendMessage>();
                     var transportToConnection = Channel.CreateUnbounded<byte[]>();
                     var channelConnection = new ChannelConnection<SendMessage, byte[]>(connectionToTransport, transportToConnection);
-                    await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection);
+                    await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection, TransferMode.Text);
 
                     var data = await transportToConnection.In.ReadAllAsync().OrTimeout();
                     await longPollingTransport.Running.OrTimeout();
@@ -169,7 +170,7 @@ namespace Microsoft.AspNetCore.Client.Tests
                     var connectionToTransport = Channel.CreateUnbounded<SendMessage>();
                     var transportToConnection = Channel.CreateUnbounded<byte[]>();
                     var channelConnection = new ChannelConnection<SendMessage, byte[]>(connectionToTransport, transportToConnection);
-                    await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection);
+                    await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection, TransferMode.Text);
 
                     var exception =
                         await Assert.ThrowsAsync<HttpRequestException>(async () => await transportToConnection.In.Completion.OrTimeout());
@@ -205,7 +206,7 @@ namespace Microsoft.AspNetCore.Client.Tests
                     var connectionToTransport = Channel.CreateUnbounded<SendMessage>();
                     var transportToConnection = Channel.CreateUnbounded<byte[]>();
                     var channelConnection = new ChannelConnection<SendMessage, byte[]>(connectionToTransport, transportToConnection);
-                    await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection);
+                    await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection, TransferMode.Text);
 
                     await connectionToTransport.Out.WriteAsync(new SendMessage());
 
@@ -246,7 +247,7 @@ namespace Microsoft.AspNetCore.Client.Tests
                     var connectionToTransport = Channel.CreateUnbounded<SendMessage>();
                     var transportToConnection = Channel.CreateUnbounded<byte[]>();
                     var channelConnection = new ChannelConnection<SendMessage, byte[]>(connectionToTransport, transportToConnection);
-                    await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection);
+                    await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection, TransferMode.Text);
 
                     connectionToTransport.Out.Complete();
 
@@ -297,7 +298,7 @@ namespace Microsoft.AspNetCore.Client.Tests
                     var channelConnection = new ChannelConnection<SendMessage, byte[]>(connectionToTransport, transportToConnection);
 
                     // Start the transport
-                    await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection);
+                    await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection, TransferMode.Text);
 
                     // Wait for the transport to finish
                     await longPollingTransport.Running.OrTimeout();
@@ -362,7 +363,7 @@ namespace Microsoft.AspNetCore.Client.Tests
                     await connectionToTransport.Out.WriteAsync(new SendMessage(Encoding.UTF8.GetBytes("World"), tcs2)).OrTimeout();
 
                     // Start the transport
-                    await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection);
+                    await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection, TransferMode.Text);
 
                     connectionToTransport.Out.Complete();
 

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/ServerSentEventsTransportTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/ServerSentEventsTransportTests.cs
@@ -49,7 +49,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                     var connectionToTransport = Channel.CreateUnbounded<SendMessage>();
                     var transportToConnection = Channel.CreateUnbounded<byte[]>();
                     var channelConnection = new ChannelConnection<SendMessage, byte[]>(connectionToTransport, transportToConnection);
-                    await sseTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection).OrTimeout();
+                    await sseTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection, Sockets.TransferMode.Binary).OrTimeout();
 
                     await eventStreamTcs.Task.OrTimeout();
                     await sseTransport.StopAsync().OrTimeout();

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/TestConnection.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/TestConnection.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Threading.Tasks.Channels;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Sockets.Client;
 using Microsoft.AspNetCore.Sockets.Internal.Formatters;
 using Newtonsoft.Json;
@@ -33,6 +34,8 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
         public Task Disposed => _disposed.Task;
         public ReadableChannel<byte[]> SentMessages => _sentMessages.In;
         public WritableChannel<byte[]> ReceivedMessages => _receivedMessages.Out;
+
+        public IFeatureCollection Features => throw new NotImplementedException();
 
         public TestConnection()
         {

--- a/test/Microsoft.AspNetCore.SignalR.Tests/WebSocketsTransportTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/WebSocketsTransportTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading.Tasks;
 using System.Threading.Tasks.Channels;
 using Microsoft.AspNetCore.SignalR.Tests.Common;
+using Microsoft.AspNetCore.Sockets;
 using Microsoft.AspNetCore.Sockets.Client;
 using Microsoft.AspNetCore.Sockets.Internal;
 using Microsoft.AspNetCore.Testing.xunit;
@@ -40,7 +41,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                 var channelConnection = new ChannelConnection<SendMessage, byte[]>(connectionToTransport, transportToConnection);
 
                 var webSocketsTransport = new WebSocketsTransport(loggerFactory);
-                await webSocketsTransport.StartAsync(new Uri(_serverFixture.WebSocketsUrl + "/echo"), channelConnection).OrTimeout();
+                await webSocketsTransport.StartAsync(new Uri(_serverFixture.WebSocketsUrl + "/echo"), channelConnection, TransferMode.Text).OrTimeout();
                 await webSocketsTransport.StopAsync().OrTimeout();
                 await webSocketsTransport.Running.OrTimeout();
             }
@@ -57,7 +58,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                 var channelConnection = new ChannelConnection<SendMessage, byte[]>(connectionToTransport, transportToConnection);
 
                 var webSocketsTransport = new WebSocketsTransport(loggerFactory);
-                await webSocketsTransport.StartAsync(new Uri(_serverFixture.WebSocketsUrl + "/echo"), channelConnection);
+                await webSocketsTransport.StartAsync(new Uri(_serverFixture.WebSocketsUrl + "/echo"), channelConnection, TransferMode.Text);
                 connectionToTransport.Out.TryComplete();
                 await webSocketsTransport.Running.OrTimeout();
             }
@@ -74,7 +75,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                 var channelConnection = new ChannelConnection<SendMessage, byte[]>(connectionToTransport, transportToConnection);
 
                 var webSocketsTransport = new WebSocketsTransport(loggerFactory);
-                await webSocketsTransport.StartAsync(new Uri(_serverFixture.WebSocketsUrl + "/echo"), channelConnection);
+                await webSocketsTransport.StartAsync(new Uri(_serverFixture.WebSocketsUrl + "/echo"), channelConnection, TransferMode.Text);
 
                 var sendTcs = new TaskCompletionSource<object>();
                 connectionToTransport.Out.TryWrite(new SendMessage(new byte[] { 0x42 }, sendTcs));

--- a/test/Microsoft.AspNetCore.Sockets.Tests/ServerSentEventsTests.cs
+++ b/test/Microsoft.AspNetCore.Sockets.Tests/ServerSentEventsTests.cs
@@ -16,12 +16,15 @@ namespace Microsoft.AspNetCore.Sockets.Tests
 {
     public class ServerSentEventsTests
     {
+        private static readonly ConnectionContext _fakeConnectionContext
+            = new DefaultConnectionContext(string.Empty, null, null);
+
         [Fact]
         public async Task SSESetsContentType()
         {
             var channel = Channel.CreateUnbounded<byte[]>();
             var context = new DefaultHttpContext();
-            var sse = new ServerSentEventsTransport(channel, connectionId: string.Empty, loggerFactory: new LoggerFactory());
+            var sse = new ServerSentEventsTransport(channel, _fakeConnectionContext, loggerFactory: new LoggerFactory());
 
             Assert.True(channel.Out.TryComplete());
 
@@ -38,7 +41,7 @@ namespace Microsoft.AspNetCore.Sockets.Tests
             var context = new DefaultHttpContext();
             var feature = new HttpBufferingFeature();
             context.Features.Set<IHttpBufferingFeature>(feature);
-            var sse = new ServerSentEventsTransport(channel, connectionId: string.Empty, loggerFactory: new LoggerFactory());
+            var sse = new ServerSentEventsTransport(channel, _fakeConnectionContext, loggerFactory: new LoggerFactory());
 
             Assert.True(channel.Out.TryComplete());
 
@@ -58,7 +61,7 @@ namespace Microsoft.AspNetCore.Sockets.Tests
             var context = new DefaultHttpContext();
             var ms = new MemoryStream();
             context.Response.Body = ms;
-            var sse = new ServerSentEventsTransport(channel, connectionId: string.Empty, loggerFactory: new LoggerFactory());
+            var sse = new ServerSentEventsTransport(channel, _fakeConnectionContext, loggerFactory: new LoggerFactory());
 
             var task = sse.ProcessRequestAsync(context, context.RequestAborted);
 
@@ -79,7 +82,7 @@ namespace Microsoft.AspNetCore.Sockets.Tests
         {
             var channel = Channel.CreateUnbounded<byte[]>();
             var context = new DefaultHttpContext();
-            var sse = new ServerSentEventsTransport(channel, connectionId: string.Empty, loggerFactory: new LoggerFactory());
+            var sse = new ServerSentEventsTransport(channel, _fakeConnectionContext, loggerFactory: new LoggerFactory());
             var ms = new MemoryStream();
             context.Response.Body = ms;
 

--- a/test/Microsoft.AspNetCore.Sockets.Tests/WebSocketsTests.cs
+++ b/test/Microsoft.AspNetCore.Sockets.Tests/WebSocketsTests.cs
@@ -17,6 +17,9 @@ namespace Microsoft.AspNetCore.Sockets.Tests
 {
     public class WebSocketsTests
     {
+        private static readonly ConnectionContext _fakeConnectionContext
+            = new DefaultConnectionContext(string.Empty, null, null);
+
         [Theory]
         [InlineData(WebSocketMessageType.Text)]
         [InlineData(WebSocketMessageType.Binary)]
@@ -29,7 +32,7 @@ namespace Microsoft.AspNetCore.Sockets.Tests
             using (var applicationSide = ChannelConnection.Create<byte[]>(transportToApplication, applicationToTransport))
             using (var feature = new TestWebSocketConnectionFeature())
             {
-                var ws = new WebSocketsTransport(new WebSocketOptions(), transportSide, connectionId: string.Empty, loggerFactory: new LoggerFactory());
+                var ws = new WebSocketsTransport(new WebSocketOptions(), transportSide, _fakeConnectionContext, loggerFactory: new LoggerFactory());
 
                 // Give the server socket to the transport and run it
                 var transport = ws.ProcessSocketAsync(await feature.AcceptAsync());
@@ -72,7 +75,8 @@ namespace Microsoft.AspNetCore.Sockets.Tests
             using (var applicationSide = ChannelConnection.Create<byte[]>(transportToApplication, applicationToTransport))
             using (var feature = new TestWebSocketConnectionFeature())
             {
-                var ws = new WebSocketsTransport(new WebSocketOptions() { WebSocketMessageType = webSocketMessageType }, transportSide, connectionId: string.Empty, loggerFactory: new LoggerFactory());
+                var ws = new WebSocketsTransport(
+                    new WebSocketOptions() { WebSocketMessageType = webSocketMessageType }, transportSide, _fakeConnectionContext, loggerFactory: new LoggerFactory());
 
                 // Give the server socket to the transport and run it
                 var transport = ws.ProcessSocketAsync(await feature.AcceptAsync());
@@ -115,7 +119,7 @@ namespace Microsoft.AspNetCore.Sockets.Tests
                     applicationSide.Out.TryComplete();
                 }
 
-                var ws = new WebSocketsTransport(new WebSocketOptions(), transportSide, connectionId: string.Empty, loggerFactory: new LoggerFactory());
+                var ws = new WebSocketsTransport(new WebSocketOptions(), transportSide, _fakeConnectionContext, loggerFactory: new LoggerFactory());
 
                 // Give the server socket to the transport and run it
                 var transport = ws.ProcessSocketAsync(await feature.AcceptAsync());
@@ -148,7 +152,7 @@ namespace Microsoft.AspNetCore.Sockets.Tests
             using (var applicationSide = ChannelConnection.Create<byte[]>(transportToApplication, applicationToTransport))
             using (var feature = new TestWebSocketConnectionFeature())
             {
-                var ws = new WebSocketsTransport(new WebSocketOptions(), transportSide, connectionId: string.Empty, loggerFactory: new LoggerFactory());
+                var ws = new WebSocketsTransport(new WebSocketOptions(), transportSide, _fakeConnectionContext, loggerFactory: new LoggerFactory());
 
                 // Give the server socket to the transport and run it
                 var transport = ws.ProcessSocketAsync(await feature.AcceptAsync());
@@ -184,7 +188,7 @@ namespace Microsoft.AspNetCore.Sockets.Tests
                     CloseTimeout = TimeSpan.FromSeconds(1)
                 };
 
-                var ws = new WebSocketsTransport(options, transportSide, connectionId: string.Empty, loggerFactory: new LoggerFactory());
+                var ws = new WebSocketsTransport(options, transportSide, _fakeConnectionContext, loggerFactory: new LoggerFactory());
 
                 var serverSocket = await feature.AcceptAsync();
                 // Give the server socket to the transport and run it
@@ -217,7 +221,7 @@ namespace Microsoft.AspNetCore.Sockets.Tests
                     CloseTimeout = TimeSpan.FromSeconds(1)
                 };
 
-                var ws = new WebSocketsTransport(options, transportSide, connectionId: string.Empty, loggerFactory: new LoggerFactory());
+                var ws = new WebSocketsTransport(options, transportSide, _fakeConnectionContext, loggerFactory: new LoggerFactory());
 
                 var serverSocket = await feature.AcceptAsync();
                 // Give the server socket to the transport and run it
@@ -250,7 +254,7 @@ namespace Microsoft.AspNetCore.Sockets.Tests
                     // We want to verify behavior without timeout affecting it
                     CloseTimeout = TimeSpan.FromSeconds(20)
                 };
-                var ws = new WebSocketsTransport(options, transportSide, connectionId: string.Empty, loggerFactory: new LoggerFactory());
+                var ws = new WebSocketsTransport(options, transportSide, _fakeConnectionContext, loggerFactory: new LoggerFactory());
 
                 var serverSocket = await feature.AcceptAsync();
                 // Give the server socket to the transport and run it
@@ -287,7 +291,7 @@ namespace Microsoft.AspNetCore.Sockets.Tests
                     // We want to verify behavior without timeout affecting it
                     CloseTimeout = TimeSpan.FromSeconds(20)
                 };
-                var ws = new WebSocketsTransport(options, transportSide, connectionId: string.Empty, loggerFactory: new LoggerFactory());
+                var ws = new WebSocketsTransport(options, transportSide, _fakeConnectionContext, loggerFactory: new LoggerFactory());
 
                 var serverSocket = await feature.AcceptAsync();
                 // Give the server socket to the transport and run it


### PR DESCRIPTION
Yet another prototype for binary protocol support. Works end-to-end - possible to send  base64 encoded MessagePack messages over SSE. 

Issues:
- cheating - messages sent from the client are just binary because post can handle that - only messages from the server over event-stream are base64 encoded. Hard to make it symmetric because of the first message the client sends to the server. This message contains the protocol to be used and is supposed to be text only. This protocol is on Hub level and encoding happens in the HttpConnection.
- ~The SSE transport could not be stopped from the client (not sure if any of the end-to-end tests run against SSE - the one I tried always hanged/timed out)~ fixed in a41ef82f19e76ed13fb8d276fa3d1ec3803179ff
- Need to pass ConnectionContext to transports to be able to get the ITransferModeFeature
- ~On the server side need to base64 encode in the SSE transport because we give the channel to the user~
- half of the tests fail due to NotImplementedException, the other half was blindly updated to compile - they need to be reviewed whether slapping TransferMode.Text is OK and whether we need to test the other mode. 
- need to find the right place for TransferMode et al.