### PR TITLE
Exceptions from user's event handlers should be caught and logged

### DIFF
--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/Internal/SocketClientLoggerExtensions.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/Internal/SocketClientLoggerExtensions.cs
@@ -150,6 +150,10 @@ namespace Microsoft.AspNetCore.Sockets.Client.Internal
         private static readonly Action<ILogger, DateTime, string, Exception> _stoppingClient =
             LoggerMessage.Define<DateTime, string>(LogLevel.Information, 18, "{time}: Connection Id {connectionId}: Stopping client.");
 
+        private static readonly Action<ILogger, DateTime, string, string, Exception> _exceptionThrownFromHandler =
+            LoggerMessage.Define<DateTime, string, string>(LogLevel.Error, 19, "{time}: Connection Id {connectionId}: An exception was thrown from the '{eventHandlerName}' event handler.");
+
+
         public static void StartTransport(this ILogger logger, string connectionId, TransferMode transferMode)
         {
             if (logger.IsEnabled(LogLevel.Information))
@@ -507,6 +511,14 @@ namespace Microsoft.AspNetCore.Sockets.Client.Internal
             if (logger.IsEnabled(LogLevel.Information))
             {
                 _stoppingClient(logger, DateTime.Now, connectionId, null);
+            }
+        }
+
+        public static void ExceptionThrownFromEventHandler(this ILogger logger, string connectionId, string eventHandlerName, Exception exception)
+        {
+            if (logger.IsEnabled(LogLevel.Error))
+            {
+                _exceptionThrownFromHandler(logger, DateTime.Now, connectionId, eventHandlerName, exception);
             }
         }
     }

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.cs
@@ -804,6 +804,66 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
         }
 
         [Fact]
+        public async Task CanReceiveDataEvenIfUserThrowsSynchronouslyInConnectedEvent()
+        {
+            var mockHttpHandler = new Mock<HttpMessageHandler>();
+            mockHttpHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                .Returns<HttpRequestMessage, CancellationToken>(async (request, cancellationToken) =>
+                {
+                    await Task.Yield();
+
+                    var content = string.Empty;
+
+                    if (request.Method == HttpMethod.Get)
+                    {
+                        content = "42";
+                    }
+
+                    return request.Method == HttpMethod.Options
+                        ? ResponseUtils.CreateResponse(HttpStatusCode.OK, ResponseUtils.CreateNegotiationResponse())
+                        : ResponseUtils.CreateResponse(HttpStatusCode.OK, content);
+                });
+
+            var connection = new HttpConnection(new Uri("http://fakeuri.org/"), TransportType.LongPolling, loggerFactory: null, httpMessageHandler: mockHttpHandler.Object);
+            try
+            {
+                connection.Connected += () =>
+                {
+                    throw new InvalidOperationException();
+                };
+
+                var receiveTcs = new TaskCompletionSource<string>();
+                connection.Received += data =>
+                {
+                    receiveTcs.TrySetResult(Encoding.UTF8.GetString(data));
+                    return Task.CompletedTask;
+                };
+
+                connection.Closed += e =>
+                {
+                    if (e != null)
+                    {
+                        receiveTcs.TrySetException(e);
+                    }
+                    else
+                    {
+                        receiveTcs.TrySetCanceled();
+                    }
+                    return Task.CompletedTask;
+                };
+
+                await connection.StartAsync();
+
+                Assert.Equal("42", await receiveTcs.Task.OrTimeout());
+            }
+            finally
+            {
+                await connection.DisposeAsync();
+            }
+        }
+
+        [Fact]
         public async Task CanReceiveDataEvenIfExceptionThrownFromPreviousReceivedEvent()
         {
             var mockHttpHandler = new Mock<HttpMessageHandler>();
@@ -828,7 +888,6 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
             var connection = new HttpConnection(new Uri("http://fakeuri.org/"), TransportType.LongPolling, loggerFactory: null, httpMessageHandler: mockHttpHandler.Object);
             try
             {
-
                 var receiveTcs = new TaskCompletionSource<string>();
 
                 var receivedRaised = false;
@@ -867,6 +926,68 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
             }
         }
 
+        [Fact]
+        public async Task CanReceiveDataEvenIfExceptionThrownSynchronouslyFromPreviousReceivedEvent()
+        {
+            var mockHttpHandler = new Mock<HttpMessageHandler>();
+            mockHttpHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                .Returns<HttpRequestMessage, CancellationToken>(async (request, cancellationToken) =>
+                {
+                    await Task.Yield();
+
+                    var content = string.Empty;
+
+                    if (request.Method == HttpMethod.Get)
+                    {
+                        content = "42";
+                    }
+
+                    return request.Method == HttpMethod.Options
+                        ? ResponseUtils.CreateResponse(HttpStatusCode.OK, ResponseUtils.CreateNegotiationResponse())
+                        : ResponseUtils.CreateResponse(HttpStatusCode.OK, content);
+                });
+
+            var connection = new HttpConnection(new Uri("http://fakeuri.org/"), TransportType.LongPolling, loggerFactory: null, httpMessageHandler: mockHttpHandler.Object);
+            try
+            {
+                var receiveTcs = new TaskCompletionSource<string>();
+
+                var receivedRaised = false;
+                connection.Received += data =>
+                {
+                    if (!receivedRaised)
+                    {
+                        receivedRaised = true;
+                        throw new InvalidOperationException();
+                    }
+
+                    receiveTcs.TrySetResult(Encoding.UTF8.GetString(data));
+                    return Task.CompletedTask;
+                };
+
+                connection.Closed += e =>
+                {
+                    if (e != null)
+                    {
+                        receiveTcs.TrySetException(e);
+                    }
+                    else
+                    {
+                        receiveTcs.TrySetCanceled();
+                    }
+                    return Task.CompletedTask;
+                };
+
+                await connection.StartAsync();
+
+                Assert.Equal("42", await receiveTcs.Task.OrTimeout());
+            }
+            finally
+            {
+                await connection.DisposeAsync();
+            }
+        }
 
         [Fact]
         public async Task CannotSendAfterReceiveThrewException()

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.cs
@@ -476,7 +476,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
                 closedTcs.SetResult(null);
                 return Task.CompletedTask;
             };
-                
+
             await connection.StartAsync();
             channel.Out.TryWrite(Array.Empty<byte>());
 
@@ -745,6 +745,128 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
                 await connection.DisposeAsync();
             }
         }
+
+        [Fact]
+        public async Task CanReceiveDataEvenIfUserThrowsInConnectedEvent()
+        {
+            var mockHttpHandler = new Mock<HttpMessageHandler>();
+            mockHttpHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                .Returns<HttpRequestMessage, CancellationToken>(async (request, cancellationToken) =>
+                {
+                    await Task.Yield();
+
+                    var content = string.Empty;
+
+                    if (request.Method == HttpMethod.Get)
+                    {
+                        content = "42";
+                    }
+
+                    return request.Method == HttpMethod.Options
+                        ? ResponseUtils.CreateResponse(HttpStatusCode.OK, ResponseUtils.CreateNegotiationResponse())
+                        : ResponseUtils.CreateResponse(HttpStatusCode.OK, content);
+                });
+
+            var connection = new HttpConnection(new Uri("http://fakeuri.org/"), TransportType.LongPolling, loggerFactory: null, httpMessageHandler: mockHttpHandler.Object);
+            try
+            {
+                connection.Connected += () => Task.FromException(new InvalidOperationException());
+
+                var receiveTcs = new TaskCompletionSource<string>();
+                connection.Received += data =>
+                {
+                    receiveTcs.TrySetResult(Encoding.UTF8.GetString(data));
+                    return Task.CompletedTask;
+                };
+
+                connection.Closed += e =>
+                {
+                    if (e != null)
+                    {
+                        receiveTcs.TrySetException(e);
+                    }
+                    else
+                    {
+                        receiveTcs.TrySetCanceled();
+                    }
+                    return Task.CompletedTask;
+                };
+
+                await connection.StartAsync();
+
+                Assert.Equal("42", await receiveTcs.Task.OrTimeout());
+            }
+            finally
+            {
+                await connection.DisposeAsync();
+            }
+        }
+
+        [Fact]
+        public async Task CanReceiveDataEvenIfExceptionThrownFromPreviousReceivedEvent()
+        {
+            var mockHttpHandler = new Mock<HttpMessageHandler>();
+            mockHttpHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                .Returns<HttpRequestMessage, CancellationToken>(async (request, cancellationToken) =>
+                {
+                    await Task.Yield();
+
+                    var content = string.Empty;
+
+                    if (request.Method == HttpMethod.Get)
+                    {
+                        content = "42";
+                    }
+
+                    return request.Method == HttpMethod.Options
+                        ? ResponseUtils.CreateResponse(HttpStatusCode.OK, ResponseUtils.CreateNegotiationResponse())
+                        : ResponseUtils.CreateResponse(HttpStatusCode.OK, content);
+                });
+
+            var connection = new HttpConnection(new Uri("http://fakeuri.org/"), TransportType.LongPolling, loggerFactory: null, httpMessageHandler: mockHttpHandler.Object);
+            try
+            {
+
+                var receiveTcs = new TaskCompletionSource<string>();
+
+                var receivedRaised = false;
+                connection.Received += data =>
+                {
+                    if (!receivedRaised)
+                    {
+                        receivedRaised = true;
+                        return Task.FromException(new InvalidOperationException());
+                    }
+
+                    receiveTcs.TrySetResult(Encoding.UTF8.GetString(data));
+                    return Task.CompletedTask;
+                };
+
+                connection.Closed += e =>
+                {
+                    if (e != null)
+                    {
+                        receiveTcs.TrySetException(e);
+                    }
+                    else
+                    {
+                        receiveTcs.TrySetCanceled();
+                    }
+                    return Task.CompletedTask;
+                };
+
+                await connection.StartAsync();
+
+                Assert.Equal("42", await receiveTcs.Task.OrTimeout());
+            }
+            finally
+            {
+                await connection.DisposeAsync();
+            }
+        }
+
 
         [Fact]
         public async Task CannotSendAfterReceiveThrewException()


### PR DESCRIPTION
Otherwise they can spoil event queue and make the client not raise the Received event anymore

Fixes: #818