### PR TITLE
Implement #1162 by adding client timeout for JavaScript

### DIFF
--- a/client-ts/Microsoft.AspNetCore.SignalR.Client.TS.Tests/Connection.spec.ts
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Client.TS.Tests/Connection.spec.ts
@@ -158,6 +158,7 @@ describe("Connection", () => {
             send(data: any): Promise<void> {
                 return Promise.reject("");
             },
+            type: TransportType.LongPolling,
             stop(): void { },
             onreceive: undefined,
             onclose: undefined,
@@ -321,6 +322,7 @@ describe("Connection", () => {
                 connect(url: string, requestedTransferMode: TransferMode): Promise<TransferMode> { return Promise.resolve(transportTransferMode); },
                 send(data: any): Promise<void> { return Promise.resolve(); },
                 stop(): void {},
+                type: TransportType.LongPolling,
                 onreceive: null,
                 onclose: null,
                 mode: transportTransferMode

--- a/client-ts/Microsoft.AspNetCore.SignalR.Client.TS.Tests/Connection.spec.ts
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Client.TS.Tests/Connection.spec.ts
@@ -158,7 +158,6 @@ describe("Connection", () => {
             send(data: any): Promise<void> {
                 return Promise.reject("");
             },
-            type: TransportType.LongPolling,
             stop(): void { },
             onreceive: undefined,
             onclose: undefined,
@@ -321,8 +320,7 @@ describe("Connection", () => {
                 // mode: TransferMode : TransferMode.Text
                 connect(url: string, requestedTransferMode: TransferMode): Promise<TransferMode> { return Promise.resolve(transportTransferMode); },
                 send(data: any): Promise<void> { return Promise.resolve(); },
-                stop(): void {},
-                type: TransportType.LongPolling,
+                stop(): void { },
                 onreceive: null,
                 onclose: null,
                 mode: transportTransferMode

--- a/client-ts/Microsoft.AspNetCore.SignalR.Client.TS.Tests/HubConnection.spec.ts
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Client.TS.Tests/HubConnection.spec.ts
@@ -12,7 +12,6 @@ import { MessageType } from "../Microsoft.AspNetCore.SignalR.Client.TS/IHubProto
 
 import { asyncit as it, captureException, delay, PromiseSource } from './Utils';
 import { IHubConnectionOptions } from "../Microsoft.AspNetCore.SignalR.Client.TS/IHubConnectionOptions";
-import { connect } from "tls";
 
 describe("HubConnection", () => {
 
@@ -441,7 +440,7 @@ describe("HubConnection", () => {
             expect(await invokePromise).toBe("foo");
         });
 
-        it("does not terminate if messages are received", async() => {
+        it("does not terminate if messages are received", async () => {
             let connection = new TestConnection();
             connection.transportType = TransportType.ServerSentEvents;
             let hubConnection = new HubConnection(connection, { serverTimeoutInMilliseconds: 100 });
@@ -466,7 +465,7 @@ describe("HubConnection", () => {
 
             expect(error).toBeUndefined();
         });
-        
+
         it("terminates if no messages received within timeout interval", async () => {
             let connection = new TestConnection();
             connection.transportType = TransportType.ServerSentEvents;
@@ -486,8 +485,6 @@ describe("HubConnection", () => {
 
 class TestConnection implements IConnection {
     readonly features: any = {};
-
-    transportType: TransportType = TransportType.LongPolling;
 
     start(): Promise<void> {
         return Promise.resolve();

--- a/client-ts/Microsoft.AspNetCore.SignalR.Client.TS.Tests/HubConnection.spec.ts
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Client.TS.Tests/HubConnection.spec.ts
@@ -442,7 +442,6 @@ describe("HubConnection", () => {
 
         it("does not terminate if messages are received", async () => {
             let connection = new TestConnection();
-            connection.transportType = TransportType.ServerSentEvents;
             let hubConnection = new HubConnection(connection, { serverTimeoutInMilliseconds: 100 });
 
             let p = new PromiseSource<Error>();
@@ -468,7 +467,6 @@ describe("HubConnection", () => {
 
         it("terminates if no messages received within timeout interval", async () => {
             let connection = new TestConnection();
-            connection.transportType = TransportType.ServerSentEvents;
             let hubConnection = new HubConnection(connection, { serverTimeoutInMilliseconds: 100 });
 
             let p = new PromiseSource<Error>();

--- a/client-ts/Microsoft.AspNetCore.SignalR.Client.TS.Tests/HubConnection.spec.ts
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Client.TS.Tests/HubConnection.spec.ts
@@ -4,7 +4,7 @@
 import { IConnection } from "../Microsoft.AspNetCore.SignalR.Client.TS/IConnection"
 import { HubConnection } from "../Microsoft.AspNetCore.SignalR.Client.TS/HubConnection"
 import { DataReceived, ConnectionClosed } from "../Microsoft.AspNetCore.SignalR.Client.TS/Common"
-import { TransportType, ITransport, TransferMode, LongPollingTransport } from "../Microsoft.AspNetCore.SignalR.Client.TS/Transports"
+import { TransportType, ITransport, TransferMode } from "../Microsoft.AspNetCore.SignalR.Client.TS/Transports"
 import { Observer } from "../Microsoft.AspNetCore.SignalR.Client.TS/Observable"
 import { TextMessageFormat } from "../Microsoft.AspNetCore.SignalR.Client.TS/Formatters"
 import { ILogger, LogLevel } from "../Microsoft.AspNetCore.SignalR.Client.TS/ILogger"

--- a/client-ts/Microsoft.AspNetCore.SignalR.Client.TS.Tests/Utils.ts
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Client.TS.Tests/Utils.ts
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+import { clearTimeout, setTimeout } from "timers";
+
 export function asyncit(expectation: string, assertion?: () => Promise<any>, timeout?: number): void {
     let testFunction: (done: DoneFn) => void;
     if (assertion) {
@@ -23,5 +25,33 @@ export async function captureException(fn: () => Promise<any>): Promise<Error> {
         return null;
     } catch (e) {
         return e;
+    }
+}
+
+export function delay(durationInMilliseconds: number): Promise<void> {
+    let source = new PromiseSource<void>();
+    setTimeout(() => source.resolve(), durationInMilliseconds);
+    return source.promise;
+}
+
+export class PromiseSource<T> {
+    public promise: Promise<T>
+
+    private resolver: (value?: T | PromiseLike<T>) => void;
+    private rejecter: (reason?: any) => void;
+
+    constructor() {
+        this.promise = new Promise<T>((resolve, reject) => {
+            this.resolver = resolve;
+            this.rejecter = reject;
+        });
+    }
+
+    resolve(value?: T | PromiseLike<T>) {
+        this.resolver(value);
+    }
+
+    reject(reason?: any) {
+        this.rejecter(reason);
     }
 }

--- a/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/HttpConnection.ts
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/HttpConnection.ts
@@ -89,7 +89,7 @@ export class HttpConnection implements IConnection {
                     ? TransferMode.Binary
                     : TransferMode.Text;
 
-            this.features.transferMode = await this.transport.connect(this.url, requestedTransferMode);
+            this.features.transferMode = await this.transport.connect(this.url, requestedTransferMode, this);
 
             // only change the state if we were connecting to not overwrite
             // the state if the connection is already marked as Disconnected

--- a/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/HttpConnection.ts
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/HttpConnection.ts
@@ -42,6 +42,10 @@ export class HttpConnection implements IConnection {
         this.options = options;
     }
 
+    get transportType(): TransportType {
+        return this.transport.type;
+    }
+
     async start(): Promise<void> {
         if (this.connectionState != ConnectionState.Initial) {
             return Promise.reject(new Error("Cannot start a connection that is not in the 'Initial' state."));
@@ -144,7 +148,7 @@ export class HttpConnection implements IConnection {
         return this.transport.send(data);
     }
 
-    async stop(): Promise<void> {
+    async stop(error? : Error): Promise<void> {
         let previousState = this.connectionState;
         this.connectionState = ConnectionState.Disconnected;
 
@@ -154,10 +158,10 @@ export class HttpConnection implements IConnection {
         catch (e) {
             // this exception is returned to the user as a rejected Promise from the start method
         }
-        this.stopConnection(/*raiseClosed*/ previousState == ConnectionState.Connected);
+        this.stopConnection(/*raiseClosed*/ previousState == ConnectionState.Connected, error);
     }
 
-    private stopConnection(raiseClosed: Boolean, error?: any) {
+    private stopConnection(raiseClosed: Boolean, error?: Error) {
         if (this.transport) {
             this.transport.stop();
             this.transport = null;

--- a/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/HttpConnection.ts
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/HttpConnection.ts
@@ -42,10 +42,6 @@ export class HttpConnection implements IConnection {
         this.options = options;
     }
 
-    get transportType(): TransportType {
-        return this.transport.type;
-    }
-
     async start(): Promise<void> {
         if (this.connectionState != ConnectionState.Initial) {
             return Promise.reject(new Error("Cannot start a connection that is not in the 'Initial' state."));

--- a/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/HubConnection.ts
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/HubConnection.ts
@@ -97,7 +97,7 @@ export class HubConnection {
     }
 
     private configureTimeout() {
-        if (this.connection.transportType !== TransportType.LongPolling) {
+        if (this.connection.features && this.connection.features.inherentKeepAlive === true) {
             // Set the timeout timer
             this.timeoutHandle = setTimeout(() => this.serverTimeout(), this.serverTimeoutInMilliseconds);
         }

--- a/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/HubConnection.ts
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/HubConnection.ts
@@ -59,9 +59,8 @@ export class HubConnection {
     }
 
     private processIncomingData(data: any) {
-        // For some reason, our TypeScript refs are set up for clearTimeout to take NodeJS.Timer... which is weird.
         if (this.timeoutHandle !== undefined) {
-            clearTimeout(<any>this.timeoutHandle);
+            clearTimeout(this.timeoutHandle);
         }
 
         // Parse the messages

--- a/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/HubConnection.ts
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/HubConnection.ts
@@ -13,12 +13,15 @@ import { Base64EncodedHubProtocol } from "./Base64EncodedHubProtocol"
 import { ILogger, LogLevel } from "./ILogger"
 import { ConsoleLogger, NullLogger, LoggerFactory } from "./Loggers"
 import { IHubConnectionOptions } from "./IHubConnectionOptions"
+import { setTimeout, clearTimeout } from "timers";
 
 export { TransportType } from "./Transports"
 export { HttpConnection } from "./HttpConnection"
 export { JsonHubProtocol } from "./JsonHubProtocol"
 export { LogLevel, ILogger } from "./ILogger"
 export { ConsoleLogger, NullLogger } from "./Loggers"
+
+const DEFAULT_SERVER_TIMEOUT_IN_MS: number = 30 * 1000;
 
 export class HubConnection {
     private readonly connection: IConnection;
@@ -28,9 +31,14 @@ export class HubConnection {
     private methods: Map<string, ((...args: any[]) => void)[]>;
     private id: number;
     private closedCallbacks: ConnectionClosed[];
+    private timeoutHandle: NodeJS.Timer;
+    private serverTimeoutInMilliseconds: number;
 
     constructor(urlOrConnection: string | IConnection, options: IHubConnectionOptions = {}) {
         options = options || {};
+
+        this.serverTimeoutInMilliseconds = options.serverTimeoutInMilliseconds || DEFAULT_SERVER_TIMEOUT_IN_MS;
+
         if (typeof urlOrConnection === "string") {
             this.connection = new HttpConnection(urlOrConnection, options);
         }
@@ -51,6 +59,11 @@ export class HubConnection {
     }
 
     private processIncomingData(data: any) {
+        // For some reason, our TypeScript refs are set up for clearTimeout to take NodeJS.Timer... which is weird.
+        if (this.timeoutHandle !== undefined) {
+            clearTimeout(<any>this.timeoutHandle);
+        }
+
         // Parse the messages
         let messages = this.protocol.parseMessages(data);
 
@@ -79,6 +92,21 @@ export class HubConnection {
                     break;
             }
         }
+
+        this.configureTimeout();
+    }
+
+    private configureTimeout() {
+        if (this.connection.transportType !== TransportType.LongPolling) {
+            // Set the timeout timer
+            this.timeoutHandle = setTimeout(() => this.serverTimeout(), this.serverTimeoutInMilliseconds);
+        }
+    }
+
+    private serverTimeout() {
+        // The server hasn't talked to us in a while. It doesn't like us anymore ... :(
+        // Terminate the connection
+        this.connection.stop(new Error("Server timeout elapsed without receiving a message from the server."));
     }
 
     private invokeClientMethod(invocationMessage: InvocationMessage) {
@@ -122,6 +150,8 @@ export class HubConnection {
         if (requestedTransferMode === TransferMode.Binary && actualTransferMode === TransferMode.Text) {
             this.protocol = new Base64EncodedHubProtocol(this.protocol);
         }
+
+        this.configureTimeout();
     }
 
     stop(): void {

--- a/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/HubConnection.ts
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/HubConnection.ts
@@ -97,7 +97,7 @@ export class HubConnection {
     }
 
     private configureTimeout() {
-        if (this.connection.features && this.connection.features.inherentKeepAlive === true) {
+        if (!this.connection.features || !this.connection.features.inherentKeepAlive) {
             // Set the timeout timer
             this.timeoutHandle = setTimeout(() => this.serverTimeout(), this.serverTimeoutInMilliseconds);
         }

--- a/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/IConnection.ts
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/IConnection.ts
@@ -7,8 +7,6 @@ import { TransportType, TransferMode, ITransport } from  "./Transports"
 export interface IConnection {
     readonly features: any;
 
-    readonly transportType: TransportType;
-
     start(): Promise<void>;
     send(data: any): Promise<void>;
     stop(error?: Error): void;

--- a/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/IConnection.ts
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/IConnection.ts
@@ -7,9 +7,11 @@ import { TransportType, TransferMode, ITransport } from  "./Transports"
 export interface IConnection {
     readonly features: any;
 
+    readonly transportType: TransportType;
+
     start(): Promise<void>;
     send(data: any): Promise<void>;
-    stop(): void;
+    stop(error?: Error): void;
 
     onreceive: DataReceived;
     onclose: ConnectionClosed;

--- a/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/IHubConnectionOptions.ts
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/IHubConnectionOptions.ts
@@ -7,4 +7,5 @@ import { ILogger, LogLevel } from "./ILogger"
 
 export interface IHubConnectionOptions extends IHttpConnectionOptions {
     protocol?: IHubProtocol;
+    serverTimeoutInMilliseconds?: number;
 }

--- a/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/Microsoft.AspNetCore.SignalR.Client.TS.csproj
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/Microsoft.AspNetCore.SignalR.Client.TS.csproj
@@ -11,7 +11,6 @@
 
   <ItemGroup>
     <Inputs Include="*.ts;" />
-    <Inputs Remove="IFeatureCollection.ts" />
     <Outputs Include="@(Inputs -> '$(SignalRClientDistFolder)src\%(FileName).d.ts')" />
     <Outputs Include="@(Inputs -> '$(SignalRClientDistFolder)src\%(FileName).js')" />
     <Outputs Include="$(SignalRClientDistFolder)browser\signalr-client.js" />

--- a/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/Microsoft.AspNetCore.SignalR.Client.TS.csproj
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/Microsoft.AspNetCore.SignalR.Client.TS.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <Inputs Include="*.ts;" />
+    <Inputs Remove="IFeatureCollection.ts" />
     <Outputs Include="@(Inputs -> '$(SignalRClientDistFolder)src\%(FileName).d.ts')" />
     <Outputs Include="@(Inputs -> '$(SignalRClientDistFolder)src\%(FileName).js')" />
     <Outputs Include="$(SignalRClientDistFolder)browser\signalr-client.js" />

--- a/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/Transports.ts
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/Transports.ts
@@ -189,7 +189,7 @@ export class LongPollingTransport implements ITransport {
     private pollXhr: XMLHttpRequest;
     private shouldPoll: boolean;
 
-    constructor(httpClient: IHttpClient, jwtBearer: () => string, logger: ILogger, connection: IConnection) {
+    constructor(httpClient: IHttpClient, jwtBearer: () => string, logger: ILogger) {
         this.httpClient = httpClient;
         this.jwtBearer = jwtBearer;
         this.logger = logger;

--- a/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/Transports.ts
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/Transports.ts
@@ -23,6 +23,7 @@ export interface ITransport {
     stop(): void;
     onreceive: DataReceived;
     onclose: TransportClosed;
+    type: TransportType;
 }
 
 export class WebSocketTransport implements ITransport {
@@ -34,6 +35,8 @@ export class WebSocketTransport implements ITransport {
         this.logger = logger;
         this.jwtBearer = jwtBearer;
     }
+
+    type: TransportType = TransportType.WebSockets;
 
     connect(url: string, requestedTransferMode: TransferMode): Promise<TransferMode> {
 
@@ -112,6 +115,8 @@ export class ServerSentEventsTransport implements ITransport {
         this.jwtBearer = jwtBearer;
         this.logger = logger;
     }
+
+    type: TransportType = TransportType.ServerSentEvents;
 
     connect(url: string, requestedTransferMode: TransferMode): Promise<TransferMode> {
         if (typeof (EventSource) === "undefined") {
@@ -193,6 +198,8 @@ export class LongPollingTransport implements ITransport {
         this.jwtBearer = jwtBearer;
         this.logger = logger;
     }
+
+    type: TransportType = TransportType.LongPolling;
 
     connect(url: string, requestedTransferMode: TransferMode): Promise<TransferMode> {
         this.url = url;

--- a/client-ts/Microsoft.AspNetCore.SignalR.Test.Server/wwwroot/js/hubConnectionTests.js
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Test.Server/wwwroot/js/hubConnectionTests.js
@@ -379,6 +379,30 @@ describe('hubConnection', function () {
                         done();
                     });
             });
+
+            if(transportType != signalR.TransportType.LongPolling) {
+                it("terminates if no messages received within timeout interval", function(done) {
+                    var options = {
+                        transport: transportType,
+                        logging: signalR.LogLevel.Trace,
+                        serverTimeoutInMilliseconds: 100
+                    };
+
+                    var hubConnection = new signalR.HubConnection(TESTHUBENDPOINT_URL, options);
+
+                    var timeout = setTimeout(200, function() {
+                        fail("Server timeout did not fire within expected interval");
+                    });
+
+                    hubConnection.start().then(function() {
+                        hubConnection.onclose(function(error) {
+                            clearTimeout(timeout);
+                            expect(error).toEqual(new Error("Server timeout elapsed without receiving a message from the server."));
+                            done();
+                        });
+                    });
+                });
+            }
         });
     });
 

--- a/client-ts/Microsoft.AspNetCore.SignalR.Test.Server/wwwroot/js/hubConnectionTests.js
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Test.Server/wwwroot/js/hubConnectionTests.js
@@ -258,13 +258,13 @@ describe('hubConnection', function () {
                 hubConnection.start().then(function () {
                     return hubConnection.invoke('InvokeWithString', message);
                 })
-                    .then(function () {
-                        return hubConnection.stop();
-                    })
-                    .catch(function (e) {
-                        fail(e);
-                        done();
-                    });
+                .then(function () {
+                    return hubConnection.stop();
+                })
+                .catch(function (e) {
+                    fail(e);
+                    done();
+                });
             });
 
             it('closed with error if hub cannot be created', function (done) {
@@ -315,31 +315,31 @@ describe('hubConnection', function () {
                 hubConnection.start().then(function () {
                     return hubConnection.invoke('EchoComplexObject', complexObject);
                 })
-                    .then(function (value) {
-                        if (protocol.name === "messagepack") {
-                            // msgpack creates a Buffer for byte arrays and jasmine fails to compare a Buffer
-                            // and a Uint8Array even though Buffer instances are also Uint8Array instances
-                            value.ByteArray = new Uint8Array(value.ByteArray);
+                .then(function (value) {
+                    if (protocol.name === "messagepack") {
+                        // msgpack creates a Buffer for byte arrays and jasmine fails to compare a Buffer
+                        // and a Uint8Array even though Buffer instances are also Uint8Array instances
+                        value.ByteArray = new Uint8Array(value.ByteArray);
 
-                            // GUIDs are serialized as raw type which is a string containing bytes which need to
-                            // be extracted. Note that with msgpack5 the original bytes will be encoded with utf8
-                            // and needs to be decoded. To not go into utf8 encoding intricacies the test uses values
-                            // less than 0x80.
-                            let guidBytes = [];
-                            for (let i = 0; i < value.GUID.length; i++) {
-                                guidBytes.push(value.GUID.charCodeAt(i));
-                            }
-                            value.GUID = new Uint8Array(guidBytes);
+                        // GUIDs are serialized as raw type which is a string containing bytes which need to
+                        // be extracted. Note that with msgpack5 the original bytes will be encoded with utf8
+                        // and needs to be decoded. To not go into utf8 encoding intricacies the test uses values
+                        // less than 0x80.
+                        let guidBytes = [];
+                        for (let i = 0; i < value.GUID.length; i++) {
+                            guidBytes.push(value.GUID.charCodeAt(i));
                         }
-                        expect(value).toEqual(complexObject);
-                    })
-                    .then(function () {
-                        hubConnection.stop();
-                    })
-                    .catch(function (e) {
-                        fail(e);
-                        done();
-                    });
+                        value.GUID = new Uint8Array(guidBytes);
+                    }
+                    expect(value).toEqual(complexObject);
+                })
+                .then(function () {
+                    hubConnection.stop();
+                })
+                .catch(function (e) {
+                    fail(e);
+                    done();
+                });
             });
         });
     });

--- a/client-ts/Microsoft.AspNetCore.SignalR.Test.Server/wwwroot/js/hubConnectionTests.js
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Test.Server/wwwroot/js/hubConnectionTests.js
@@ -56,7 +56,7 @@ describe('hubConnection', function () {
                 });
 
                 hubConnection.start().then(function () {
-                    hubConnection.send('SendCustomObject', { Name: 'test', Value: 42});
+                    hubConnection.send('SendCustomObject', { Name: 'test', Value: 42 });
                 }).catch(function (e) {
                     fail(e);
                     done();
@@ -258,13 +258,13 @@ describe('hubConnection', function () {
                 hubConnection.start().then(function () {
                     return hubConnection.invoke('InvokeWithString', message);
                 })
-                .then(function() {
-                    return hubConnection.stop();
-                })
-                .catch(function (e) {
-                    fail(e);
-                    done();
-                });
+                    .then(function () {
+                        return hubConnection.stop();
+                    })
+                    .catch(function (e) {
+                        fail(e);
+                        done();
+                    });
             });
 
             it('closed with error if hub cannot be created', function (done) {
@@ -315,31 +315,31 @@ describe('hubConnection', function () {
                 hubConnection.start().then(function () {
                     return hubConnection.invoke('EchoComplexObject', complexObject);
                 })
-                .then(function (value) {
-                    if (protocol.name === "messagepack") {
-                        // msgpack creates a Buffer for byte arrays and jasmine fails to compare a Buffer
-                        // and a Uint8Array even though Buffer instances are also Uint8Array instances
-                        value.ByteArray = new Uint8Array(value.ByteArray);
+                    .then(function (value) {
+                        if (protocol.name === "messagepack") {
+                            // msgpack creates a Buffer for byte arrays and jasmine fails to compare a Buffer
+                            // and a Uint8Array even though Buffer instances are also Uint8Array instances
+                            value.ByteArray = new Uint8Array(value.ByteArray);
 
-                        // GUIDs are serialized as raw type which is a string containing bytes which need to
-                        // be extracted. Note that with msgpack5 the original bytes will be encoded with utf8
-                        // and needs to be decoded. To not go into utf8 encoding intricacies the test uses values
-                        // less than 0x80.
-                        let guidBytes = [];
-                        for (let i = 0; i < value.GUID.length; i++) {
-                            guidBytes.push(value.GUID.charCodeAt(i));
+                            // GUIDs are serialized as raw type which is a string containing bytes which need to
+                            // be extracted. Note that with msgpack5 the original bytes will be encoded with utf8
+                            // and needs to be decoded. To not go into utf8 encoding intricacies the test uses values
+                            // less than 0x80.
+                            let guidBytes = [];
+                            for (let i = 0; i < value.GUID.length; i++) {
+                                guidBytes.push(value.GUID.charCodeAt(i));
+                            }
+                            value.GUID = new Uint8Array(guidBytes);
                         }
-                        value.GUID = new Uint8Array(guidBytes);
-                    }
-                    expect(value).toEqual(complexObject);
-                })
-                .then(function () {
-                    hubConnection.stop();
-                })
-                .catch(function (e) {
-                    fail(e);
-                    done();
-                });
+                        expect(value).toEqual(complexObject);
+                    })
+                    .then(function () {
+                        hubConnection.stop();
+                    })
+                    .catch(function (e) {
+                        fail(e);
+                        done();
+                    });
             });
         });
     });
@@ -367,21 +367,21 @@ describe('hubConnection', function () {
                         });
                         return hubConnection.start();
                     })
-                    .then(function() {
+                    .then(function () {
                         return hubConnection.invoke('Echo', message);
                     })
-                    .then(function(response) {
+                    .then(function (response) {
                         expect(response).toEqual(message);
                         return hubConnection.stop();
                     })
-                    .catch(function(e) {
+                    .catch(function (e) {
                         fail(e);
                         done();
                     });
             });
 
-            if(transportType != signalR.TransportType.LongPolling) {
-                it("terminates if no messages received within timeout interval", function(done) {
+            if (transportType != signalR.TransportType.LongPolling) {
+                it("terminates if no messages received within timeout interval", function (done) {
                     var options = {
                         transport: transportType,
                         logging: signalR.LogLevel.Trace,
@@ -390,12 +390,12 @@ describe('hubConnection', function () {
 
                     var hubConnection = new signalR.HubConnection(TESTHUBENDPOINT_URL, options);
 
-                    var timeout = setTimeout(200, function() {
+                    var timeout = setTimeout(200, function () {
                         fail("Server timeout did not fire within expected interval");
                     });
 
-                    hubConnection.start().then(function() {
-                        hubConnection.onclose(function(error) {
+                    hubConnection.start().then(function () {
+                        hubConnection.onclose(function (error) {
                             clearTimeout(timeout);
                             expect(error).toEqual(new Error("Server timeout elapsed without receiving a message from the server."));
                             done();


### PR DESCRIPTION
Add client timeout to JS client. It is configurable via an option and defaults to 30 seconds (the server ping rate defaults to 15 seconds, so this is effectively 2 server ping intervals).

NOTE: Should not be merged until #1161 is merged since it will immediately break any connection that goes idle for 30 seconds :).

Fixes #1162