### PR TITLE
Starting HubOptions

### DIFF
--- a/src/Microsoft.AspNetCore.SignalR.Http/SignalRDependencyInjectionExtensions.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Http/SignalRDependencyInjectionExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.AspNetCore.SignalR;
 
 namespace Microsoft.Extensions.DependencyInjection
@@ -9,6 +10,12 @@ namespace Microsoft.Extensions.DependencyInjection
     {
         public static ISignalRBuilder AddSignalR(this IServiceCollection services)
         {
+            return AddSignalR(services, o => { });
+        }
+
+        public static ISignalRBuilder AddSignalR(this IServiceCollection services, Action<HubOptions> configure)
+        {
+            services.Configure(configure);
             services.AddSockets();
             return services.AddSignalRCore();
         }

--- a/src/Microsoft.AspNetCore.SignalR.Http/SignalRDependencyInjectionExtensions.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Http/SignalRDependencyInjectionExtensions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Extensions.DependencyInjection
     {
         public static ISignalRBuilder AddSignalR(this IServiceCollection services)
         {
-            return AddSignalR(services, o => { });
+            return AddSignalR(services, _ => { });
         }
 
         public static ISignalRBuilder AddSignalR(this IServiceCollection services, Action<HubOptions> configure)

--- a/src/Microsoft.AspNetCore.SignalR/HubEndPoint.cs
+++ b/src/Microsoft.AspNetCore.SignalR/HubEndPoint.cs
@@ -124,7 +124,7 @@ namespace Microsoft.AspNetCore.SignalR
                         {
                             if (NegotiationProtocol.TryParseMessage(buffer, out var negotiationMessage))
                             {
-                                var protocol = _protocolResolver.GetProtocol(negotiationMessage.Protocol, connection, _hubOptions.Value);
+                                var protocol = _protocolResolver.GetProtocol(negotiationMessage.Protocol, connection);
 
                                 var transportCapabilities = connection.Features.Get<IConnectionTransportFeature>()?.TransportCapabilities
                                     ?? throw new InvalidOperationException("Unable to read transport capabilities.");

--- a/src/Microsoft.AspNetCore.SignalR/HubEndPoint.cs
+++ b/src/Microsoft.AspNetCore.SignalR/HubEndPoint.cs
@@ -13,13 +13,14 @@ using System.Threading.Tasks.Channels;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR.Features;
 using Microsoft.AspNetCore.SignalR.Internal;
+using Microsoft.AspNetCore.SignalR.Internal.Encoders;
 using Microsoft.AspNetCore.SignalR.Internal.Protocol;
 using Microsoft.AspNetCore.Sockets;
 using Microsoft.AspNetCore.Sockets.Features;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Internal;
 using Microsoft.Extensions.Logging;
-using Microsoft.AspNetCore.SignalR.Internal.Encoders;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.SignalR
 {
@@ -36,16 +37,19 @@ namespace Microsoft.AspNetCore.SignalR
         private readonly ILogger<HubEndPoint<THub>> _logger;
         private readonly IServiceScopeFactory _serviceScopeFactory;
         private readonly IHubProtocolResolver _protocolResolver;
+        private readonly IOptions<HubOptions> _hubOptions;
 
         public HubEndPoint(HubLifetimeManager<THub> lifetimeManager,
                            IHubProtocolResolver protocolResolver,
                            IHubContext<THub> hubContext,
+                           IOptions<HubOptions> hubOptions,
                            ILogger<HubEndPoint<THub>> logger,
                            IServiceScopeFactory serviceScopeFactory)
         {
             _protocolResolver = protocolResolver;
             _lifetimeManager = lifetimeManager;
             _hubContext = hubContext;
+            _hubOptions = hubOptions;
             _logger = logger;
             _serviceScopeFactory = serviceScopeFactory;
 
@@ -120,7 +124,7 @@ namespace Microsoft.AspNetCore.SignalR
                         {
                             if (NegotiationProtocol.TryParseMessage(buffer, out var negotiationMessage))
                             {
-                                var protocol = _protocolResolver.GetProtocol(negotiationMessage.Protocol, connection);
+                                var protocol = _protocolResolver.GetProtocol(negotiationMessage.Protocol, connection, _hubOptions.Value);
 
                                 var transportCapabilities = connection.Features.Get<IConnectionTransportFeature>()?.TransportCapabilities
                                     ?? throw new InvalidOperationException("Unable to read transport capabilities.");

--- a/src/Microsoft.AspNetCore.SignalR/HubOptions.cs
+++ b/src/Microsoft.AspNetCore.SignalR/HubOptions.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Newtonsoft.Json;
+
+namespace Microsoft.AspNetCore.SignalR
+{
+    public class HubOptions
+    {
+        public JsonSerializerSettings JsonSerializerSettings { get; set; }
+    }
+}

--- a/src/Microsoft.AspNetCore.SignalR/Internal/DefaultHubProtocolResolver.cs
+++ b/src/Microsoft.AspNetCore.SignalR/Internal/DefaultHubProtocolResolver.cs
@@ -3,18 +3,26 @@
 
 using System;
 using Microsoft.AspNetCore.SignalR.Internal.Protocol;
+using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 
 namespace Microsoft.AspNetCore.SignalR.Internal
 {
     public class DefaultHubProtocolResolver : IHubProtocolResolver
     {
-        public IHubProtocol GetProtocol(string protocolName, HubConnectionContext connection, HubOptions options)
+        private readonly IOptions<HubOptions> _options;
+
+        public DefaultHubProtocolResolver(IOptions<HubOptions> options)
+        {
+            _options = options;
+        }
+
+        public IHubProtocol GetProtocol(string protocolName, HubConnectionContext connection)
         {
             switch (protocolName?.ToLowerInvariant())
             {
                 case "json":
-                    return new JsonHubProtocol(JsonSerializer.Create(options.JsonSerializerSettings));
+                    return new JsonHubProtocol(JsonSerializer.Create(_options.Value.JsonSerializerSettings));
                 case "messagepack":
                     return new MessagePackHubProtocol();
                 default:

--- a/src/Microsoft.AspNetCore.SignalR/Internal/DefaultHubProtocolResolver.cs
+++ b/src/Microsoft.AspNetCore.SignalR/Internal/DefaultHubProtocolResolver.cs
@@ -9,12 +9,12 @@ namespace Microsoft.AspNetCore.SignalR.Internal
 {
     public class DefaultHubProtocolResolver : IHubProtocolResolver
     {
-        public IHubProtocol GetProtocol(string protocolName, HubConnectionContext connection)
+        public IHubProtocol GetProtocol(string protocolName, HubConnectionContext connection, HubOptions options)
         {
             switch (protocolName?.ToLowerInvariant())
             {
                 case "json":
-                    return new JsonHubProtocol(new JsonSerializer());
+                    return new JsonHubProtocol(JsonSerializer.Create(options.JsonSerializerSettings));
                 case "messagepack":
                     return new MessagePackHubProtocol();
                 default:

--- a/src/Microsoft.AspNetCore.SignalR/Internal/IHubProtocolResolver.cs
+++ b/src/Microsoft.AspNetCore.SignalR/Internal/IHubProtocolResolver.cs
@@ -7,6 +7,6 @@ namespace Microsoft.AspNetCore.SignalR.Internal
 {
     public interface IHubProtocolResolver
     {
-        IHubProtocol GetProtocol(string protocolName, HubConnectionContext connection, HubOptions options);
+        IHubProtocol GetProtocol(string protocolName, HubConnectionContext connection);
     }
 }

--- a/src/Microsoft.AspNetCore.SignalR/Internal/IHubProtocolResolver.cs
+++ b/src/Microsoft.AspNetCore.SignalR/Internal/IHubProtocolResolver.cs
@@ -7,6 +7,6 @@ namespace Microsoft.AspNetCore.SignalR.Internal
 {
     public interface IHubProtocolResolver
     {
-        IHubProtocol GetProtocol(string protocolName, HubConnectionContext connection);
+        IHubProtocol GetProtocol(string protocolName, HubConnectionContext connection, HubOptions options);
     }
 }

--- a/test/Microsoft.AspNetCore.SignalR.Tests/HubEndpointTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/HubEndpointTests.cs
@@ -10,9 +10,10 @@ using System.Threading.Tasks.Channels;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR.Internal.Protocol;
 using Microsoft.AspNetCore.SignalR.Tests.Common;
-using Microsoft.CSharp;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 using Xunit;
 
 namespace Microsoft.AspNetCore.SignalR.Tests
@@ -491,7 +492,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
 
                 await Task.WhenAll(firstClient.Connected, secondClient.Connected).OrTimeout();
 
-                await firstClient.SendInvocationAsync("BroadcastMethod", "test").OrTimeout();
+                await firstClient.SendInvocationAsync(nameof(MethodHub.BroadcastMethod), "test").OrTimeout();
 
                 foreach (var result in await Task.WhenAll(
                     firstClient.ReadAsync(),
@@ -769,6 +770,43 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             }
         }
 
+        [Fact]
+        public async Task HubOptionsCanUseCustomJsonSerializerSettings()
+        {
+            var serviceProvider = CreateServiceProvider(services =>
+            {
+                services.AddSignalR(o =>
+                {
+                    o.JsonSerializerSettings = new JsonSerializerSettings
+                    {
+                        ContractResolver = new CamelCasePropertyNamesContractResolver()
+                    };
+                });
+            });
+
+            var endPoint = serviceProvider.GetService<HubEndPoint<MethodHub>>();
+
+            using (var client = new TestClient())
+            {
+                var endPointLifetime = endPoint.OnConnectedAsync(client.Connection);
+
+                await client.Connected.OrTimeout();
+
+                await client.SendInvocationAsync(nameof(MethodHub.BroadcastItem)).OrTimeout();
+
+                var message = await client.ReadAsync().OrTimeout() as InvocationMessage;
+
+                var customItem = message.Arguments[0].ToString();
+                // Originally "Message" and "paramName"
+                Assert.Contains("message", customItem);
+                Assert.Contains("paramName", customItem);
+
+                client.Dispose();
+
+                await endPointLifetime.OrTimeout();
+            }
+        }
+
         private static void AssertHubMessage(HubMessage expected, HubMessage actual)
         {
             // We aren't testing InvocationIds here
@@ -1014,6 +1052,11 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             public Task BroadcastMethod(string message)
             {
                 return Clients.All.InvokeAsync("Broadcast", message);
+            }
+
+            public Task BroadcastItem()
+            {
+                return Clients.All.InvokeAsync("Broadcast", new { Message = "test", paramName = "test" });
             }
 
             public Task<int> TaskValueMethod()

--- a/test/Microsoft.AspNetCore.SignalR.Tests/Internal/DefaultHubProtocolResolverTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/Internal/DefaultHubProtocolResolverTests.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks.Channels;
 using Microsoft.AspNetCore.SignalR.Internal;
 using Microsoft.AspNetCore.SignalR.Internal.Protocol;
 using Microsoft.AspNetCore.Sockets;
+using Microsoft.Extensions.Options;
 using Moq;
 using Newtonsoft.Json;
 using Xunit;
@@ -22,7 +23,7 @@ namespace Microsoft.AspNetCore.SignalR.Common.Protocol.Tests
             var mockConnection = new Mock<HubConnectionContext>(Channel.CreateUnbounded<HubMessage>().Out, new Mock<ConnectionContext>().Object);
             Assert.IsType(
                 protocol.GetType(),
-                new DefaultHubProtocolResolver().GetProtocol(protocol.Name, mockConnection.Object));
+                new DefaultHubProtocolResolver(Options.Create(new HubOptions())).GetProtocol(protocol.Name, mockConnection.Object));
         }
 
         [Theory]
@@ -32,7 +33,7 @@ namespace Microsoft.AspNetCore.SignalR.Common.Protocol.Tests
         {
             var mockConnection = new Mock<HubConnectionContext>(Channel.CreateUnbounded<HubMessage>().Out, new Mock<ConnectionContext>().Object);
             var exception = Assert.Throws<NotSupportedException>(
-                () => new DefaultHubProtocolResolver().GetProtocol(protocolName, mockConnection.Object));
+                () => new DefaultHubProtocolResolver(Options.Create(new HubOptions())).GetProtocol(protocolName, mockConnection.Object));
 
             Assert.Equal($"The protocol '{protocolName ?? "(null)"}' is not supported.", exception.Message);
         }


### PR DESCRIPTION
https://github.com/aspnet/SignalR/issues/254 and https://github.com/aspnet/SignalR/issues/261

Wanted to get feedback to see if this is the design we want. Then I'll add a test.
Do we want it to be `HubOptions<THub>`? 

Current usage:
```c#
services.Configure<HubOptions>(options =>
{
    options.JsonSerializerSettings = new JsonSerializerSettings()
    {
        ContractResolver = new CamelCasePropertyNamesContractResolver()
    };
});
```