### PR TITLE
Putting signalr-client into @aspnet scope

### DIFF
--- a/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/Microsoft.AspNetCore.SignalR.Client.TS.csproj
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/Microsoft.AspNetCore.SignalR.Client.TS.csproj
@@ -52,7 +52,7 @@
       Command="git checkout HEAD -- $(MSBuildThisFileDirectory)../package-lock.json"
       Condition="$(IsGitRepository) AND '$(VersionSuffix)' != ''" />
     <ItemGroup>
-      <TSClient Include="$(MSBuildThisFileDirectory)../signalr-client*.tgz" />
+      <TSClient Include="$(MSBuildThisFileDirectory)../aspnet-signalr-client*.tgz" />
     </ItemGroup>
     <Move SourceFiles="@(TSClient)" DestinationFolder="$(PackageOutputPath)" />
   </Target>

--- a/client-ts/package.json
+++ b/client-ts/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "signalr-client",
+  "name": "@aspnet/signalr-client",
   "version": "0.1.0",
   "description": "ASP.NET Core SignalR",
   "main": "dist/src/index.js",


### PR DESCRIPTION
Note: this is just for pushing the client to the registry. Once it is there I will update projects that use this module.