### PR TITLE
[Redis] Remove groups properly from connection disconnection

### DIFF
--- a/src/Microsoft.AspNetCore.SignalR.Redis/RedisHubLifetimeManager.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Redis/RedisHubLifetimeManager.cs
@@ -122,7 +122,7 @@ namespace Microsoft.AspNetCore.SignalR.Redis
                 if (groupMessage.Action == GroupAction.Remove)
                 {
                     var connection = _connections[groupMessage.ConnectionId];
-                    if (connection != null && !await RemoveGroupAsyncCore(connection, groupMessage.Group))
+                    if (connection == null || !await RemoveGroupAsyncCore(connection, groupMessage.Group))
                     {
                         // user not on this server
                         return;

--- a/src/Microsoft.AspNetCore.SignalR.Redis/RedisHubLifetimeManager.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Redis/RedisHubLifetimeManager.cs
@@ -275,7 +275,7 @@ namespace Microsoft.AspNetCore.SignalR.Redis
             return Task.WhenAll(connectionTask, userTask);
         }
 
-        public override async Task OnDisconnectedAsync(HubConnectionContext connection)
+        public override Task OnDisconnectedAsync(HubConnectionContext connection)
         {
             _connections.Remove(connection);
 
@@ -307,7 +307,7 @@ namespace Microsoft.AspNetCore.SignalR.Redis
                 }
             }
 
-            await Task.WhenAll(tasks);
+            return Task.WhenAll(tasks);
         }
 
         public override async Task AddGroupAsync(string connectionId, string groupName)

--- a/src/Microsoft.AspNetCore.SignalR.Redis/RedisHubLifetimeManager.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Redis/RedisHubLifetimeManager.cs
@@ -122,7 +122,7 @@ namespace Microsoft.AspNetCore.SignalR.Redis
                 if (groupMessage.Action == GroupAction.Remove)
                 {
                     var connection = _connections[groupMessage.ConnectionId];
-                    if (connection == null || !await RemoveGroupAsyncCore(connection, groupMessage.Group))
+                    if (connection == null || !(await RemoveGroupAsyncCore(connection, groupMessage.Group)))
                     {
                         // user not on this server
                         return;


### PR DESCRIPTION
Before we would remove the connection from the `_connections` list which would prevent `RemoveGroupAsync` from removing the group locally and cause it to send a message to other servers which would make `OnDisconnectedAsync` wait for 30 seconds for an ACK it would never receive. And then `OnDisconnectedAsync` would throw a `TaskCanceledException`. The reason I didn't move the `_connections.Remove(connection);` to the end of `OnDisconnectedAsync` is to prevent groups being added to the connection while it is clearing out groups.