### PR TITLE
Progress towards unsubscribing from streaming messages

### DIFF
--- a/client-ts/Microsoft.AspNetCore.SignalR.Client.TS.Tests/HubConnection.spec.ts
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Client.TS.Tests/HubConnection.spec.ts
@@ -248,6 +248,47 @@ describe("HubConnection", () => {
             connection.receive({ type: 3, invocationId: connection.lastInvocationId });
             expect(await observer.completed).toEqual([1, 2, 3]);
         });
+
+        it("can complete all subscriptions", async () => {
+            let connection = new TestConnection();
+
+            let hubConnection = new HubConnection(connection);
+            let observer1 = new TestObserver();
+            let observer2 = new TestObserver();
+            let stream = hubConnection.stream<any>("testMethod");
+            stream.subscribe(observer1);
+            stream.subscribe(observer2);
+
+            connection.receive({ type: 2, invocationId: connection.lastInvocationId, item: 1 });
+            expect(observer1.itemsReceived).toEqual([1]);
+            expect(observer2.itemsReceived).toEqual([1]);
+
+            stream.complete();
+
+            connection.receive({ type: 2, invocationId: connection.lastInvocationId, item: 2 });
+            expect(await observer1.completed).toEqual([1]);
+            expect(await observer2.completed).toEqual([1]);
+        });
+
+        it("does not allow subscriptions after completing", async () => {
+            let connection = new TestConnection();
+
+            let hubConnection = new HubConnection(connection);
+            let observer1 = new TestObserver();
+            let observer2 = new TestObserver();
+            let stream = hubConnection.stream<any>("testMethod");
+            stream.subscribe(observer1);
+
+            connection.receive({ type: 2, invocationId: connection.lastInvocationId, item: 1 });
+            expect(observer1.itemsReceived).toEqual([1]);
+
+            stream.complete();
+            stream.subscribe(observer2);
+
+            connection.receive({ type: 2, invocationId: connection.lastInvocationId, item: 2 });
+            expect(await observer1.completed).toEqual([1]);
+            expect(observer2.itemsReceived).toEqual([]);
+        });
     });
 });
 

--- a/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/HubConnection.ts
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/HubConnection.ts
@@ -5,7 +5,7 @@ import { ConnectionClosed } from "./Common"
 import { IConnection } from "./IConnection"
 import { HttpConnection} from "./HttpConnection"
 import { TransportType, TransferMode } from "./Transports"
-import { Subject, Observable } from "./Observable"
+import { Subject, Rx } from "./Observable"
 import { IHubProtocol, ProtocolType, MessageType, HubMessage, CompletionMessage, ResultMessage, InvocationMessage, NegotiationMessage } from "./IHubProtocol";
 import { JsonHubProtocol } from "./JsonHubProtocol";
 import { TextMessageFormat } from "./Formatters"
@@ -136,7 +136,7 @@ export class HubConnection {
         return this.connection.stop();
     }
 
-    stream<T>(methodName: string, ...args: any[]): Observable<T> {
+    stream<T>(methodName: string, ...args: any[]): Rx.Observable<T> {
         let invocationDescriptor = this.createInvocation(methodName, args, false);
 
         let subject = new Subject<T>();

--- a/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/Observable.ts
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/Observable.ts
@@ -8,6 +8,7 @@ export interface Observer<T> {
     next: (value: T) => void;
     error: (err: any) => void;
     complete: () => void;
+    isCompleted?: boolean;
 }
 
 export interface Observable<T> {
@@ -23,24 +24,52 @@ export class Subject<T> implements Observable<T> {
     }
 
     public next(item: T): void {
-        for (let observer of this.observers) {
-            observer.next(item);
+        // loop backwards because array.splice can happen
+        // and a backwards loop avoids missing items
+        for (let i = this.observers.length - 1; i >= 0; i--) {
+            let observer = this.observers[i];
+            if (observer.closed === true) {
+                continue;
+            }
+            else {
+                observer.next(item);
+            }
+
+            if (observer.closed === true) {
+                this.unsubscribe(observer);
+            }
         }
     }
 
     public error(err: any): void {
-        for (let observer of this.observers) {
-            observer.error(err);
+        // loop backwards because array.splice can happen
+        // and a backwards loop avoids missing items
+        for (let i = this.observers.length - 1; i >= 0; i--) {
+            this.observers[i].error(err);
         }
     }
 
     public complete(): void {
-        for (let observer of this.observers) {
-            observer.complete();
+        // loop backwards because array.splice can happen
+        // and a backwards loop avoids missing items
+        for (let i = this.observers.length - 1; i >= 0; i--) {
+            this.unsubscribe(this.observers[i]);
         }
     }
 
     public subscribe(observer: Observer<T>): void {
         this.observers.push(observer);
+    }
+
+    public unsubscribe(observer: Observer<T>): void {
+        if (observer.isCompleted !== true) {
+            observer.isCompleted = true;
+            let index = this.observers.indexOf(observer);
+            if (index !== -1) {
+                this.observers.splice(index, 1);
+                // TODO: send some kind of completion to let server know
+                observer.complete();
+            }
+        }
     }
 }

--- a/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/Observable.ts
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/Observable.ts
@@ -1,23 +1,28 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-// TODO: Seamless RxJs integration
-// From RxJs: https://github.com/ReactiveX/rxjs/blob/master/src/Observer.ts
-export interface Observer<T> {
-    closed?: boolean;
-    next: (value: T) => void;
-    error: (err: any) => void;
-    complete: () => void;
+
+export declare module Rx {
+    // From RxJs: https://github.com/ReactiveX/rxjs/blob/master/src/Observer.ts
+    export interface Observer<T> {
+        closed?: boolean;
+        next: (value: T) => void;
+        error: (err: any) => void;
+        complete: () => void;
+    }
+
+    export class Observable<T> {
+        public _isScalar: boolean;
+        // TODO: Return a Subscription so the caller can unsubscribe? IDisposable in System.IObservable
+        subscribe(observer: Observer<T>): void;
+        // complete(): void;
+    }
 }
 
-export interface Observable<T> {
-    // TODO: Return a Subscription so the caller can unsubscribe? IDisposable in System.IObservable
-    subscribe(observer: Observer<T>): void;
-    complete(): void;
-}
+export class Subject<T> implements Rx.Observable<T> {
+    public _isScalar: boolean = false;
 
-export class Subject<T> implements Observable<T> {
-    observers: Observer<T>[];
+    observers: Rx.Observer<T>[];
     completed: boolean;
 
     constructor() {
@@ -29,7 +34,7 @@ export class Subject<T> implements Observable<T> {
         // loop backwards because array.splice can happen
         // and a backwards loop avoids missing items
         for (let i: number = this.observers.length - 1; i >= 0; i--) {
-            let observer: Observer<T> = this.observers[i];
+            let observer: Rx.Observer<T> = this.observers[i];
             if (observer.closed === true) {
                 continue;
             } else {
@@ -52,7 +57,7 @@ export class Subject<T> implements Observable<T> {
 
     public complete(): void {
         this.completed = true;
-        let observers: Observer<T>[] = this.observers;
+        let observers: Rx.Observer<T>[] = this.observers;
         this.observers = [];
         // loop backwards because array.splice can happen
         // and a backwards loop avoids missing items
@@ -62,13 +67,13 @@ export class Subject<T> implements Observable<T> {
         // TODO: send some kind of completion to let server know to stop streaming
     }
 
-    public subscribe(observer: Observer<T>): void {
+    public subscribe(observer: Rx.Observer<T>): void {
         if (this.completed === false) {
             this.observers.push(observer);
         }
     }
 
-    private unsubscribe(observers: Observer<T>[], observer: Observer<T>): void {
+    private unsubscribe(observers: Rx.Observer<T>[], observer: Rx.Observer<T>): void {
         let index: number = observers.indexOf(observer);
         if (index !== -1) {
             observers.splice(index, 1);

--- a/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/Observable.ts
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/Observable.ts
@@ -13,13 +13,16 @@ export interface Observer<T> {
 export interface Observable<T> {
     // TODO: Return a Subscription so the caller can unsubscribe? IDisposable in System.IObservable
     subscribe(observer: Observer<T>): void;
+    complete(): void;
 }
 
 export class Subject<T> implements Observable<T> {
     observers: Observer<T>[];
+    completed: boolean;
 
     constructor() {
         this.observers = [];
+        this.completed = false;
     }
 
     public next(item: T): void {
@@ -48,6 +51,7 @@ export class Subject<T> implements Observable<T> {
     }
 
     public complete(): void {
+        this.completed = true;
         let observers: Observer<T>[] = this.observers;
         this.observers = [];
         // loop backwards because array.splice can happen
@@ -59,7 +63,9 @@ export class Subject<T> implements Observable<T> {
     }
 
     public subscribe(observer: Observer<T>): void {
-        this.observers.push(observer);
+        if (this.completed === false) {
+            this.observers.push(observer);
+        }
     }
 
     private unsubscribe(observers: Observer<T>[], observer: Observer<T>): void {


### PR DESCRIPTION
This allows users to locally unsubscribe from streaming messages so their callbacks aren't called anymore.
Server still sends messages because we don't have a way of telling it to stop yet.

We also still need a way of completing individual subscriptions on a single stream.

Current usage:
```typescript
var stream = connection.stream("method");
stream.subscribe({
    next: function (item) {
        console.log(item);
    }
});

// do things

stream.complete();
```

~~Need to add tests.~~