### PR TITLE
Setting ContentType in the HTTP responses

### DIFF
--- a/src/Microsoft.AspNetCore.Sockets.Http/HttpConnectionDispatcher.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Http/HttpConnectionDispatcher.cs
@@ -55,6 +55,7 @@ namespace Microsoft.AspNetCore.Sockets
                 }
                 else
                 {
+                    context.Response.ContentType = "text/plain";
                     context.Response.StatusCode = StatusCodes.Status405MethodNotAllowed;
                 }
             }
@@ -78,6 +79,7 @@ namespace Microsoft.AspNetCore.Sockets
                 }
                 else
                 {
+                    context.Response.ContentType = "text/plain";
                     context.Response.StatusCode = StatusCodes.Status405MethodNotAllowed;
                 }
             }
@@ -167,6 +169,7 @@ namespace Microsoft.AspNetCore.Sockets
 
                         // The connection was disposed
                         context.Response.StatusCode = StatusCodes.Status404NotFound;
+                        context.Response.ContentType = "plain/text";
                         return;
                     }
 
@@ -414,6 +417,8 @@ namespace Microsoft.AspNetCore.Sockets
                 return;
             }
 
+            context.Response.ContentType = "text/plain";
+
             var transport = (TransportType?)connection.Metadata[ConnectionMetadataNames.Transport];
             if (transport == TransportType.WebSockets)
             {
@@ -441,14 +446,13 @@ namespace Microsoft.AspNetCore.Sockets
                     return;
                 }
             }
-
-            context.Response.ContentType = "text/plain";
         }
 
         private async Task<bool> EnsureConnectionStateAsync(DefaultConnectionContext connection, HttpContext context, TransportType transportType, TransportType supportedTransports, ConnectionLogScope logScope, HttpSocketOptions options)
         {
             if ((supportedTransports & transportType) == 0)
             {
+                context.Response.ContentType = "text/plain";
                 context.Response.StatusCode = StatusCodes.Status404NotFound;
                 _logger.TransportNotSupported(connection.ConnectionId, transportType);
                 await context.Response.WriteAsync($"{transportType} transport not supported by this end point type");
@@ -463,6 +467,7 @@ namespace Microsoft.AspNetCore.Sockets
             }
             else if (transport != transportType)
             {
+                context.Response.ContentType = "text/plain";
                 context.Response.StatusCode = StatusCodes.Status400BadRequest;
                 _logger.CannotChangeTransport(connection.ConnectionId, transport.Value, transportType);
                 await context.Response.WriteAsync("Cannot change transports mid-connection");
@@ -497,6 +502,7 @@ namespace Microsoft.AspNetCore.Sockets
             {
                 // There's no connection ID: bad request
                 context.Response.StatusCode = StatusCodes.Status400BadRequest;
+                context.Response.ContentType = "text/plain";
                 await context.Response.WriteAsync("Connection ID required");
                 return null;
             }
@@ -505,6 +511,7 @@ namespace Microsoft.AspNetCore.Sockets
             {
                 // No connection with that ID: Not Found
                 context.Response.StatusCode = StatusCodes.Status404NotFound;
+                context.Response.ContentType = "text/plain";
                 await context.Response.WriteAsync("No Connection with that ID");
                 return null;
             }

--- a/src/Microsoft.AspNetCore.Sockets.Http/HttpConnectionDispatcher.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Http/HttpConnectionDispatcher.cs
@@ -441,6 +441,8 @@ namespace Microsoft.AspNetCore.Sockets
                     return;
                 }
             }
+
+            context.Response.ContentType = "text/plain";
         }
 
         private async Task<bool> EnsureConnectionStateAsync(DefaultConnectionContext connection, HttpContext context, TransportType transportType, TransportType supportedTransports, ConnectionLogScope logScope, HttpSocketOptions options)

--- a/src/Microsoft.AspNetCore.Sockets.Http/Internal/Transports/LongPollingTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Http/Internal/Transports/LongPollingTransport.cs
@@ -39,8 +39,6 @@ namespace Microsoft.AspNetCore.Sockets.Internal.Transports
                     return;
                 }
 
-                // REVIEW: What should the content type be?
-
                 var contentLength = 0;
                 var buffers = new List<byte[]>();
                 // We're intentionally not checking cancellation here because we need to drain messages we've got so far,
@@ -54,6 +52,7 @@ namespace Microsoft.AspNetCore.Sockets.Internal.Transports
                 }
 
                 context.Response.ContentLength = contentLength;
+                context.Response.ContentType = "application/octet-stream";
 
                 foreach (var buffer in buffers)
                 {

--- a/src/Microsoft.AspNetCore.Sockets.Http/Internal/Transports/LongPollingTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Http/Internal/Transports/LongPollingTransport.cs
@@ -35,6 +35,7 @@ namespace Microsoft.AspNetCore.Sockets.Internal.Transports
                 {
                     await _application.Completion;
                     _logger.LongPolling204(_connectionId, context.TraceIdentifier);
+                    context.Response.ContentType = "text/plain";
                     context.Response.StatusCode = StatusCodes.Status204NoContent;
                     return;
                 }
@@ -79,12 +80,14 @@ namespace Microsoft.AspNetCore.Sockets.Internal.Transports
                     _logger.PollTimedOut(_connectionId, context.TraceIdentifier);
 
                     context.Response.ContentLength = 0;
+                    context.Response.ContentType = "text/plain";
                     context.Response.StatusCode = StatusCodes.Status200OK;
                 }
                 else
                 {
                     // Case 3
                     _logger.LongPolling204(_connectionId, context.TraceIdentifier);
+                    context.Response.ContentType = "text/plain";
                     context.Response.StatusCode = StatusCodes.Status204NoContent;
                 }
             }


### PR DESCRIPTION
This fixes the issue #1106 where Firefox tries to parse all responses without Content-Type as Xml and displays the 'XML Parsing Error: no root element found' warning in the dev console.

Also making auth test work in IE