### PR TITLE
[Redis] Reorder some code to make it less spaghetti

### DIFF
--- a/src/Microsoft.AspNetCore.SignalR.Redis/RedisHubLifetimeManager.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Redis/RedisHubLifetimeManager.cs
@@ -88,7 +88,7 @@ namespace Microsoft.AspNetCore.SignalR.Redis
             }
             _bus = _redisServerConnection.GetSubscriber();
 
-            SubscribeToBroadcast();
+            SubscribeToHub();
             SubscribeToAllExcept();
             SubscribeToInternalGroup();
             SubscribeToInternalServerName();
@@ -395,7 +395,7 @@ namespace Microsoft.AspNetCore.SignalR.Redis
             }
         }
 
-        private void SubscribeToBroadcast()
+        private void SubscribeToHub()
         {
             _logger.Subscribing(_channelNamePrefix);
             _bus.Subscribe(_channelNamePrefix, async (c, data) =>


### PR DESCRIPTION
- Pulled out subscriptions to separate functions
- Moved `OnConnectedAsync` and `OnDisconnectedAsync` to be right after the constructor
- WriteAsync is now static