### PR TITLE
Enable reconnect for Redis connection by default

### DIFF
--- a/src/Microsoft.AspNetCore.SignalR.Redis/Internal/RedisLoggerExtensions.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Redis/Internal/RedisLoggerExtensions.cs
@@ -32,6 +32,12 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Internal
         private static readonly Action<ILogger, Exception> _notConnected =
             LoggerMessage.Define(LogLevel.Warning, new EventId(6, nameof(Connected)), "Not connected to Redis.");
 
+        private static readonly Action<ILogger, Exception> _connectionRestored =
+            LoggerMessage.Define(LogLevel.Information, new EventId(7, nameof(ConnectionRestored)), "Connection to Redis restored.");
+
+        private static readonly Action<ILogger, Exception> _connectionFailed =
+            LoggerMessage.Define(LogLevel.Warning, new EventId(8, nameof(ConnectionFailed)), "Connection to Redis failed.");
+
         public static void ConnectingToEndpoints(this ILogger logger, EndPointCollection endpoints)
         {
             if (logger.IsEnabled(LogLevel.Information))
@@ -68,6 +74,16 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Internal
         public static void NotConnected(this ILogger logger)
         {
             _notConnected(logger, null);
+        }
+
+        public static void ConnectionRestored(this ILogger logger)
+        {
+            _connectionRestored(logger, null);
+        }
+
+        public static void ConnectionFailed(this ILogger logger, Exception exception)
+        {
+            _connectionFailed(logger, exception);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.SignalR.Redis/Internal/RedisLoggerExtensions.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Redis/Internal/RedisLoggerExtensions.cs
@@ -2,7 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
 using Microsoft.Extensions.Logging;
+using StackExchange.Redis;
 
 namespace Microsoft.AspNetCore.SignalR.Redis.Internal
 {
@@ -27,9 +29,15 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Internal
         private static readonly Action<ILogger, string, Exception> _unsubscribe =
             LoggerMessage.Define<string>(LogLevel.Trace, new EventId(5, nameof(Unsubscribe)), "Unsubscribing from channel: {channel}.");
 
-        public static void ConnectingToEndpoints(this ILogger logger, string endpoints)
+        private static readonly Action<ILogger, Exception> _notConnected =
+            LoggerMessage.Define(LogLevel.Warning, new EventId(6, nameof(Connected)), "Not connected to Redis.");
+
+        public static void ConnectingToEndpoints(this ILogger logger, EndPointCollection endpoints)
         {
-            _connectingToEndpoints(logger, endpoints, null);
+            if (logger.IsEnabled(LogLevel.Information))
+            {
+                _connectingToEndpoints(logger, string.Join(", ", endpoints.Select(e => EndPointCollection.ToString(e))), null);
+            }
         }
 
         public static void Connected(this ILogger logger)
@@ -55,6 +63,11 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Internal
         public static void Unsubscribe(this ILogger logger, string channelName)
         {
             _unsubscribe(logger, channelName, null);
+        }
+
+        public static void NotConnected(this ILogger logger)
+        {
+            _notConnected(logger, null);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.SignalR.Redis/Internal/RedisLoggerExtensions.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Redis/Internal/RedisLoggerExtensions.cs
@@ -42,7 +42,10 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Internal
         {
             if (logger.IsEnabled(LogLevel.Information))
             {
-                _connectingToEndpoints(logger, string.Join(", ", endpoints.Select(e => EndPointCollection.ToString(e))), null);
+                if (endpoints.Count > 0)
+                {
+                    _connectingToEndpoints(logger, string.Join(", ", endpoints.Select(e => EndPointCollection.ToString(e))), null);
+                }
             }
         }
 

--- a/src/Microsoft.AspNetCore.SignalR.Redis/RedisHubLifetimeManager.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Redis/RedisHubLifetimeManager.cs
@@ -51,7 +51,7 @@ namespace Microsoft.AspNetCore.SignalR.Redis
             _ackHandler = new AckHandler();
 
             var writer = new LoggerTextWriter(logger);
-            _logger.ConnectingToEndpoints(string.Join(", ", options.Value.Options.EndPoints.Select(e => EndPointCollection.ToString(e))));
+            _logger.ConnectingToEndpoints(options.Value.Options.EndPoints);
             _redisServerConnection = _options.Connect(writer);
 
             _redisServerConnection.ConnectionRestored += (_, e) =>
@@ -72,7 +72,7 @@ namespace Microsoft.AspNetCore.SignalR.Redis
             }
             else
             {
-                _logger.LogWarning("Not connected to redis.");
+                _logger.NotConnected();
             }
             _bus = _redisServerConnection.GetSubscriber();
 

--- a/src/Microsoft.AspNetCore.SignalR.Redis/RedisOptions.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Redis/RedisOptions.cs
@@ -10,7 +10,11 @@ namespace Microsoft.AspNetCore.SignalR.Redis
 {
     public class RedisOptions
     {
-        public ConfigurationOptions Options { get; set; } = new ConfigurationOptions();
+        public ConfigurationOptions Options { get; set; } = new ConfigurationOptions()
+        {
+            // Enable reconnecting by default
+            AbortOnConnectFail = false
+        };
 
         public Func<TextWriter, IConnectionMultiplexer> Factory { get; set; }
 
@@ -25,6 +29,7 @@ namespace Microsoft.AspNetCore.SignalR.Redis
                     Options.EndPoints.Add(IPAddress.Loopback, 0);
                     Options.SetDefaultPorts();
                 }
+
                 return ConnectionMultiplexer.Connect(Options, log);
             }
 

--- a/src/Microsoft.AspNetCore.SignalR.Redis/RedisOptions.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Redis/RedisOptions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.SignalR.Redis
 {
     public class RedisOptions
     {
-        public ConfigurationOptions Options { get; set; } = new ConfigurationOptions()
+        public ConfigurationOptions Options { get; set; } = new ConfigurationOptions
         {
             // Enable reconnecting by default
             AbortOnConnectFail = false


### PR DESCRIPTION
For now if you try to send when the redis connection is down you'll get something like:
```
Error: No connection is available to service this operation:
PUBLISH ChatSample.Hubs.Chat; SocketFailure on 127.0.0.1:6379/Subscription,
origin: Error, input-buffer: 0, outstanding: 0, last-read: 1s ago, last-write: 1s ago,
unanswered-write: 21077s ago, keep-alive: 60s, pending: 0, state: Connecting,
last-heartbeat: never, last-mbeat: -1s ago, global: 1s ago
```
and we won't keep a queue or anything around.

We'll probably want to change the error returned in the future.