### PR TITLE
Change negotiate to POST

### DIFF
--- a/client-ts/Microsoft.AspNetCore.SignalR.Client.TS.Tests/Common.ts
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Client.TS.Tests/Common.ts
@@ -10,3 +10,14 @@ export function eachTransport(action: (transport: TransportType) => void) {
         TransportType.LongPolling ];
     transportTypes.forEach(t => action(t));
 };
+
+export function eachEndpointUrl(action: (givenUrl: string, expectedUrl: string) => void) {
+    let urls = [
+        [ "http://tempuri.org/endpoint/?q=my/Data", "http://tempuri.org/endpoint/negotiate?q=my/Data" ],
+        [ "http://tempuri.org/endpoint?q=my/Data", "http://tempuri.org/endpoint/negotiate?q=my/Data" ],
+        [ "http://tempuri.org/endpoint", "http://tempuri.org/endpoint/negotiate" ],
+        [ "http://tempuri.org/endpoint/", "http://tempuri.org/endpoint/negotiate" ]
+    ];
+
+    urls.forEach(t => action(t[0], t[1]));
+}

--- a/client-ts/Microsoft.AspNetCore.SignalR.Client.TS.Tests/Connection.spec.ts
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Client.TS.Tests/Connection.spec.ts
@@ -212,7 +212,7 @@ describe("Connection", () => {
 
         it("preserves user query with / before query", async done =>
         {
-            connection = new HttpConnection("http://tempuri.org/endpoint/?q=myData", options);
+            connection = new HttpConnection("http://tempuri.org/endpoint/?q=my/Data", options);
 
             try {
                 await connection.start();
@@ -223,11 +223,11 @@ describe("Connection", () => {
                 done();
             }
 
-            expect(negotiateUrl).toBe("http://tempuri.org/endpoint/negotiate?q=myData");
+            expect(negotiateUrl).toBe("http://tempuri.org/endpoint/negotiate?q=my/Data");
         });
 
         it("preserves user query without / before query", async done => {
-            connection = new HttpConnection("http://tempuri.org/endpoint?q=myData", options);
+            connection = new HttpConnection("http://tempuri.org/endpoint?q=my/Data", options);
 
             try {
                 await connection.start();
@@ -238,7 +238,7 @@ describe("Connection", () => {
                 done();
             }
 
-            expect(negotiateUrl).toBe("http://tempuri.org/endpoint/negotiate?q=myData");
+            expect(negotiateUrl).toBe("http://tempuri.org/endpoint/negotiate?q=my/Data");
         });
 
         it("adds negotiate after path without /", async done => {
@@ -270,35 +270,6 @@ describe("Connection", () => {
 
             expect(negotiateUrl).toBe("http://tempuri.org/endpoint/negotiate");
         });
-    });
-
-    it("preserves users connection string in negotiate request", async done => {
-        let options: IHttpConnectionOptions = {
-            httpClient: <IHttpClient>{
-                post(url: string): Promise<string> {
-                    expect(url).toBe("http://tempuri.org/negotiate?q=myData");
-                    connection.stop();
-                    return Promise.resolve("{}");
-                },
-                get(url: string): Promise<string> {
-                    connection.stop();
-                    return Promise.resolve("");
-                }
-            },
-            logging: null
-        } as IHttpConnectionOptions;
-
-
-        let connection = new HttpConnection("http://tempuri.org?q=myData", options);
-
-        try {
-            await connection.start();
-            done();
-        }
-        catch (e) {
-            fail();
-            done();
-        }
     });
 
     eachTransport((requestedTransport: TransportType) => {

--- a/client-ts/Microsoft.AspNetCore.SignalR.Client.TS.Tests/Connection.spec.ts
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Client.TS.Tests/Connection.spec.ts
@@ -24,7 +24,7 @@ describe("Connection", () => {
     it("starting connection fails if getting id fails", async (done) => {
         let options: IHttpConnectionOptions = {
             httpClient: <IHttpClient>{
-                options(url: string): Promise<string> {
+                post(url: string): Promise<string> {
                     return Promise.reject("error");
                 },
                 get(url: string): Promise<string> {
@@ -50,7 +50,7 @@ describe("Connection", () => {
     it("cannot start a running connection", async (done) => {
         let options: IHttpConnectionOptions = {
             httpClient: <IHttpClient>{
-                options(url: string): Promise<string> {
+                post(url: string): Promise<string> {
                     connection.start()
                         .then(() => {
                             fail();
@@ -84,7 +84,7 @@ describe("Connection", () => {
     it("cannot start a stopped connection", async (done) => {
         let options: IHttpConnectionOptions = {
             httpClient: <IHttpClient>{
-                options(url: string): Promise<string> {
+                post(url: string): Promise<string> {
                     return Promise.reject("error");
                 },
                 get(url: string): Promise<string> {
@@ -118,7 +118,7 @@ describe("Connection", () => {
     it("can stop a starting connection", async (done) => {
         let options: IHttpConnectionOptions = {
             httpClient: <IHttpClient>{
-                options(url: string): Promise<string> {
+                post(url: string): Promise<string> {
                     connection.stop();
                     return Promise.resolve("{}");
                 },
@@ -165,7 +165,7 @@ describe("Connection", () => {
 
         let options: IHttpConnectionOptions = {
             httpClient: <IHttpClient>{
-                options(url: string): Promise<string> {
+                post(url: string): Promise<string> {
                     return Promise.resolve("{ \"connectionId\": \"42\" }");
                 },
                 get(url: string): Promise<string> {
@@ -199,7 +199,7 @@ describe("Connection", () => {
         it(`cannot be started if requested ${TransportType[requestedTransport]} transport not available on server`, async done => {
             let options: IHttpConnectionOptions = {
                 httpClient: <IHttpClient>{
-                    options(url: string): Promise<string> {
+                    post(url: string): Promise<string> {
                         return Promise.resolve("{ \"connectionId\": \"42\", \"availableTransports\": [] }");
                     },
                     get(url: string): Promise<string> {
@@ -226,7 +226,7 @@ describe("Connection", () => {
     it("cannot be started if no transport available on server and no transport requested", async done => {
         let options: IHttpConnectionOptions = {
             httpClient: <IHttpClient>{
-                options(url: string): Promise<string> {
+                post(url: string): Promise<string> {
                     return Promise.resolve("{ \"connectionId\": \"42\", \"availableTransports\": [] }");
                 },
                 get(url: string): Promise<string> {
@@ -251,7 +251,7 @@ describe("Connection", () => {
     it('does not send OPTIONS request if WebSockets transport requested explicitly', async done => {
         let options: IHttpConnectionOptions = {
             httpClient: <IHttpClient>{
-                options(url: string): Promise<string> {
+                post(url: string): Promise<string> {
                     return Promise.reject("Should not be called");
                 },
                 get(url: string): Promise<string> {
@@ -295,7 +295,7 @@ describe("Connection", () => {
 
             let options: IHttpConnectionOptions = {
                 httpClient: <IHttpClient>{
-                    options(url: string): Promise<string> {
+                    post(url: string): Promise<string> {
                         return Promise.resolve("{ \"connectionId\": \"42\", \"availableTransports\": [] }");
                     },
                     get(url: string): Promise<string> {

--- a/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/HttpClient.ts
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/HttpClient.ts
@@ -5,17 +5,12 @@ import { HttpError } from "./HttpError"
 
 export interface IHttpClient {
     get(url: string, headers?: Map<string, string>): Promise<string>;
-    options(url: string, headers?: Map<string, string>): Promise<string>;
     post(url: string, content: string, headers?: Map<string, string>): Promise<string>;
 }
 
 export class HttpClient implements IHttpClient {
     get(url: string, headers?: Map<string, string>): Promise<string> {
         return this.xhr("GET", url, headers);
-    }
-
-    options(url: string, headers?: Map<string, string>): Promise<string> {
-        return this.xhr("OPTIONS", url, headers);
     }
 
     post(url: string, content: string, headers?: Map<string, string>): Promise<string> {

--- a/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/HttpConnection.ts
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/HttpConnection.ts
@@ -59,7 +59,7 @@ export class HttpConnection implements IConnection {
                 this.transport = this.createTransport(this.options.transport, [TransportType[TransportType.WebSockets]]);
             }
             else {
-                let negotiatePayload = await this.httpClient.options(this.url);
+                let negotiatePayload = await this.httpClient.post(this.resolveNegotiateUrl(this.url), "");
                 let negotiateResponse: INegotiateResponse = JSON.parse(negotiatePayload);
                 this.connectionId = negotiateResponse.connectionId;
 
@@ -187,6 +187,17 @@ export class HttpConnection implements IConnection {
         let normalizedUrl = baseUrl + url;
         this.logger.log(LogLevel.Information, `Normalizing '${url}' to '${normalizedUrl}'`);
         return normalizedUrl;
+    }
+
+    private resolveNegotiateUrl(url: string): string {
+        let index = url.indexOf("?");
+        let negotiateUrl = this.url.substring(0, index == -1 ? url.length : index);
+        if (!negotiateUrl.endsWith('/')) {
+            negotiateUrl += '/';
+        }
+        negotiateUrl += "negotiate";
+        negotiateUrl += index == -1 ? "" : url.substring(index);
+        return negotiateUrl;
     }
 
     onreceive: DataReceived;

--- a/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/HttpConnection.ts
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/HttpConnection.ts
@@ -69,7 +69,7 @@ export class HttpConnection implements IConnection {
                 }
 
                 if (this.connectionId) {
-                    this.url += (this.url.indexOf("?") == -1 ? "?" : "&") + `id=${this.connectionId}`;
+                    this.url += (this.url.indexOf("?") === -1 ? "?" : "&") + `id=${this.connectionId}`;
                     this.transport = this.createTransport(this.options.transport, negotiateResponse.availableTransports);
                 }
             }

--- a/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/HttpConnection.ts
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/HttpConnection.ts
@@ -191,12 +191,12 @@ export class HttpConnection implements IConnection {
 
     private resolveNegotiateUrl(url: string): string {
         let index = url.indexOf("?");
-        let negotiateUrl = this.url.substring(0, index == -1 ? url.length : index);
-        if (negotiateUrl[negotiateUrl.length - 1] !== '/') {
-            negotiateUrl += '/';
+        let negotiateUrl = this.url.substring(0, index === -1 ? url.length : index);
+        if (negotiateUrl[negotiateUrl.length - 1] !== "/") {
+            negotiateUrl += "/";
         }
         negotiateUrl += "negotiate";
-        negotiateUrl += index == -1 ? "" : url.substring(index);
+        negotiateUrl += index === -1 ? "" : url.substring(index);
         return negotiateUrl;
     }
 

--- a/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/HttpConnection.ts
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/HttpConnection.ts
@@ -192,7 +192,7 @@ export class HttpConnection implements IConnection {
     private resolveNegotiateUrl(url: string): string {
         let index = url.indexOf("?");
         let negotiateUrl = this.url.substring(0, index == -1 ? url.length : index);
-        if (!negotiateUrl.endsWith('/')) {
+        if (negotiateUrl[negotiateUrl.length - 1] !== '/') {
             negotiateUrl += '/';
         }
         negotiateUrl += "negotiate";

--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/HttpConnection.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/HttpConnection.cs
@@ -220,7 +220,14 @@ namespace Microsoft.AspNetCore.Sockets.Client
             {
                 // Get a connection ID from the server
                 logger.EstablishingConnection(url);
-                using (var request = new HttpRequestMessage(HttpMethod.Options, url))
+                var urlBuilder = new UriBuilder(url);
+                if (!urlBuilder.Path.EndsWith("/"))
+                {
+                    urlBuilder.Path += "/";
+                }
+                urlBuilder.Path += "negotiate";
+
+                using (var request = new HttpRequestMessage(HttpMethod.Post, urlBuilder.Uri))
                 {
                     request.Headers.UserAgent.Add(Constants.UserAgentHeader);
                     using (var response = await httpClient.SendAsync(request))

--- a/src/Microsoft.AspNetCore.Sockets.Http/HttpConnectionDispatcher.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Http/HttpConnectionDispatcher.cs
@@ -60,10 +60,8 @@ namespace Microsoft.AspNetCore.Sockets
 
         public async Task ExecuteNegotiateAsync(HttpContext context, HttpSocketOptions options)
         {
-            // Create the log scope and attempt to pass the Connection ID to it so as many logs as possible contain
-            // the Connection ID metadata. If this is the negotiate request then the Connection ID for the scope will
-            // be set a little later.
-            var logScope = new ConnectionLogScope(GetConnectionId(context));
+            // Create the log scope and the scope connectionId param will be set when the connection is created.
+            var logScope = new ConnectionLogScope(connectionId: string.Empty);
             using (_logger.BeginScope(logScope))
             {
                 if (!await AuthorizeHelper.AuthorizeAsync(context, options.AuthorizationData))

--- a/src/Microsoft.AspNetCore.Sockets.Http/SocketRouteBuilder.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Http/SocketRouteBuilder.cs
@@ -28,6 +28,7 @@ namespace Microsoft.AspNetCore.Sockets
             socketConfig(socketBuilder);
             var socket = socketBuilder.Build();
             _routes.MapRoute(path, c => _dispatcher.ExecuteAsync(c, options, socket));
+            _routes.MapRoute(path + "/negotiate", c => _dispatcher.ExecuteNegotiateAsync(c, options));
         }
 
         public void MapEndPoint<TEndPoint>(string path) where TEndPoint : EndPoint

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.cs
@@ -53,7 +53,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
                 {
                     await Task.Yield();
 
-                    return request.Method == HttpMethod.Options
+                    return IsNegotiateRequest(request)
                         ? ResponseUtils.CreateResponse(HttpStatusCode.OK, ResponseUtils.CreateNegotiationResponse())
                         : ResponseUtils.CreateResponse(HttpStatusCode.OK);
                 });
@@ -82,7 +82,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
                 .Returns<HttpRequestMessage, CancellationToken>(async (request, cancellationToken) =>
                 {
                     await Task.Yield();
-                    return request.Method == HttpMethod.Options
+                    return IsNegotiateRequest(request)
                         ? ResponseUtils.CreateResponse(HttpStatusCode.OK, ResponseUtils.CreateNegotiationResponse())
                         : ResponseUtils.CreateResponse(HttpStatusCode.OK);
                 });
@@ -132,7 +132,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
                     // allow DisposeAsync to continue once we know we are past the connection state check
                     allowDisposeTcs.SetResult(null);
                     await releaseNegotiateTcs.Task;
-                    return request.Method == HttpMethod.Options
+                    return IsNegotiateRequest(request)
                         ? ResponseUtils.CreateResponse(HttpStatusCode.OK, ResponseUtils.CreateNegotiationResponse())
                         : ResponseUtils.CreateResponse(HttpStatusCode.OK);
                 });
@@ -173,7 +173,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
                 .Returns<HttpRequestMessage, CancellationToken>(async (request, cancellationToken) =>
                 {
                     await Task.Yield();
-                    return request.Method == HttpMethod.Options
+                    return IsNegotiateRequest(request)
                         ? ResponseUtils.CreateResponse(HttpStatusCode.OK, ResponseUtils.CreateNegotiationResponse())
                         : ResponseUtils.CreateResponse(HttpStatusCode.OK);
                 });
@@ -197,7 +197,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
                 .Returns<HttpRequestMessage, CancellationToken>(async (request, cancellationToken) =>
                 {
                     await Task.Yield();
-                    return request.Method == HttpMethod.Options
+                    return IsNegotiateRequest(request)
                         ? ResponseUtils.CreateResponse(HttpStatusCode.OK, ResponseUtils.CreateNegotiationResponse())
                         : ResponseUtils.CreateResponse(HttpStatusCode.OK);
                 });
@@ -223,7 +223,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
 
                     return request.Method == HttpMethod.Get
                         ? ResponseUtils.CreateResponse(HttpStatusCode.InternalServerError)
-                        : request.Method == HttpMethod.Options
+                        : IsNegotiateRequest(request)
                             ? ResponseUtils.CreateResponse(HttpStatusCode.OK, ResponseUtils.CreateNegotiationResponse())
                             : ResponseUtils.CreateResponse(HttpStatusCode.OK);
                 });
@@ -250,7 +250,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
                 .Returns<HttpRequestMessage, CancellationToken>(async (request, cancellationToken) =>
                 {
                     await Task.Yield();
-                    return request.Method == HttpMethod.Options
+                    return IsNegotiateRequest(request)
                         ? ResponseUtils.CreateResponse(HttpStatusCode.OK, ResponseUtils.CreateNegotiationResponse())
                         : ResponseUtils.CreateResponse(HttpStatusCode.OK);
                 });
@@ -297,7 +297,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
                 .Returns<HttpRequestMessage, CancellationToken>(async (request, cancellationToken) =>
                 {
                     await Task.Yield();
-                    return request.Method == HttpMethod.Options
+                    return IsNegotiateRequest(request)
                         ? ResponseUtils.CreateResponse(HttpStatusCode.OK, ResponseUtils.CreateNegotiationResponse())
                         : ResponseUtils.CreateResponse(HttpStatusCode.OK);
                 });
@@ -353,7 +353,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
                 .Returns<HttpRequestMessage, CancellationToken>(async (request, cancellationToken) =>
                 {
                     await Task.Yield();
-                    return request.Method == HttpMethod.Options
+                    return IsNegotiateRequest(request)
                         ? ResponseUtils.CreateResponse(HttpStatusCode.OK, ResponseUtils.CreateNegotiationResponse())
                         : ResponseUtils.CreateResponse(HttpStatusCode.OK);
                 });
@@ -397,7 +397,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
                 .Returns<HttpRequestMessage, CancellationToken>(async (request, cancellationToken) =>
                 {
                     await Task.Yield();
-                    return request.Method == HttpMethod.Options
+                    return IsNegotiateRequest(request)
                         ? ResponseUtils.CreateResponse(HttpStatusCode.OK, ResponseUtils.CreateNegotiationResponse())
                         : ResponseUtils.CreateResponse(HttpStatusCode.OK);
                 });
@@ -454,7 +454,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
                 {
                     await Task.Yield();
 
-                    return request.Method == HttpMethod.Options
+                    return IsNegotiateRequest(request)
                         ? ResponseUtils.CreateResponse(HttpStatusCode.OK, ResponseUtils.CreateNegotiationResponse())
                         : ResponseUtils.CreateResponse(HttpStatusCode.OK);
                 });
@@ -491,14 +491,17 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
                 .Returns<HttpRequestMessage, CancellationToken>(async (request, cancellationToken) =>
                 {
                     await Task.Yield();
+                    if (IsNegotiateRequest(request))
+                    {
+                        return ResponseUtils.CreateResponse(HttpStatusCode.OK, ResponseUtils.CreateNegotiationResponse());
+                    }
+
                     if (request.Method == HttpMethod.Post)
                     {
                         sendTcs.SetResult(await request.Content.ReadAsByteArrayAsync());
                     }
 
-                    return request.Method == HttpMethod.Options
-                        ? ResponseUtils.CreateResponse(HttpStatusCode.OK, ResponseUtils.CreateNegotiationResponse())
-                        : ResponseUtils.CreateResponse(HttpStatusCode.OK);
+                    return ResponseUtils.CreateResponse(HttpStatusCode.OK);
                 });
 
             var connection = new HttpConnection(new Uri("http://fakeuri.org/"), TransportType.LongPolling, loggerFactory: null, httpMessageHandler: mockHttpHandler.Object);
@@ -542,7 +545,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
                         content = "T2:T:42;";
                     }
 
-                    return request.Method == HttpMethod.Options
+                    return IsNegotiateRequest(request)
                         ? ResponseUtils.CreateResponse(HttpStatusCode.OK, ResponseUtils.CreateNegotiationResponse())
                         : ResponseUtils.CreateResponse(HttpStatusCode.OK, content);
                 });
@@ -568,10 +571,10 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
                 {
                     await Task.Yield();
 
-                    return request.Method == HttpMethod.Post
-                        ? ResponseUtils.CreateResponse(HttpStatusCode.InternalServerError)
-                        : request.Method == HttpMethod.Options
-                            ? ResponseUtils.CreateResponse(HttpStatusCode.OK, ResponseUtils.CreateNegotiationResponse())
+                    return IsNegotiateRequest(request)
+                        ? ResponseUtils.CreateResponse(HttpStatusCode.OK, ResponseUtils.CreateNegotiationResponse())
+                        : request.Method == HttpMethod.Post
+                            ? ResponseUtils.CreateResponse(HttpStatusCode.InternalServerError)
                             : ResponseUtils.CreateResponse(HttpStatusCode.OK);
                 });
 
@@ -601,7 +604,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
                         content = "42";
                     }
 
-                    return request.Method == HttpMethod.Options
+                    return IsNegotiateRequest(request)
                         ? ResponseUtils.CreateResponse(HttpStatusCode.OK, ResponseUtils.CreateNegotiationResponse())
                         : ResponseUtils.CreateResponse(HttpStatusCode.OK, content);
                 });
@@ -656,7 +659,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
                         content = "42";
                     }
 
-                    return request.Method == HttpMethod.Options
+                    return IsNegotiateRequest(request)
                         ? ResponseUtils.CreateResponse(HttpStatusCode.OK, ResponseUtils.CreateNegotiationResponse())
                         : ResponseUtils.CreateResponse(HttpStatusCode.OK, content);
                 });
@@ -719,7 +722,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
                         content = "42";
                     }
 
-                    return request.Method == HttpMethod.Options
+                    return IsNegotiateRequest(request)
                         ? ResponseUtils.CreateResponse(HttpStatusCode.OK, ResponseUtils.CreateNegotiationResponse())
                         : ResponseUtils.CreateResponse(HttpStatusCode.OK, content);
                 });
@@ -777,7 +780,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
 
                     return request.Method == HttpMethod.Get
                         ? ResponseUtils.CreateResponse(HttpStatusCode.InternalServerError)
-                        : request.Method == HttpMethod.Options
+                        : IsNegotiateRequest(request)
                             ? ResponseUtils.CreateResponse(HttpStatusCode.OK, ResponseUtils.CreateNegotiationResponse())
                             : ResponseUtils.CreateResponse(HttpStatusCode.OK);
                 });
@@ -893,7 +896,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
                 .Returns<HttpRequestMessage, CancellationToken>(async (request, cancellationToken) =>
                 {
                     await Task.Yield();
-                    return request.Method == HttpMethod.Options
+                    return IsNegotiateRequest(request)
                         ? ResponseUtils.CreateResponse(HttpStatusCode.OK, ResponseUtils.CreateNegotiationResponse())
                         : ResponseUtils.CreateResponse(HttpStatusCode.OK);
                 });
@@ -925,6 +928,12 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
                 It.IsAny<Uri>(), It.IsAny<Channel<byte[], SendMessage>>(), TransferMode.Text, It.IsAny<string>()), Times.Once);
             Assert.NotNull(transferModeFeature);
             Assert.Equal(TransferMode.Binary, transferModeFeature.TransferMode);
+        }
+
+        private bool IsNegotiateRequest(HttpRequestMessage request)
+        {
+            return request.Method == HttpMethod.Post &&
+                request.RequestUri.ToString().Contains("/negotiate");
         }
     }
 }

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.cs
@@ -958,7 +958,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
         private bool IsNegotiateRequest(HttpRequestMessage request)
         {
             return request.Method == HttpMethod.Post &&
-                request.RequestUri.ToString().Contains("/negotiate");
+                new UriBuilder(request.RequestUri).Path.EndsWith("/negotiate");
         }
     }
 }

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.cs
@@ -951,8 +951,8 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
                 });
 
             var connection = new HttpConnection(new Uri(requested), TransportType.LongPolling, loggerFactory: null, httpMessageHandler: mockHttpHandler.Object);
-            await connection.StartAsync();
-            await connection.DisposeAsync();
+            await connection.StartAsync().OrTimeout();
+            await connection.DisposeAsync().OrTimeout();
         }
 
         private bool IsNegotiateRequest(HttpRequestMessage request)

--- a/test/Microsoft.AspNetCore.Sockets.Tests/HttpConnectionDispatcherTests.cs
+++ b/test/Microsoft.AspNetCore.Sockets.Tests/HttpConnectionDispatcherTests.cs
@@ -37,12 +37,9 @@ namespace Microsoft.AspNetCore.Sockets.Tests
             services.AddOptions();
             var ms = new MemoryStream();
             context.Request.Path = "/foo";
-            context.Request.Method = "OPTIONS";
+            context.Request.Method = "POST";
             context.Response.Body = ms;
-            var builder = new SocketBuilder(services.BuildServiceProvider());
-            builder.UseEndPoint<TestEndPoint>();
-            var app = builder.Build();
-            await dispatcher.ExecuteAsync(context, new HttpSocketOptions(), app);
+            await dispatcher.ExecuteNegotiateAsync(context, new HttpSocketOptions());
             var negotiateResponse = JsonConvert.DeserializeObject<JObject>(Encoding.UTF8.GetString(ms.ToArray()));
             var connectionId = negotiateResponse.Value<string>("connectionId");
             Assert.True(manager.TryGetConnection(connectionId, out var connectionContext));
@@ -64,12 +61,9 @@ namespace Microsoft.AspNetCore.Sockets.Tests
             services.AddOptions();
             var ms = new MemoryStream();
             context.Request.Path = "/foo";
-            context.Request.Method = "OPTIONS";
+            context.Request.Method = "POST";
             context.Response.Body = ms;
-            var builder = new SocketBuilder(services.BuildServiceProvider());
-            builder.UseEndPoint<TestEndPoint>();
-            var app = builder.Build();
-            await dispatcher.ExecuteAsync(context, new HttpSocketOptions { Transports = transports }, app);
+            await dispatcher.ExecuteNegotiateAsync(context, new HttpSocketOptions { Transports = transports });
 
             var negotiateResponse = JsonConvert.DeserializeObject<JObject>(Encoding.UTF8.GetString(ms.ToArray()));
             var availableTransports = (TransportType)0;


### PR DESCRIPTION
https://github.com/aspnet/SignalR/issues/1111

Another option would be to make `ExecuteAsync` take a flag and do all the logic as before with the `/path/negotiate` route passing in a "Negotiate" flag