### PR TITLE
Fix the VarInt example for the 2GiB

### DIFF
--- a/specs/HubProtocol.md
+++ b/specs/HubProtocol.md
@@ -612,7 +612,7 @@ Examples:
  * VarInt: `0x35` (`%00110101`) - the most significant bit is 0 so the value is %x0110101 i.e. 0x35 (53)
  * VarInt: `0x80 0x25` (`%10000000 %00101001`) - the most significant bit of the first byte is 1 so the remaining bits (%x0000000) are the lowest bits of the value. The most significant bit of the second byte is 0 meaning this is last byte of the VarInt. The actual value bits (%x0101001) need to be prepended to the bits we already read so the values is %01010010000000 i.e. 0x1480 (5248)
 
-The biggest supported payloads are 2GB in size so the biggest number we need to support is 0x7fffffff which when encoded as VarInt is 0xFF 0xFF 0xFF 0xFF 0x7F - hence the maximum size of the length prefix is 5 bytes.
+The biggest supported payloads are 2GB in size so the biggest number we need to support is 0x7fffffff which when encoded as VarInt is 0xFF 0xFF 0xFF 0xFF 0x07 - hence the maximum size of the length prefix is 5 bytes.
 
 For example, when sending the following frames (`\n` indicates the actual Line Feed character, not an escape sequence):
 

--- a/src/Microsoft.AspNetCore.SignalR.Common/Internal/Formatters/BinaryMessageParser.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Common/Internal/Formatters/BinaryMessageParser.cs
@@ -29,7 +29,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Formatters
             // byte is 0 meaning this is last byte of the VarInt. The actual value bits (%x0101001) need to be
             // prepended to the bits we already read so the values is %01010010000000 i.e. 0x1480 (5248)
             // We support paylads up to 2GB so the biggest number we support is 7fffffff which when encoded as
-            // VarInt is 0xFF 0xFF 0xFF 0xFF 0x7F - hence the maximum length prefix is 5 bytes.
+            // VarInt is 0xFF 0xFF 0xFF 0xFF 0x07 - hence the maximum length prefix is 5 bytes.
 
             var length = 0U;
             var numBytes = 0;


### PR DESCRIPTION
`0x7fffffff` has 31 binary ones. The first four bytes of the VarInt account for 4*7=28, so the fifth byte only needs the remaining three