### PR TITLE
Fixing JS end-to-end tests

### DIFF
--- a/client-ts/Microsoft.AspNetCore.SignalR.Test.Server/wwwroot/js/hubConnectionTests.js
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Test.Server/wwwroot/js/hubConnectionTests.js
@@ -46,15 +46,8 @@ describe('hubConnection', function () {
                 var hubConnection = new signalR.HubConnection(TESTHUBENDPOINT_URL, options);
 
                 hubConnection.on('CustomObject', function (customObject) {
-                    // messageapack does not have a setting to use camelCasing
-                    if (protocol.name == 'messagepack') {
-                        expect(customObject.Name).toBe('test');
-                        expect(customObject.Value).toBe(42);
-                    }
-                    else {
-                        expect(customObject.name).toBe('test');
-                        expect(customObject.value).toBe(42);
-                    }
+                    expect(customObject.Name).toBe('test');
+                    expect(customObject.Value).toBe(42);
                     hubConnection.stop();
                 });
 


### PR DESCRIPTION
In one of the [previous commits](https://github.com/aspnet/SignalR/commit/70df19c8a27f88d1d68ef13a293e1b06abb25a9e#diff-fafe51a9878a334f3cd66cd770c3f9e7R19) I changed the contract resolver for JSON protocol to be the DefaultContractResolver (as opposed to the default CamelCasePropertyNamesContractResolver). This was done in the rel branch and broke some new tests in the dev branch after merging rel.