### PR TITLE
Hubconnection Disposables

### DIFF
--- a/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.cs
@@ -126,6 +126,8 @@ namespace Microsoft.AspNetCore.SignalR.Client
         private async Task DisposeAsyncCore()
         {
             await _connection.DisposeAsync();
+            _connectionActive?.Dispose();
+            _loggerFactory?.Dispose();
         }
 
         // TODO: Client return values/tasks?


### PR DESCRIPTION
Added ILoggerFactory and CancellationTokenSource to DisposeAsync
However ILoggerFactory should not be disposed if Hubconnectionbuilder was not used to instantiate Hubconnection.