### PR TITLE
Initial support for websocket subprotocols

### DIFF
--- a/src/Microsoft.AspNetCore.Sockets.Http/Internal/Transports/WebSocketsTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Http/Internal/Transports/WebSocketsTransport.cs
@@ -47,7 +47,7 @@ namespace Microsoft.AspNetCore.Sockets.Internal.Transports
         {
             Debug.Assert(context.WebSockets.IsWebSocketRequest, "Not a websocket request");
 
-            using (var ws = await context.WebSockets.AcceptWebSocketAsync())
+            using (var ws = await context.WebSockets.AcceptWebSocketAsync(_options.SubProtocol))
             {
                 _logger.SocketOpened(_connection.ConnectionId);
 

--- a/src/Microsoft.AspNetCore.Sockets.Http/WebSocketOptions.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Http/WebSocketOptions.cs
@@ -8,5 +8,7 @@ namespace Microsoft.AspNetCore.Sockets
     public class WebSocketOptions
     {
         public TimeSpan CloseTimeout { get; set; } = TimeSpan.FromSeconds(5);
+
+        public string SubProtocol { get; set; }
     }
 }

--- a/test/Microsoft.AspNetCore.Sockets.Tests/MapEndPointTests.cs
+++ b/test/Microsoft.AspNetCore.Sockets.Tests/MapEndPointTests.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.SignalR.Tests.Common;
+using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
@@ -96,7 +97,8 @@ namespace Microsoft.AspNetCore.Sockets.Tests
             Assert.Equal(2, authCount);
         }
 
-        [Fact]
+        [ConditionalFact]
+        [OSSkipCondition(OperatingSystems.Windows, WindowsVersions.Win7, WindowsVersions.Win2008R2, SkipReason = "No WebSockets Client for this platform")]
         public async Task MapEndPointWithWebSocketSubProtocolSetsProtocol()
         {
             var host = new WebHostBuilder()

--- a/test/Microsoft.AspNetCore.Sockets.Tests/MapEndPointTests.cs
+++ b/test/Microsoft.AspNetCore.Sockets.Tests/MapEndPointTests.cs
@@ -2,10 +2,15 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
+using System.Net.WebSockets;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.SignalR.Tests.Common;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
@@ -89,6 +94,55 @@ namespace Microsoft.AspNetCore.Sockets.Tests
                 .Build();
 
             Assert.Equal(2, authCount);
+        }
+
+        [Fact]
+        public async Task MapEndPointWithWebSocketSubProtocolSetsProtocol()
+        {
+            var host = new WebHostBuilder()
+                .UseUrls("http://127.0.0.1:0")
+                .UseKestrel()
+                .ConfigureServices(services =>
+                {
+                    services.AddSockets();
+                    services.AddEndPoint<MyEndPoint>();
+                })
+                .Configure(app =>
+                {
+                    app.UseSockets(routes =>
+                    {
+                        routes.MapEndPoint<MyEndPoint>("socket", httpSocketOptions =>
+                        {
+                            httpSocketOptions.WebSockets.SubProtocol = "protocol1";
+                        });
+                    });
+                })
+                .Build();
+
+            await host.StartAsync();
+
+            var feature = host.ServerFeatures.Get<IServerAddressesFeature>();
+            var address = feature.Addresses.First().Replace("http", "ws") + "/socket";
+
+            var client = new ClientWebSocket();
+            client.Options.AddSubProtocol("protocol1");
+            client.Options.AddSubProtocol("protocol2");
+            await client.ConnectAsync(new Uri(address), CancellationToken.None);
+            Assert.Equal("protocol1", client.SubProtocol);
+            await client.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, "", CancellationToken.None).OrTimeout();
+            var result = await client.ReceiveAsync(new ArraySegment<byte>(new byte[1024]), CancellationToken.None).OrTimeout();
+            Assert.Equal(WebSocketMessageType.Close, result.MessageType);
+        }
+
+        private class MyEndPoint : EndPoint
+        {
+            public override async Task OnConnectedAsync(ConnectionContext connection)
+            {
+                while (!await connection.Transport.In.WaitToReadAsync())
+                {
+
+                }
+            }
         }
 
         private class InheritedAuthEndPoint : AuthEndPoint

--- a/test/Microsoft.AspNetCore.Sockets.Tests/Microsoft.AspNetCore.Sockets.Tests.csproj
+++ b/test/Microsoft.AspNetCore.Sockets.Tests/Microsoft.AspNetCore.Sockets.Tests.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp2.0</TargetFrameworks>
+    
+    <RuntimeIdentifier Condition="'$(TargetFramework)' != 'netcoreapp2.0'">win7-x64</RuntimeIdentifier>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Exposes a SubProtocol property on WebSocketOptions that picks the
protocol for all connections on the end point.
- This is required for things like mqtt over websockets (the SubProtocol in
this case is something like mqtt or mqttv3.1)
- Added test

#402 

PS: We could look at making this a Func that selects the subprotocol based on the requested protocols but this seems like it could be a start.