### PR TITLE
Update hub route in client sample

### DIFF
--- a/samples/ClientSample/HubSample.cs
+++ b/samples/ClientSample/HubSample.cs
@@ -28,7 +28,7 @@ namespace ClientSample
 
         public static async Task<int> ExecuteAsync(string baseUrl)
         {
-            baseUrl = string.IsNullOrEmpty(baseUrl) ? "http://localhost:5000/hubs" : baseUrl;
+            baseUrl = string.IsNullOrEmpty(baseUrl) ? "http://localhost:5000/default" : baseUrl;
 
             var loggerFactory = new LoggerFactory();
 


### PR DESCRIPTION
https://github.com/aspnet/SignalR/blob/dev/samples/SocketsSample/Startup.cs#L51 
The default chat hub in the SocketsSample used to be mapped to "hubs". Now it's "default" and the Client Sample needs to point to that.