### PR TITLE
Prototype - syntactic sugar for creating HubConnections

### DIFF
--- a/src/Microsoft.AspNetCore.SignalR.Client/HttpHubConnection.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client/HttpHubConnection.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Threading.Tasks.Channels;
+using Microsoft.AspNetCore.SignalR.Internal.Protocol;
+using Microsoft.AspNetCore.Sockets;
+using Microsoft.AspNetCore.Sockets.Client;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.SignalR.Client
+{
+    // NOTE: This requires making HubConnection methods virtual or making IHubConnection interface
+    // to make `On` extension methods work
+    public class HttpHubConnection
+    {
+        private HubConnection _hubConnection;
+
+        public event Func<Task> Connected
+        {
+            add { _hubConnection.Connected += value; }
+            remove { _hubConnection.Connected -= value; }
+        }
+
+        public event Func<Exception, Task> Closed
+        {
+            add { _hubConnection.Closed += value; }
+            remove { _hubConnection.Closed -= value; }
+        }
+
+        public HttpHubConnection(Uri url, ILoggerFactory loggerFactory = null)
+        {
+            var httpConnection = new HttpConnection(url, loggerFactory);
+            _hubConnection = new HubConnection(httpConnection, loggerFactory);
+        }
+
+        public HttpHubConnection(Uri url, TransportType transportType, ILoggerFactory loggerFactory = null)
+        {
+            var httpConnection = new HttpConnection(url, transportType, loggerFactory);
+            _hubConnection = new HubConnection(httpConnection, loggerFactory);
+        }
+
+        public HttpHubConnection(Uri url, TransportType transportType, IHubProtocol hubProtocol, ILoggerFactory loggerFactory = null)
+        {
+            var httpConnection = new HttpConnection(url, transportType, loggerFactory);
+            _hubConnection = new HubConnection(httpConnection, hubProtocol, loggerFactory);
+        }
+
+        public Task StartAsync() => _hubConnection.StartAsync();
+
+        public Task DisposeAsync() => _hubConnection.DisposeAsync();
+
+        public void On(string methodName, Type[] parameterTypes, Func<object[], Task> handler)
+            => _hubConnection.On(methodName, parameterTypes, handler);
+
+
+        public ReadableChannel<object> Stream(string methodName, Type returnType, CancellationToken cancellationToken, params object[] args)
+            => _hubConnection.Stream(methodName, returnType, cancellationToken, args);
+
+        public Task<object> InvokeAsync(string methodName, Type returnType, CancellationToken cancellationToken, params object[] args)
+            => _hubConnection.InvokeAsync(methodName, returnType, cancellationToken, args);
+
+        public Task SendAsync(string methodName, CancellationToken cancellationToken, params object[] args)
+            => _hubConnection.SendAsync(methodName, cancellationToken, args);
+    }
+}

--- a/src/Microsoft.AspNetCore.SignalR.Client/HubConnectionBuilder.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client/HubConnectionBuilder.cs
@@ -1,0 +1,83 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel;
+using System.Net.Http;
+using Microsoft.AspNetCore.SignalR.Internal.Protocol;
+using Microsoft.AspNetCore.Sockets;
+using Microsoft.AspNetCore.Sockets.Client;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+namespace Microsoft.AspNetCore.SignalR.Client
+{
+    public class HubConnectionBuilder
+    {
+        private readonly Uri _url;
+        private ILoggerFactory _loggerFactory;
+        private TransportType? _transportType;
+        private IHubProtocol _hubProtocol;
+        private HttpMessageHandler _httpMessageHandler;
+
+        public HubConnectionBuilder(Uri url)
+        {
+            _url = url;
+        }
+
+        public HubConnectionBuilder WithLogger(ILoggerFactory loggerFactory)
+        {
+            _loggerFactory = loggerFactory;
+            return this;
+        }
+
+        public HubConnectionBuilder WithTransportType(TransportType transportType)
+        {
+            _transportType = transportType;
+            return this;
+        }
+
+        public HubConnectionBuilder WithHubProtocol(IHubProtocol hubProtocol)
+        {
+            _hubProtocol = hubProtocol;
+            return this;
+        }
+
+        public HubConnectionBuilder WithHttpMessageHandler(HttpMessageHandler httpMessageHandler)
+        {
+            _httpMessageHandler = httpMessageHandler;
+            return this;
+        }
+
+        public HubConnection Build()
+        {
+            var httpConnection = new HttpConnection(_url, _transportType ?? TransportType.All, _loggerFactory, _httpMessageHandler);
+            return new HubConnection(httpConnection, _hubProtocol ?? new JsonHubProtocol(new JsonSerializer()), _loggerFactory);
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override bool Equals(object obj)
+        {
+            return base.Equals(obj);
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override string ToString()
+        {
+            return base.ToString();
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public new Type GetType()
+        {
+            return base.GetType();
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.SignalR.Client/HubConnectionFactory.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client/HubConnectionFactory.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.SignalR.Internal.Protocol;
+using Microsoft.AspNetCore.Sockets;
+using Microsoft.AspNetCore.Sockets.Client;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.SignalR.Client
+{
+    public static class HubConnectionFactory
+    {
+        public static HubConnection Create(Uri url, ILoggerFactory loggerFactory = null)
+        {
+            var httpConnection = new HttpConnection(url, loggerFactory);
+            return new HubConnection(httpConnection, loggerFactory);
+        }
+
+        public static HubConnection Create(Uri url, TransportType transportType, ILoggerFactory loggerFactory = null)
+        {
+            var httpConnection = new HttpConnection(url, transportType, loggerFactory);
+            return new HubConnection(httpConnection, loggerFactory);
+        }
+
+        public static HubConnection Create(Uri url, TransportType transportType, IHubProtocol protocol, ILoggerFactory loggerFactory = null)
+        {
+            var httpConnection = new HttpConnection(url, transportType, loggerFactory);
+            return new HubConnection(httpConnection, protocol, loggerFactory);
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.SignalR.Client/HubConnectionOptions.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client/HubConnectionOptions.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using Microsoft.AspNetCore.SignalR.Internal.Protocol;
+using Microsoft.AspNetCore.Sockets;
+using Microsoft.AspNetCore.Sockets.Client;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+namespace Microsoft.AspNetCore.SignalR.Client
+{
+    public class HubConnectionOptions
+    {
+        public Uri Url { get; set; }
+        public ILoggerFactory LoggerFactory { get; set; }
+        public TransportType TransportType { get; set; } = TransportType.All;
+        public IHubProtocol HubProtocol { get; set; }
+
+        public HttpMessageHandler HttpMessageHandler { get; set; }
+
+        public HubConnection Create()
+        {
+            var httpConnection = new HttpConnection(Url, TransportType, LoggerFactory, HttpMessageHandler);
+            return new HubConnection(httpConnection, HubProtocol ?? new JsonHubProtocol(new JsonSerializer()), LoggerFactory);
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/HubConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/HubConnectionTests.cs
@@ -96,6 +96,34 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
 
         [Theory]
         [MemberData(nameof(HubProtocolsAndTransportsAndHubPaths))]
+        public async Task CheckFixedMessage_HttHubConnection(IHubProtocol protocol, TransportType transportType, string path)
+        {
+            using (StartLog(out var loggerFactory))
+            {
+                var connection = HubConnectionFactory.Create(new Uri(_serverFixture.BaseUrl + path), transportType, protocol, loggerFactory);
+                try
+                {
+                    await connection.StartAsync().OrTimeout();
+
+                    var result = await connection.InvokeAsync<string>("HelloWorld").OrTimeout();
+
+                    Assert.Equal("Hello World!", result);
+                }
+                catch (Exception ex)
+                {
+                    loggerFactory.CreateLogger<HubConnectionTests>().LogError(ex, "Exception from test");
+                    throw;
+                }
+                finally
+                {
+                    await connection.DisposeAsync().OrTimeout();
+                }
+            }
+        }
+
+
+        [Theory]
+        [MemberData(nameof(HubProtocolsAndTransportsAndHubPaths))]
         public async Task CheckFixedMessage_HubConnectionBuilder(IHubProtocol protocol, TransportType transportType, string path)
         {
             using (StartLog(out var loggerFactory))

--- a/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/HubConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/HubConnectionTests.cs
@@ -66,6 +66,67 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
             }
         }
 
+
+        [Theory]
+        [MemberData(nameof(HubProtocolsAndTransportsAndHubPaths))]
+        public async Task CheckFixedMessage_HubConnectionFactory(IHubProtocol protocol, TransportType transportType, string path)
+        {
+            using (StartLog(out var loggerFactory))
+            {
+                var connection = HubConnectionFactory.Create(new Uri(_serverFixture.BaseUrl + path), transportType, protocol, loggerFactory);
+                try
+                {
+                    await connection.StartAsync().OrTimeout();
+
+                    var result = await connection.InvokeAsync<string>("HelloWorld").OrTimeout();
+
+                    Assert.Equal("Hello World!", result);
+                }
+                catch (Exception ex)
+                {
+                    loggerFactory.CreateLogger<HubConnectionTests>().LogError(ex, "Exception from test");
+                    throw;
+                }
+                finally
+                {
+                    await connection.DisposeAsync().OrTimeout();
+                }
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(HubProtocolsAndTransportsAndHubPaths))]
+        public async Task CheckFixedMessage_HubConnectionBuilder(IHubProtocol protocol, TransportType transportType, string path)
+        {
+            using (StartLog(out var loggerFactory))
+            {
+                var connection =
+                    new HubConnectionBuilder(new Uri(_serverFixture.BaseUrl + path))
+                        .WithTransportType(transportType)
+                        .WithHubProtocol(protocol)
+                        .WithLogger(loggerFactory)
+                        .Build();
+
+                try
+                {
+                    await connection.StartAsync().OrTimeout();
+
+                    var result = await connection.InvokeAsync<string>("HelloWorld").OrTimeout();
+
+                    Assert.Equal("Hello World!", result);
+                }
+                catch (Exception ex)
+                {
+                    loggerFactory.CreateLogger<HubConnectionTests>().LogError(ex, "Exception from test");
+                    throw;
+                }
+                finally
+                {
+                    await connection.DisposeAsync().OrTimeout();
+                }
+            }
+        }
+
         [Theory]
         [MemberData(nameof(HubProtocolsAndTransportsAndHubPaths))]
         public async Task CanSendAndReceiveMessage(IHubProtocol protocol, TransportType transportType, string path)

--- a/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/HubConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/HubConnectionTests.cs
@@ -96,6 +96,41 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
 
         [Theory]
         [MemberData(nameof(HubProtocolsAndTransportsAndHubPaths))]
+        public async Task CheckFixedMessage_HubConnectionOptions(IHubProtocol protocol, TransportType transportType, string path)
+        {
+            using (StartLog(out var loggerFactory))
+            {
+                var connection = new HubConnectionOptions
+                    {
+                        Url = new Uri(_serverFixture.BaseUrl + path),
+                        HubProtocol = protocol,
+                        TransportType = transportType,
+                        LoggerFactory = loggerFactory
+                    }.Create();
+
+                try
+                {
+                    await connection.StartAsync().OrTimeout();
+
+                    var result = await connection.InvokeAsync<string>("HelloWorld").OrTimeout();
+
+                    Assert.Equal("Hello World!", result);
+                }
+                catch (Exception ex)
+                {
+                    loggerFactory.CreateLogger<HubConnectionTests>().LogError(ex, "Exception from test");
+                    throw;
+                }
+                finally
+                {
+                    await connection.DisposeAsync().OrTimeout();
+                }
+            }
+        }
+
+
+        [Theory]
+        [MemberData(nameof(HubProtocolsAndTransportsAndHubPaths))]
         public async Task CheckFixedMessage_HttHubConnection(IHubProtocol protocol, TransportType transportType, string path)
         {
             using (StartLog(out var loggerFactory))


### PR DESCRIPTION
*Prototype*
Two patterns of enabling creating `HubConnection` instances without creating HttpConnection first. I like neither of these - they seem just a little better than creating an HttpConnection. If you know a better way tell me

@davidfowl 