### PR TITLE
Give Client a chance to receive Close Frame from Server

### DIFF
--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/HttpConnection.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/HttpConnection.cs
@@ -409,14 +409,14 @@ namespace Microsoft.AspNetCore.Sockets.Client
                 // _startTask is returned to the user and they should handle exceptions.
             }
 
-            if (_transportChannel != null)
-            {
-                Output.TryComplete();
-            }
-
             if (_transport != null)
             {
                 await _transport.StopAsync();
+            }
+
+            if (_transportChannel != null)
+            {
+                Output.TryComplete();
             }
 
             if (_receiveLoopTask != null)

--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/HttpConnection.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/HttpConnection.cs
@@ -409,14 +409,14 @@ namespace Microsoft.AspNetCore.Sockets.Client
                 // _startTask is returned to the user and they should handle exceptions.
             }
 
-            if (_transport != null)
-            {
-                await _transport.StopAsync();
-            }
-
             if (_transportChannel != null)
             {
                 Output.TryComplete();
+            }
+
+            if (_transport != null)
+            {
+                await _transport.StopAsync();
             }
 
             if (_receiveLoopTask != null)

--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/Internal/SocketClientLoggerExtensions.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/Internal/SocketClientLoggerExtensions.cs
@@ -62,6 +62,9 @@ namespace Microsoft.AspNetCore.Sockets.Client.Internal
         private static readonly Action<ILogger, DateTime, string, Exception> _closingWebSocketFailed =
             LoggerMessage.Define<DateTime, string>(LogLevel.Information, 16, "{time}: Connection Id {connectionId}: Closing webSocket failed.");
 
+        private static readonly Action<ILogger, DateTime, string, Exception> _cancelMessage =
+            LoggerMessage.Define<DateTime, string>(LogLevel.Debug, 17, "{time}: Connection Id {connectionId}: Canceled passing message to application.");
+
         // Category: ServerSentEventsTransport and LongPollingTransport
         private static readonly Action<ILogger, DateTime, string, int, Uri, Exception> _sendingMessages =
             LoggerMessage.Define<DateTime, string, int, Uri>(LogLevel.Debug, 9, "{time}: Connection Id {connectionId}: Sending {count} message(s) to the server using url: {url}.");
@@ -280,6 +283,14 @@ namespace Microsoft.AspNetCore.Sockets.Client.Internal
             if (logger.IsEnabled(LogLevel.Information))
             {
                 _closingWebSocketFailed(logger, DateTime.Now, connectionId, exception);
+            }
+        }
+
+        public static void CancelMessage(this ILogger logger, string connectionId)
+        {
+            if (logger.IsEnabled(LogLevel.Debug))
+            {
+                _cancelMessage(logger, DateTime.Now, connectionId, null);
             }
         }
 

--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/WebSocketsTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/WebSocketsTransport.cs
@@ -147,6 +147,7 @@ namespace Microsoft.AspNetCore.Sockets.Client
                     }
                     catch (OperationCanceledException)
                     {
+                        _logger.CancelMessage(_connectionId);
                     }
                 }
             }

--- a/test/Microsoft.AspNetCore.SignalR.Tests/WebSocketsTransportTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/WebSocketsTransportTests.cs
@@ -62,7 +62,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                 await webSocketsTransport.StartAsync(new Uri(_serverFixture.WebSocketsUrl + "/echo"), channelConnection,
                     TransferMode.Binary, connectionId: string.Empty);
                 connectionToTransport.Out.TryComplete();
-                await webSocketsTransport.Running.OrTimeout();
+                await webSocketsTransport.Running.OrTimeout(TimeSpan.FromSeconds(10));
             }
         }
 


### PR DESCRIPTION
Issue was `HttpConnection.DisposeAsync()` was being called and it would complete the Channel then call `transport.StopAsync()`, the Channel completion would trigger the transport send loop to exit and cancel the `_transportCts` which would cause `_webSocket.ReceiveAsync()` to exit so it can't receive the close frame. This would happen in parallel with us calling `_webSocket.CloseOutputAsync`.

Now we use a different CTS for the webSocket calls so we have a chance to send and receive a close frame before exiting.
https://github.com/aspnet/SignalR/issues/720