### PR TITLE
Fix WebSocket race in E2E test

### DIFF
--- a/test/Microsoft.AspNetCore.SignalR.Tests/EndToEndTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/EndToEndTests.cs
@@ -160,7 +160,18 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                     }
 
                     logger.LogInformation("Sending {length} byte message", bytes.Length);
-                    await connection.SendAsync(bytes).OrTimeout();
+                    try
+                    {
+                        await connection.SendAsync(bytes).OrTimeout();
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        // Because the server and client are run in the same process there is a race where websocket.SendAsync
+                        // can send a message but before returning be suspended allowing the server to run the EchoEndpoint and
+                        // send a close frame which triggers a cancellation token on the client and cancels the websocket.SendAsync.
+                        // Our solution to this is to just catch OperationCanceledException from the sent message if the race happens
+                        // because we know the send went through, and its safe to check the response.
+                    }
                     logger.LogInformation("Sent message", bytes.Length);
 
                     logger.LogInformation("Receiving message");


### PR DESCRIPTION
Same as https://github.com/aspnet/SignalR/pull/745
This is one possible fix. Another is we could host the server out of process for E2E tests, which has the advantage of avoiding this issue in future tests.