### PR TITLE
Removing sending OPTIONS request if WebSocket transport requested

### DIFF
--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/DefaultTransportFactory.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/DefaultTransportFactory.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNetCore.Sockets.Client
                 throw new ArgumentOutOfRangeException(nameof(requestedTransportType));
             }
 
-            if (httpClient == null)
+            if (httpClient == null && requestedTransportType != TransportType.WebSockets)
             {
                 throw new ArgumentNullException(nameof(httpClient));
             }

--- a/test/Microsoft.AspNetCore.SignalR.Tests/DefaultTransportFactoryTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/DefaultTransportFactoryTests.cs
@@ -23,13 +23,24 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                 () => new DefaultTransportFactory(transportType, new LoggerFactory(), new HttpClient()));
         }
 
-        [Fact]
-        public void DefaultTransportFactoryCannotBeCreatedWithoutHttpClient()
+        [Theory]
+        [InlineData(TransportType.All)]
+        [InlineData(TransportType.LongPolling)]
+        [InlineData(TransportType.ServerSentEvents)]
+        [InlineData(TransportType.LongPolling | TransportType.WebSockets)]
+        [InlineData(TransportType.ServerSentEvents | TransportType.WebSockets)]
+        public void DefaultTransportFactoryCannotBeCreatedWithoutHttpClient(TransportType transportType)
         {
             var exception = Assert.Throws<ArgumentNullException>(
-                () => new DefaultTransportFactory(TransportType.All, new LoggerFactory(), httpClient: null));
+                () => new DefaultTransportFactory(transportType, new LoggerFactory(), httpClient: null));
 
             Assert.Equal("httpClient", exception.ParamName);
+        }
+
+        [Fact]
+        public void DefaultTransportFactoryCanBeCreatedWithoutHttpClientIfWebSocketsTransportRequestedExplicitly()
+        {
+            new DefaultTransportFactory(TransportType.WebSockets, new LoggerFactory(), httpClient: null);
         }
 
         [ConditionalTheory]

--- a/test/Microsoft.AspNetCore.SignalR.Tests/EndToEndTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/EndToEndTests.cs
@@ -18,6 +18,8 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Testing;
 using Xunit;
 using Xunit.Abstractions;
+using Moq;
+using Moq.Protected;
 
 namespace Microsoft.AspNetCore.SignalR.Tests
 {
@@ -93,6 +95,54 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                     logger.LogInformation("Closing socket");
                     await ws.CloseAsync(WebSocketCloseStatus.Empty, "", CancellationToken.None).OrTimeout();
                     logger.LogInformation("Closed socket");
+                }
+            }
+        }
+
+        [ConditionalFact]
+        [OSSkipCondition(OperatingSystems.Windows, WindowsVersions.Win7, WindowsVersions.Win2008R2, SkipReason = "No WebSockets Client for this platform")]
+        public async Task HTTPRequestsNotSentWhenWebSocketsTransportRequested()
+        {
+            using (StartLog(out var loggerFactory, testName: $"HTTPRequestsNotSentWhenWebSocketsTransportRequested"))
+            {
+                var logger = loggerFactory.CreateLogger<EndToEndTests>();
+                var url = _serverFixture.BaseUrl + "/echo";
+
+                var mockHttpHandler = new Mock<HttpMessageHandler>();
+                mockHttpHandler.Protected()
+                    .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                    .Returns<HttpRequestMessage, CancellationToken>(
+                        (request, cancellationToken) => Task.FromException<HttpResponseMessage>(new InvalidOperationException("HTTP requests should not be sent.")));
+
+                var connection = new HttpConnection(new Uri(url), TransportType.WebSockets, loggerFactory, mockHttpHandler.Object);
+
+                try
+                {
+                    var receiveTcs = new TaskCompletionSource<byte[]>();
+                    connection.OnReceived((data, state) =>
+                    {
+                        var tcs = (TaskCompletionSource<byte[]>)state;
+                        tcs.TrySetResult(data);
+                        return Task.CompletedTask;
+                    }, receiveTcs);
+
+                    var message = new byte[] { 42 };
+                    await connection.StartAsync().OrTimeout();
+                    await connection.SendAsync(message).OrTimeout();
+
+                    var receivedData = await receiveTcs.Task.OrTimeout();
+                    Assert.Equal(message, receivedData);
+                }
+                catch (Exception ex)
+                {
+                    logger.LogInformation(ex, "Test threw exception");
+                    throw;
+                }
+                finally
+                {
+                    logger.LogInformation("Disposing Connection");
+                    await connection.DisposeAsync().OrTimeout();
+                    logger.LogInformation("Disposed Connection");
                 }
             }
         }

--- a/test/Microsoft.AspNetCore.SignalR.Tests/EndToEndTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/EndToEndTests.cs
@@ -11,15 +11,15 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR.Client;
 using Microsoft.AspNetCore.SignalR.Tests.Common;
 using Microsoft.AspNetCore.Sockets;
-using Microsoft.AspNetCore.Sockets.Features;
 using Microsoft.AspNetCore.Sockets.Client;
+using Microsoft.AspNetCore.Sockets.Features;
 using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Testing;
-using Xunit;
-using Xunit.Abstractions;
 using Moq;
 using Moq.Protected;
+using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.AspNetCore.SignalR.Tests
 {
@@ -103,7 +103,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
         [OSSkipCondition(OperatingSystems.Windows, WindowsVersions.Win7, WindowsVersions.Win2008R2, SkipReason = "No WebSockets Client for this platform")]
         public async Task HTTPRequestsNotSentWhenWebSocketsTransportRequested()
         {
-            using (StartLog(out var loggerFactory, testName: $"HTTPRequestsNotSentWhenWebSocketsTransportRequested"))
+            using (StartLog(out var loggerFactory, testName: nameof(HTTPRequestsNotSentWhenWebSocketsTransportRequested)))
             {
                 var logger = loggerFactory.CreateLogger<EndToEndTests>();
                 var url = _serverFixture.BaseUrl + "/echo";


### PR DESCRIPTION
This removes session stickiness requirement for WebSockets

Fixes: #1035