### PR TITLE
Specify NodeJS as a required toolset to build this repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ npm install @aspnet/signalr-client --registry https://dotnet.myget.org/f/aspnetc
 
 ## Building from source
 
-To run a complete build on command line only, execute `build.cmd` or `build.sh` without arguments. The build requires NodeJS (8.0 or newer) and npm to be installed on the machine.
+To run a complete build on command line only, execute `build.cmd` or `build.sh` without arguments. The build requires NodeJS (6.9 or newer) and npm to be installed on the machine.
 
 Before opening this project in Visual Studio or VS Code, execute `build.cmd /t:Restore` (Windows) or `./build.sh /t:Restore` (Linux/macOS).
 This will execute only the part of the build script that downloads and initializes a few required build tools and packages.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ npm install @aspnet/signalr-client --registry https://dotnet.myget.org/f/aspnetc
 
 ## Building from source
 
-To run a complete build on command line only, execute `build.cmd` or `build.sh` without arguments. The build requires NodeJS (6.11 or newer) and npm to be installed on the machine.
+To run a complete build on command line only, execute `build.cmd` or `build.sh` without arguments. The build requires NodeJS (8.0 or newer) and npm to be installed on the machine.
 
 Before opening this project in Visual Studio or VS Code, execute `build.cmd /t:Restore` (Windows) or `./build.sh /t:Restore` (Linux/macOS).
 This will execute only the part of the build script that downloads and initializes a few required build tools and packages.

--- a/korebuild.json
+++ b/korebuild.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://raw.githubusercontent.com/aspnet/BuildTools/dev/tools/korebuild.schema.json",
+  "channel": "dev",
+  "toolsets": {
+    "nodejs": {
+      "required": true,
+      "minVersion": "8.0"
+    }
+  }
+}

--- a/korebuild.json
+++ b/korebuild.json
@@ -4,7 +4,7 @@
   "toolsets": {
     "nodejs": {
       "required": true,
-      "minVersion": "8.0"
+      "minVersion": "6.9"
     }
   }
 }


### PR DESCRIPTION
Fails the build early if NodeJS is not available on the machine or is too old.

cref https://github.com/aspnet/BuildTools/pull/448