### PR TITLE
Others - Question

### DIFF
--- a/src/Microsoft.AspNetCore.SignalR/HubContext.cs
+++ b/src/Microsoft.AspNetCore.SignalR/HubContext.cs
@@ -22,6 +22,13 @@ namespace Microsoft.AspNetCore.SignalR
 
         public virtual IGroupManager Groups { get; }
 
+        public virtual IClientProxy Others(string connectionId)
+        {
+            var excludedIds = new List<string>();
+            excludedIds.Add(connectionId);
+            return new AllClientsExceptProxy<THub>(_lifetimeManager, excludedIds);
+        }
+
         public IClientProxy AllExcept(IReadOnlyList<string> excludedIds)
         {
             return new AllClientsExceptProxy<THub>(_lifetimeManager, excludedIds);

--- a/src/Microsoft.AspNetCore.SignalR/IHubClients.cs
+++ b/src/Microsoft.AspNetCore.SignalR/IHubClients.cs
@@ -13,6 +13,8 @@ namespace Microsoft.AspNetCore.SignalR
 
         IClientProxy Client(string connectionId);
 
+        IClientProxy Others(string connectionId);
+
         IClientProxy Group(string groupName);
 
         IClientProxy User(string userId);

--- a/test/Microsoft.AspNetCore.SignalR.Tests/HubEndpointTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/HubEndpointTests.cs
@@ -556,6 +556,54 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             }
         }
 
+        [Fact]
+        public async Task SendToOthers()
+        {
+            var serviceProvider = CreateServiceProvider();
+
+            var endPoint = serviceProvider.GetService<HubEndPoint<MethodHub>>();
+
+            using (var firstClient = new TestClient())
+            using (var secondClient = new TestClient())
+            using (var thirdClient = new TestClient())
+            {
+                Task firstEndPointTask = endPoint.OnConnectedAsync(firstClient.Connection);
+                Task secondEndPointTask = endPoint.OnConnectedAsync(secondClient.Connection);
+                Task thirdEndPointTask = endPoint.OnConnectedAsync(thirdClient.Connection);
+
+                await Task.WhenAll(firstClient.Connected, secondClient.Connected, thirdClient.Connected).OrTimeout();
+
+
+                await firstClient.SendInvocationAsync("SendToOthers", "To Others").OrTimeout();
+                await secondClient.SendInvocationAsync("ConnectionSendMethod", firstClient.Connection.ConnectionId, "To First").OrTimeout();
+
+                var firstClientResult = await firstClient.ReadAsync().OrTimeout();
+                var invocation = Assert.IsType<CompletionMessage>(firstClientResult);
+
+                firstClientResult = await firstClient.ReadAsync().OrTimeout();
+                invocation = Assert.IsType<InvocationMessage>(firstClientResult);
+                Assert.Equal("Send", invocation.Target);
+                Assert.Equal("To First", invocation.Arguments[0]);
+
+                var secondClientResult = await secondClient.ReadAsync().OrTimeout();
+                invocation = Assert.IsType<InvocationMessage>(secondClientResult);
+                Assert.Equal("Send", invocation.Target);
+                Assert.Equal("To Others", invocation.Arguments[0]);
+
+                var thirdClientResult = await thirdClient.ReadAsync().OrTimeout();
+                invocation = Assert.IsType<InvocationMessage>(thirdClientResult);
+                Assert.Equal("Send", invocation.Target);
+                Assert.Equal("To Others", invocation.Arguments[0]);
+
+                // kill the connections
+                firstClient.Dispose();
+                secondClient.Dispose();
+                thirdClient.Dispose();
+
+                await Task.WhenAll(firstEndPointTask, secondEndPointTask, thirdEndPointTask).OrTimeout();
+            }
+        }
+
         [Theory]
         [MemberData(nameof(HubTypes))]
         public async Task HubsCanAddAndSendToGroup(Type hubType)
@@ -1154,6 +1202,11 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             public Task SendToAllExcept(string message, IReadOnlyList<string> excludedIds)
             {
                 return Clients.AllExcept(excludedIds).InvokeAsync("Send", message);
+            }
+
+            public Task SendToOthers(string message)
+            {
+                return Clients.Others(Context.ConnectionId).InvokeAsync("Send", message);
             }
         }
 


### PR DESCRIPTION
This is really just a question in the form of a PR (with a test ...)
I was looking into how to implement the others client subset and I realized that I wasn't actually sure how to implement it without passing in the callers connection Id at the hub level which is just not right.  This pr also kind of shows the need for an improved API for the AllExcept subset, aka it should use params to make it more friendly for people to enter one or two id's to exclude. 
Anyways, was hoping for some guidance on this. Thanks!

This isn't alpha work so super lo pri, but I just thought I'd put it out there
