### PR TITLE
Fix potential null ref in RedisHublifetimeManager RemoveGroup

### DIFF
--- a/src/Microsoft.AspNetCore.SignalR.Redis/RedisHubLifetimeManager.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Redis/RedisHubLifetimeManager.cs
@@ -274,7 +274,7 @@ namespace Microsoft.AspNetCore.SignalR.Redis
             }
 
             var connection = _connections[connectionId];
-            if (connection != null)
+            if (connection == null)
             {
                 return;
             }


### PR DESCRIPTION
We should be making sure the connection is not null before trying to remove it from the group. 
issue: https://github.com/aspnet/SignalR/issues/704