### PR TITLE
Remove the params argument from IClientProxy

### DIFF
--- a/samples/ChatSample/Hubs/Chat.cs
+++ b/samples/ChatSample/Hubs/Chat.cs
@@ -3,6 +3,7 @@
 
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.SignalR;
 
 namespace ChatSample.Hubs
 {
@@ -23,12 +24,12 @@ namespace ChatSample.Hubs
 
         public override Task OnUsersJoined(UserDetails[] users)
         {
-            return Clients.Client(Context.ConnectionId).InvokeAsync("UsersJoined", new[] { users });
+            return Clients.Client(Context.ConnectionId).InvokeAsync("UsersJoined", users);
         }
 
         public override Task OnUsersLeft(UserDetails[] users)
         {
-            return Clients.Client(Context.ConnectionId).InvokeAsync("UsersLeft", new[] { users });
+            return Clients.Client(Context.ConnectionId).InvokeAsync("UsersLeft", users);
         }
 
         public async Task Send(string message)

--- a/src/Microsoft.AspNetCore.SignalR.Core/IClientProxy.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/IClientProxy.cs
@@ -13,6 +13,6 @@ namespace Microsoft.AspNetCore.SignalR
         /// <param name="method">name of the method to invoke</param>
         /// <param name="args">argumetns to pass to the client</param>
         /// <returns>A task that represents when the data has been sent to the client.</returns>
-        Task InvokeAsync(string method, params object[] args);
+        Task InvokeAsync(string method, object[] args);
     }
 }

--- a/src/Microsoft.AspNetCore.SignalR.Core/IClientProxyExtensions.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/IClientProxyExtensions.cs
@@ -165,7 +165,7 @@ namespace Microsoft.AspNetCore.SignalR
         /// <param name="arg7">The seventh argument</param>
         /// <param name="arg8">The eigth argument</param>
         /// <param name="arg9">The ninth argument</param>
-        /// <param name="arg10">The ninth argument</param>
+        /// <param name="arg10">The tenth argument</param>
         /// <returns>A task that represents when the data has been sent to the client.</returns>
         public static Task InvokeAsync(this IClientProxy clientProxy, string method, object arg1, object arg2, object arg3, object arg4, object arg5, object arg6, object arg7, object arg8, object arg9, object arg10)
         {

--- a/src/Microsoft.AspNetCore.SignalR.Core/IClientProxyExtensions.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/IClientProxyExtensions.cs
@@ -1,0 +1,175 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.SignalR
+{
+    public static class IClientProxyExtensions
+    {
+        /// <summary>
+        /// Invokes a method on the connection(s) represented by the <see cref="IClientProxy"/> instance.
+        /// </summary>
+        /// <param name="clientProxy">The <see cref="IClientProxy"/></param>
+        /// <param name="method">name of the method to invoke</param>
+        /// <param name="arg1">The first argument</param>
+        /// <returns>A task that represents when the data has been sent to the client.</returns>
+        public static Task InvokeAsync(this IClientProxy clientProxy, string method, object arg1)
+        {
+            return clientProxy.InvokeAsync(method, new object[] { arg1 });
+        }
+
+        /// <summary>
+        /// Invokes a method on the connection(s) represented by the <see cref="IClientProxy"/> instance.
+        /// </summary>
+        /// <param name="clientProxy">The <see cref="IClientProxy"/></param>
+        /// <param name="method">name of the method to invoke</param>
+        /// <param name="arg1">The first argument</param>
+        /// <param name="arg2">The second argument</param>
+        /// <returns>A task that represents when the data has been sent to the client.</returns>
+        public static Task InvokeAsync(this IClientProxy clientProxy, string method, object arg1, object arg2)
+        {
+            return clientProxy.InvokeAsync(method, new object[] { arg1, arg2 });
+        }
+
+        /// <summary>
+        /// Invokes a method on the connection(s) represented by the <see cref="IClientProxy"/> instance.
+        /// </summary>
+        /// <param name="clientProxy">The <see cref="IClientProxy"/></param>
+        /// <param name="method">name of the method to invoke</param>
+        /// <param name="arg1">The first argument</param>
+        /// <param name="arg2">The second argument</param>
+        /// <param name="arg3">The third argument</param>
+        /// <returns>A task that represents when the data has been sent to the client.</returns>
+        public static Task InvokeAsync(this IClientProxy clientProxy, string method, object arg1, object arg2, object arg3)
+        {
+            return clientProxy.InvokeAsync(method, new object[] { arg1, arg2, arg3 });
+        }
+
+        /// <summary>
+        /// Invokes a method on the connection(s) represented by the <see cref="IClientProxy"/> instance.
+        /// </summary>
+        /// <param name="clientProxy">The <see cref="IClientProxy"/></param>
+        /// <param name="method">name of the method to invoke</param>
+        /// <param name="arg1">The first argument</param>
+        /// <param name="arg2">The second argument</param>
+        /// <param name="arg3">The third argument</param>
+        /// <param name="arg4">The fourth argument</param>
+        /// <returns>A task that represents when the data has been sent to the client.</returns>
+        public static Task InvokeAsync(this IClientProxy clientProxy, string method, object arg1, object arg2, object arg3, object arg4)
+        {
+            return clientProxy.InvokeAsync(method, new object[] { arg1, arg2, arg3, arg4 });
+        }
+
+        /// <summary>
+        /// Invokes a method on the connection(s) represented by the <see cref="IClientProxy"/> instance.
+        /// </summary>
+        /// <param name="clientProxy">The <see cref="IClientProxy"/></param>
+        /// <param name="method">name of the method to invoke</param>
+        /// <param name="arg1">The first argument</param>
+        /// <param name="arg2">The second argument</param>
+        /// <param name="arg3">The third argument</param>
+        /// <param name="arg4">The fourth argument</param>
+        /// <param name="arg5">The fifth argument</param>
+        /// <returns>A task that represents when the data has been sent to the client.</returns>
+        public static Task InvokeAsync(this IClientProxy clientProxy, string method, object arg1, object arg2, object arg3, object arg4, object arg5)
+        {
+            return clientProxy.InvokeAsync(method, new object[] { arg1, arg2, arg3, arg4, arg5 });
+        }
+
+        /// <summary>
+        /// Invokes a method on the connection(s) represented by the <see cref="IClientProxy"/> instance.
+        /// </summary>
+        /// <param name="clientProxy">The <see cref="IClientProxy"/></param>
+        /// <param name="method">name of the method to invoke</param>
+        /// <param name="arg1">The first argument</param>
+        /// <param name="arg2">The second argument</param>
+        /// <param name="arg3">The third argument</param>
+        /// <param name="arg4">The fourth argument</param>
+        /// <param name="arg5">The fifth argument</param>
+        /// <param name="arg6">The sixth argument</param>
+        /// <returns>A task that represents when the data has been sent to the client.</returns>
+        public static Task InvokeAsync(this IClientProxy clientProxy, string method, object arg1, object arg2, object arg3, object arg4, object arg5, object arg6)
+        {
+            return clientProxy.InvokeAsync(method, new object[] { arg1, arg2, arg3, arg4, arg5, arg6 });
+        }
+
+        /// <summary>
+        /// Invokes a method on the connection(s) represented by the <see cref="IClientProxy"/> instance.
+        /// </summary>
+        /// <param name="clientProxy">The <see cref="IClientProxy"/></param>
+        /// <param name="method">name of the method to invoke</param>
+        /// <param name="arg1">The first argument</param>
+        /// <param name="arg2">The second argument</param>
+        /// <param name="arg3">The third argument</param>
+        /// <param name="arg4">The fourth argument</param>
+        /// <param name="arg5">The fifth argument</param>
+        /// <param name="arg6">The sixth argument</param>
+        /// <param name="arg7">The seventh argument</param>
+        /// <returns>A task that represents when the data has been sent to the client.</returns>
+        public static Task InvokeAsync(this IClientProxy clientProxy, string method, object arg1, object arg2, object arg3, object arg4, object arg5, object arg6, object arg7)
+        {
+            return clientProxy.InvokeAsync(method, new object[] { arg1, arg2, arg3, arg4, arg5, arg6, arg7 });
+        }
+
+        /// <summary>
+        /// Invokes a method on the connection(s) represented by the <see cref="IClientProxy"/> instance.
+        /// </summary>
+        /// <param name="clientProxy">The <see cref="IClientProxy"/></param>
+        /// <param name="method">name of the method to invoke</param>
+        /// <param name="arg1">The first argument</param>
+        /// <param name="arg2">The second argument</param>
+        /// <param name="arg3">The third argument</param>
+        /// <param name="arg4">The fourth argument</param>
+        /// <param name="arg5">The fifth argument</param>
+        /// <param name="arg6">The sixth argument</param>
+        /// <param name="arg7">The seventh argument</param>
+        /// <param name="arg8">The eigth argument</param>
+        /// <returns>A task that represents when the data has been sent to the client.</returns>
+        public static Task InvokeAsync(this IClientProxy clientProxy, string method, object arg1, object arg2, object arg3, object arg4, object arg5, object arg6, object arg7, object arg8)
+        {
+            return clientProxy.InvokeAsync(method, new object[] { arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8 });
+        }
+
+        /// <summary>
+        /// Invokes a method on the connection(s) represented by the <see cref="IClientProxy"/> instance.
+        /// </summary>
+        /// <param name="clientProxy">The <see cref="IClientProxy"/></param>
+        /// <param name="method">name of the method to invoke</param>
+        /// <param name="arg1">The first argument</param>
+        /// <param name="arg2">The second argument</param>
+        /// <param name="arg3">The third argument</param>
+        /// <param name="arg4">The fourth argument</param>
+        /// <param name="arg5">The fifth argument</param>
+        /// <param name="arg6">The sixth argument</param>
+        /// <param name="arg7">The seventh argument</param>
+        /// <param name="arg8">The eigth argument</param>
+        /// <param name="arg9">The ninth argument</param>
+        /// <returns>A task that represents when the data has been sent to the client.</returns>
+        public static Task InvokeAsync(this IClientProxy clientProxy, string method, object arg1, object arg2, object arg3, object arg4, object arg5, object arg6, object arg7, object arg8, object arg9)
+        {
+            return clientProxy.InvokeAsync(method, new object[] { arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9 });
+        }
+
+        /// <summary>
+        /// Invokes a method on the connection(s) represented by the <see cref="IClientProxy"/> instance.
+        /// </summary>
+        /// <param name="clientProxy">The <see cref="IClientProxy"/></param>
+        /// <param name="method">name of the method to invoke</param>
+        /// <param name="arg1">The first argument</param>
+        /// <param name="arg2">The second argument</param>
+        /// <param name="arg3">The third argument</param>
+        /// <param name="arg4">The fourth argument</param>
+        /// <param name="arg5">The fifth argument</param>
+        /// <param name="arg6">The sixth argument</param>
+        /// <param name="arg7">The seventh argument</param>
+        /// <param name="arg8">The eigth argument</param>
+        /// <param name="arg9">The ninth argument</param>
+        /// <param name="arg10">The ninth argument</param>
+        /// <returns>A task that represents when the data has been sent to the client.</returns>
+        public static Task InvokeAsync(this IClientProxy clientProxy, string method, object arg1, object arg2, object arg3, object arg4, object arg5, object arg6, object arg7, object arg8, object arg9, object arg10)
+        {
+            return clientProxy.InvokeAsync(method, new object[] { arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10 });
+        }
+    }
+}


### PR DESCRIPTION
- This allows passing arrays without having to explicitly ToArray() or AsEnumerable()
- Added overloads up to 10 arguments
- Added tests