### PR TITLE
Adding roundtripping test for GUID property

### DIFF
--- a/client-ts/Microsoft.AspNetCore.SignalR.Test.Server/ComplexObject.cs
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Test.Server/ComplexObject.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+
 namespace Microsoft.AspNetCore.SignalR.Test.Server
 {
     public class ComplexObject
@@ -8,5 +10,6 @@ namespace Microsoft.AspNetCore.SignalR.Test.Server
         public string String { get; set; }
         public int[] IntArray { get; set; }
         public byte[] ByteArray { get; set; }
+        public Guid GUID { get; set; }
     }
 }


### PR DESCRIPTION
This test is just a result of my investigation of using GUID properties with msgpack. My conclusion is that - when using MsgPack - if GUIDs are to be sent from the server to the client that it will be much easier just to use byte arrays, otherwise, due to ambiguity of the protocol, GUID bytes are encoded using UTF8 rules and the user gets a string that is pretty much useless. In the test I avoided this by using values smaller than 0x80 but you cannot do anything like this in reality. Sending from the client to server works fine. This test is supposed to sanction the current behavior. 