### PR TITLE
Made tweaks to .NET client logging API

### DIFF
--- a/samples/ClientSample/HubSample.cs
+++ b/samples/ClientSample/HubSample.cs
@@ -31,16 +31,11 @@ namespace ClientSample
             baseUrl = string.IsNullOrEmpty(baseUrl) ? "http://localhost:5000/default" : baseUrl;
 
             Console.WriteLine("Connecting to {0}", baseUrl);
-            var httpConnection = new HttpConnection(new Uri(baseUrl));
-            var connection = new HubConnectionBuilder()
-                .WithUrl(baseUrl)
-                .WithConsoleLogger()
-                .Build();
+            HubConnection connection = await ConnectAsync(baseUrl);
+            Console.WriteLine("Connected to {0}", baseUrl);
 
             try
             {
-                await connection.StartAsync();
-                Console.WriteLine("Connected to {0}", baseUrl);
 
                 var cts = new CancellationTokenSource();
                 Console.CancelKeyPress += (sender, a) =>
@@ -91,6 +86,27 @@ namespace ClientSample
                 await connection.DisposeAsync();
             }
             return 0;
+        }
+
+        private static async Task<HubConnection> ConnectAsync(string baseUrl)
+        {
+            // Keep trying to until we can start
+            while (true)
+            {
+                var connection = new HubConnectionBuilder()
+                                .WithUrl(baseUrl)
+                                .WithConsoleLogger(LogLevel.Trace)
+                                .Build();
+                try
+                {
+                    await connection.StartAsync();
+                    return connection;
+                }
+                catch (Exception)
+                {
+                    await Task.Delay(1000);
+                }
+            }
         }
     }
 }

--- a/src/Microsoft.AspNetCore.SignalR.Client.Core/ConnectionFactoryDelegate.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client.Core/ConnectionFactoryDelegate.cs
@@ -1,9 +1,0 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
-
-using Microsoft.AspNetCore.Sockets.Client;
-
-namespace Microsoft.AspNetCore.SignalR.Client
-{
-    public delegate IConnection ConnectionFactoryDelegate();
-}

--- a/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnectionBuilder.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnectionBuilder.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using Microsoft.AspNetCore.SignalR.Internal.Protocol;
+using Microsoft.AspNetCore.Sockets.Client;
 using Newtonsoft.Json;
 
 namespace Microsoft.AspNetCore.SignalR.Client
@@ -12,9 +13,9 @@ namespace Microsoft.AspNetCore.SignalR.Client
     public class HubConnectionBuilder : IHubConnectionBuilder
     {
         private readonly Dictionary<KeyValuePair<string, Type>, object> _settings = new Dictionary<KeyValuePair<string, Type>, object>();
-        private ConnectionFactoryDelegate _connectionFactoryDelegate;
+        private Func<IConnection> _connectionFactoryDelegate;
 
-        public void ConfigureConnectionFactory(ConnectionFactoryDelegate connectionFactoryDelegate) =>
+        public void ConfigureConnectionFactory(Func<IConnection> connectionFactoryDelegate) =>
             _connectionFactoryDelegate = connectionFactoryDelegate;
 
         public void AddSetting<T>(string name, T value)

--- a/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnectionBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnectionBuilderExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.AspNetCore.SignalR.Internal.Protocol;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
@@ -25,10 +26,18 @@ namespace Microsoft.AspNetCore.SignalR.Client
             return hubConnectionBuilder.WithHubProtocol(new MessagePackHubProtocol());
         }
 
-        public static IHubConnectionBuilder WithLogger(this IHubConnectionBuilder hubConnectionBuilder, ILoggerFactory loggerFactory)
+        public static IHubConnectionBuilder WithLoggerFactory(this IHubConnectionBuilder hubConnectionBuilder, ILoggerFactory loggerFactory)
         {
-            hubConnectionBuilder.AddSetting(HubConnectionBuilderDefaults.LoggerFactoryKey, loggerFactory);
+            hubConnectionBuilder.AddSetting(HubConnectionBuilderDefaults.LoggerFactoryKey,
+                loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory)));
             return hubConnectionBuilder;
+        }
+
+        public static IHubConnectionBuilder WithLogger(this IHubConnectionBuilder hubConnectionBuilder, Action<ILoggerFactory> configureLogging)
+        {
+            var loggerFactory = hubConnectionBuilder.GetLoggerFactory() ?? new LoggerFactory();
+            configureLogging(loggerFactory);
+            return hubConnectionBuilder.WithLoggerFactory(loggerFactory);
         }
 
         public static ILoggerFactory GetLoggerFactory(this IHubConnectionBuilder hubConnectionBuilder)

--- a/src/Microsoft.AspNetCore.SignalR.Client.Core/IHubConnectionBuilder.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client.Core/IHubConnectionBuilder.cs
@@ -1,13 +1,16 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using Microsoft.AspNetCore.Sockets.Client;
+
 namespace Microsoft.AspNetCore.SignalR.Client
 {
     public interface IHubConnectionBuilder
     {
         void AddSetting<T>(string name, T value);
         bool TryGetSetting<T>(string name, out T value);
-        void ConfigureConnectionFactory(ConnectionFactoryDelegate connectionFactory);
+        void ConfigureConnectionFactory(Func<IConnection> connectionFactoryDelegate);
         HubConnection Build();
     }
 }

--- a/src/Microsoft.AspNetCore.SignalR.Client.Core/Microsoft.AspNetCore.SignalR.Client.Core.csproj
+++ b/src/Microsoft.AspNetCore.SignalR.Client.Core/Microsoft.AspNetCore.SignalR.Client.Core.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.AspNetCore.SignalR.Client/HubConnectionBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client/HubConnectionBuilderExtensions.cs
@@ -10,17 +10,18 @@ namespace Microsoft.AspNetCore.SignalR.Client
     {
         public static IHubConnectionBuilder WithConsoleLogger(this IHubConnectionBuilder hubConnectionBuilder)
         {
-            return hubConnectionBuilder.WithConsoleLogger(new LoggerFactory());
+            return hubConnectionBuilder.WithLogger(loggerFactory =>
+            {
+                loggerFactory.AddConsole();
+            });
         }
 
-        public static IHubConnectionBuilder WithConsoleLogger(this IHubConnectionBuilder hubConnectionBuilder, ILoggerFactory loggerFactory)
+        public static IHubConnectionBuilder WithConsoleLogger(this IHubConnectionBuilder hubConnectionBuilder, LogLevel logLevel)
         {
-            if (loggerFactory == null)
+            return hubConnectionBuilder.WithLogger(loggerFactory =>
             {
-                throw new ArgumentNullException(nameof(loggerFactory));
-            }
-
-            return hubConnectionBuilder.WithLogger(loggerFactory.AddConsole());
+                loggerFactory.AddConsole(logLevel);
+            });
         }
     }
 }

--- a/src/Microsoft.AspNetCore.SignalR.Client/Microsoft.AspNetCore.SignalR.Client.csproj
+++ b/src/Microsoft.AspNetCore.SignalR.Client/Microsoft.AspNetCore.SignalR.Client.csproj
@@ -11,7 +11,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 

--- a/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/HubConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/HubConnectionTests.cs
@@ -47,7 +47,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
                 var connection = new HubConnectionBuilder()
                     .WithUrl(_serverFixture.BaseUrl + path)
                     .WithTransportType(transportType)
-                    .WithLogger(loggerFactory)
+                    .WithLoggerFactory(loggerFactory)
                     .WithHubProtocol(protocol)
                     .Build();
 

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionBuilderExtensionsTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionBuilderExtensionsTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
         {
             var connectionBuilder = new HubConnectionBuilder();
             var loggerFactory = Mock.Of<ILoggerFactory>();
-            connectionBuilder.WithLogger(loggerFactory);
+            connectionBuilder.WithLoggerFactory(loggerFactory);
             Assert.Same(loggerFactory, connectionBuilder.GetLoggerFactory());
         }
 
@@ -52,7 +52,8 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
         {
             var connectionBuilder = new HubConnectionBuilder();
             var mockLoggerFactory = new Mock<ILoggerFactory>();
-            connectionBuilder.WithConsoleLogger(mockLoggerFactory.Object);
+            connectionBuilder.WithLoggerFactory(mockLoggerFactory.Object);
+            connectionBuilder.WithConsoleLogger();
             mockLoggerFactory.Verify(f => f.AddProvider(It.IsAny<ConsoleLoggerProvider>()), Times.Once);
         }
 

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionBuilderTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionBuilderTests.cs
@@ -25,10 +25,10 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
         }
 
         [Fact]
-        public void WithConsoleLoggerThrowsForNullLoggerFactory()
+        public void WithLoggerFactoryThrowsForNullLoggerFactory()
         {
             Assert.Equal("loggerFactory",
-                Assert.Throws<ArgumentNullException>(() => new HubConnectionBuilder().WithConsoleLogger(null)).ParamName);
+                Assert.Throws<ArgumentNullException>(() => new HubConnectionBuilder().WithLoggerFactory(null)).ParamName);
         }
     }
 }

--- a/test/Microsoft.AspNetCore.SignalR.Tests/EndToEndTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/EndToEndTests.cs
@@ -287,7 +287,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                 var connection = new HubConnectionBuilder()
                         .WithUrl(new Uri(url))
                         .WithTransportType(transportType)
-                        .WithLogger(loggerFactory)
+                        .WithLoggerFactory(loggerFactory)
                         .Build();
                 try
                 {


### PR DESCRIPTION
- Removed ConnectionFactoryDelegate and used Func<IConnection>
- Changed WithLogger that accepts ILoggerFactory to WithLoggerFactory
- Made UseLogger configure the existing ILoggerFactory or create a LoggerFactory
- Add support for setting the log level for console logs
- Updated tests