### PR TITLE
Conditional WebSockets testing

### DIFF
--- a/test/Common/TestHelpers.cs
+++ b/test/Common/TestHelpers.cs
@@ -1,0 +1,24 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNetCore.SignalR.Tests.Common
+{
+	public static class TestHelpers
+    {
+        public static bool IsWebSocketsSupported()
+        {
+            try
+            {
+                new System.Net.WebSockets.ClientWebSocket().Dispose();
+            }
+            catch (PlatformNotSupportedException)
+            {
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/HubConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/HubConnectionTests.cs
@@ -243,7 +243,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
 
         public static IEnumerable<TransportType> TransportTypes()
         {
-            if (WebsocketsSupported())
+            if (TestHelpers.IsWebSocketsSupported())
             {
                 // TODO: Currently we are always sending Text messages over websockets which does not work
                 // with binary protocols. It is getting fixed separately.
@@ -253,20 +253,6 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
             }
             yield return TransportType.ServerSentEvents;
             yield return TransportType.LongPolling;
-
-            bool WebsocketsSupported()
-            {
-                try
-                {
-                    new System.Net.WebSockets.ClientWebSocket();
-                }
-                catch (PlatformNotSupportedException)
-                {
-                    return false;
-                }
-
-                return true;
-            }
         }
     }
 }

--- a/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/Microsoft.AspNetCore.SignalR.Client.FunctionalTests.csproj
+++ b/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/Microsoft.AspNetCore.SignalR.Client.FunctionalTests.csproj
@@ -17,6 +17,7 @@
     <Compile Include="..\Common\ServerFixture.cs" Link="ServerFixture.cs" />
     <Compile Include="..\Common\TaskExtensions.cs" Link="TaskExtensions.cs" />
     <Compile Include="..\Common\ChannelExtensions.cs" Link="ChannelExtensions.cs" />
+    <Compile Include="..\Common\TestHelpers.cs" Link="TestHelpers.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Microsoft.AspNetCore.SignalR.Tests/DefaultTransportFactoryTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/DefaultTransportFactoryTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Net.Http;
+using Microsoft.AspNetCore.SignalR.Tests.Common;
 using Microsoft.AspNetCore.Sockets;
 using Microsoft.AspNetCore.Sockets.Client;
 using Microsoft.AspNetCore.Testing.xunit;
@@ -73,7 +74,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
         [InlineData(TransportType.LongPolling, typeof(LongPollingTransport))]
         public void DefaultTransportFactoryCreatesRequestedTransportIfAvailable_Win7(TransportType requestedTransport, Type expectedTransportType)
         {
-            if (!WebsocketsSupported())
+            if (!TestHelpers.IsWebSocketsSupported())
             {
                 var transportFactory = new DefaultTransportFactory(requestedTransport, loggerFactory: null, httpClient: new HttpClient());
                 Assert.IsType(expectedTransportType,
@@ -85,7 +86,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
         [InlineData(TransportType.WebSockets)]
         public void DefaultTransportFactoryThrowsIfItCannotCreateRequestedTransport_Win7(TransportType requestedTransport)
         {
-            if (!WebsocketsSupported())
+            if (!TestHelpers.IsWebSocketsSupported())
             {
                 var transportFactory =
                     new DefaultTransportFactory(requestedTransport, loggerFactory: null, httpClient: new HttpClient());
@@ -94,20 +95,6 @@ namespace Microsoft.AspNetCore.SignalR.Tests
 
                 Assert.Equal("No requested transports available on the server.", ex.Message);
             }
-        }
-
-        private bool WebsocketsSupported()
-        {
-            try
-            {
-                new System.Net.WebSockets.ClientWebSocket();
-            }
-            catch (PlatformNotSupportedException)
-            {
-                return false;
-            }
-
-            return true;
         }
     }
 }

--- a/test/Microsoft.AspNetCore.SignalR.Tests/EndToEndTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/EndToEndTests.cs
@@ -58,7 +58,6 @@ namespace Microsoft.AspNetCore.SignalR.Tests
         public async Task CanStartAndStopConnectionUsingGivenTransport(TransportType transportType)
         {
             var url = _serverFixture.BaseUrl + "/echo";
-            // When WebSockets is attempted to be used on Windows 7/2008R2 it will instead use ServerSentEvents
             var connection = new HttpConnection(new Uri(url), transportType);
             await connection.StartAsync().OrTimeout();
             await connection.DisposeAsync().OrTimeout();
@@ -99,7 +98,6 @@ namespace Microsoft.AspNetCore.SignalR.Tests
         }
 
         [ConditionalTheory]
-        [OSSkipCondition(OperatingSystems.Windows, WindowsVersions.Win7, WindowsVersions.Win2008R2, SkipReason = "No WebSockets Client for this platform")]
         [MemberData(nameof(TransportTypes))]
         // TODO: transfer types
         public async Task ConnectionCanSendAndReceiveMessages(TransportType transportType)
@@ -189,7 +187,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                 var logger = loggerFactory.CreateLogger<EndToEndTests>();
 
                 var url = _serverFixture.BaseUrl + "/echo";
-                var connection = new HttpConnection(new Uri(url), loggerFactory);
+                var connection = new HttpConnection(new Uri(url), TransportType.WebSockets, loggerFactory);
                 connection.Features.Set<ITransferModeFeature>(
                     new TransferModeFeature { TransferMode = TransferMode.Binary });
 
@@ -294,12 +292,28 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             }
         }
 
-        public static IEnumerable<object[]> TransportTypes =>
-            new[]
+        public static IEnumerable<object[]> TransportTypes()
+        {
+            if (WebsocketsSupported())
             {
-                new object[] { TransportType.WebSockets },
-                new object[] { TransportType.ServerSentEvents },
-                new object[] { TransportType.LongPolling }
-            };
+                yield return new object[] { TransportType.WebSockets };
+            }
+            yield return new object[] { TransportType.ServerSentEvents };
+            yield return new object[] { TransportType.LongPolling };
+        }
+
+        private static bool WebsocketsSupported()
+        {
+            try
+            {
+                new ClientWebSocket().Dispose();
+            }
+            catch (PlatformNotSupportedException)
+            {
+                return false;
+            }
+
+            return true;
+        }
     }
 }

--- a/test/Microsoft.AspNetCore.SignalR.Tests/EndToEndTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/EndToEndTests.cs
@@ -294,26 +294,12 @@ namespace Microsoft.AspNetCore.SignalR.Tests
 
         public static IEnumerable<object[]> TransportTypes()
         {
-            if (WebsocketsSupported())
+            if (TestHelpers.IsWebSocketsSupported())
             {
                 yield return new object[] { TransportType.WebSockets };
             }
             yield return new object[] { TransportType.ServerSentEvents };
             yield return new object[] { TransportType.LongPolling };
-        }
-
-        private static bool WebsocketsSupported()
-        {
-            try
-            {
-                new ClientWebSocket().Dispose();
-            }
-            catch (PlatformNotSupportedException)
-            {
-                return false;
-            }
-
-            return true;
         }
     }
 }

--- a/test/Microsoft.AspNetCore.SignalR.Tests/Microsoft.AspNetCore.SignalR.Tests.csproj
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/Microsoft.AspNetCore.SignalR.Tests.csproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <Compile Include="..\Common\ServerFixture.cs" Link="ServerFixture.cs" />
     <Compile Include="..\Common\TaskExtensions.cs" Link="TaskExtensions.cs" />
+    <Compile Include="..\Common\TestHelpers.cs" Link="TestHelpers.cs" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Added `WebsocketsSupported` function which also lets us run `ConnectionCanSendAndReceiveMessages` on 2008R2/Win7