### PR TITLE
Implement #1157 by adding client timeout for C# client

### DIFF
--- a/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.cs
@@ -94,7 +94,7 @@ namespace Microsoft.AspNetCore.SignalR.Client
 
         private void TimeoutElapsed()
         {
-            _connection.AbortAsync(new TimeoutException("Server timeout elapsed without receiving a message from the server."));
+            _connection.AbortAsync(new TimeoutException($"Server timeout ({ServerTimeout.TotalMilliseconds:0.00}ms) elapsed without receiving a message from the server."));
         }
 
         private void ResetTimeoutTimer()

--- a/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.cs
@@ -41,7 +41,7 @@ namespace Microsoft.AspNetCore.SignalR.Client
         private int _nextId = 0;
         private volatile bool _startCalled;
         private Timer _timeoutTimer;
-        private readonly bool _needKeepAlive;
+        private bool _needKeepAlive;
 
         public Task Closed { get; }
 
@@ -69,7 +69,6 @@ namespace Microsoft.AspNetCore.SignalR.Client
             _loggerFactory = loggerFactory ?? NullLoggerFactory.Instance;
             _logger = _loggerFactory.CreateLogger<HubConnection>();
             _connection.OnReceived((data, state) => ((HubConnection)state).OnDataReceivedAsync(data), this);
-            _needKeepAlive = _connection.Features.Get<IConnectionInherentKeepAliveFeature>() == null;
             Closed = _connection.Closed.ContinueWith(task =>
             {
                 Shutdown(task.Exception);
@@ -122,6 +121,7 @@ namespace Microsoft.AspNetCore.SignalR.Client
 
             transferModeFeature.TransferMode = requestedTransferMode;
             await _connection.StartAsync();
+            _needKeepAlive = _connection.Features.Get<IConnectionInherentKeepAliveFeature>() == null;
             var actualTransferMode = transferModeFeature.TransferMode;
 
             _protocolReaderWriter = new HubProtocolReaderWriter(_protocol, GetDataEncoder(requestedTransferMode, actualTransferMode));

--- a/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.cs
@@ -47,7 +47,7 @@ namespace Microsoft.AspNetCore.SignalR.Client
 
         /// <summary>
         /// Gets or sets the server timeout interval for the connection. Changes to this value
-        /// are ignored after <see cref="StartAsync"/> is called.
+        /// will not be applied until the Keep Alive timer is next reset.
         /// </summary>
         public TimeSpan ServerTimeout { get; set; } = DefaultServerTimeout;
 

--- a/src/Microsoft.AspNetCore.SignalR.Client.Core/Internal/SignalRClientLoggerExtensions.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client.Core/Internal/SignalRClientLoggerExtensions.cs
@@ -85,6 +85,9 @@ namespace Microsoft.AspNetCore.SignalR.Client.Internal
         private static readonly Action<ILogger, string, string, string, int, Exception> _preparingStreamingInvocation =
             LoggerMessage.Define<string, string, string, int>(LogLevel.Trace, new EventId(24, nameof(PreparingStreamingInvocation)), "Preparing streaming invocation '{invocationId}' of '{target}', with return type '{returnType}' and {argumentCount} argument(s).");
 
+        private static readonly Action<ILogger, Exception> _resettingKeepAliveTimer =
+            LoggerMessage.Define(LogLevel.Trace, new EventId(25, nameof(ResettingKeepAliveTimer)), "Resetting keep-alive timer, received a message from the server");
+
         // Category: Streaming and NonStreaming
         private static readonly Action<ILogger, string, Exception> _invocationCreated =
             LoggerMessage.Define<string>(LogLevel.Trace, new EventId(0, nameof(InvocationCreated)), "Invocation {invocationId} created.");
@@ -282,7 +285,12 @@ namespace Microsoft.AspNetCore.SignalR.Client.Internal
 
         public static void ErrorInvokingClientSideMethod(this ILogger logger, string methodName, Exception exception)
         {
-             _errorInvokingClientSideMethod(logger, methodName, exception);
+            _errorInvokingClientSideMethod(logger, methodName, exception);
+        }
+
+        public static void ResettingKeepAliveTimer(this ILogger logger)
+        {
+            _resettingKeepAliveTimer(logger);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.SignalR.Client.Core/Internal/SignalRClientLoggerExtensions.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client.Core/Internal/SignalRClientLoggerExtensions.cs
@@ -290,7 +290,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Internal
 
         public static void ResettingKeepAliveTimer(this ILogger logger)
         {
-            _resettingKeepAliveTimer(logger);
+            _resettingKeepAliveTimer(logger, null);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.SignalR.Client.Core/Internal/SignalRClientLoggerExtensions.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client.Core/Internal/SignalRClientLoggerExtensions.cs
@@ -86,7 +86,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Internal
             LoggerMessage.Define<string, string, string, int>(LogLevel.Trace, new EventId(24, nameof(PreparingStreamingInvocation)), "Preparing streaming invocation '{invocationId}' of '{target}', with return type '{returnType}' and {argumentCount} argument(s).");
 
         private static readonly Action<ILogger, Exception> _resettingKeepAliveTimer =
-            LoggerMessage.Define(LogLevel.Trace, new EventId(25, nameof(ResettingKeepAliveTimer)), "Resetting keep-alive timer, received a message from the server");
+            LoggerMessage.Define(LogLevel.Trace, new EventId(25, nameof(ResettingKeepAliveTimer)), "Resetting keep-alive timer, received a message from the server.");
 
         // Category: Streaming and NonStreaming
         private static readonly Action<ILogger, string, Exception> _invocationCreated =

--- a/src/Microsoft.AspNetCore.SignalR.Client.Core/Microsoft.AspNetCore.SignalR.Client.Core.csproj
+++ b/src/Microsoft.AspNetCore.SignalR.Client.Core/Microsoft.AspNetCore.SignalR.Client.Core.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <Description>Client for ASP.NET Core SignalR</Description>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <RootNamespace>Microsoft.AspNetCore.SignalR.Client</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/HubProtocolConstants.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/HubProtocolConstants.cs
@@ -1,6 +1,6 @@
 namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
 {
-    internal static class HubProtocolConstants
+    public static class HubProtocolConstants
     {
         public const int InvocationMessageType = 1;
         public const int StreamItemMessageType = 2;

--- a/src/Microsoft.AspNetCore.Sockets.Abstractions/IConnection.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Abstractions/IConnection.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -13,6 +13,7 @@ namespace Microsoft.AspNetCore.Sockets.Client
         Task StartAsync();
         Task SendAsync(byte[] data, CancellationToken cancellationToken);
         Task DisposeAsync();
+        Task AbortAsync(Exception ex);
 
         IDisposable OnReceived(Func<byte[], object, Task> callback, object state);
 

--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/HttpConnection.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/HttpConnection.cs
@@ -95,7 +95,7 @@ namespace Microsoft.AspNetCore.Sockets.Client
             _logger = _loggerFactory.CreateLogger<HttpConnection>();
             _httpOptions = httpOptions;
             _httpClient = _httpOptions?.HttpMessageHandler == null ? new HttpClient() : new HttpClient(_httpOptions?.HttpMessageHandler);
-            _httpClient.Timeout =  HttpClientTimeout;
+            _httpClient.Timeout = HttpClientTimeout;
             _transportFactory = transportFactory ?? throw new ArgumentNullException(nameof(transportFactory));
         }
 
@@ -303,7 +303,7 @@ namespace Microsoft.AspNetCore.Sockets.Client
             // Start the transport, giving it one end of the pipeline
             try
             {
-                await _transport.StartAsync(connectUrl, applicationSide, requestedTransferMode: GetTransferMode(), connectionId: _connectionId);
+                await _transport.StartAsync(connectUrl, applicationSide, GetTransferMode(), _connectionId, this);
 
                 // actual transfer mode can differ from the one that was requested so set it on the feature
                 Debug.Assert(_transport.Mode.HasValue, "transfer mode not set after transport started");
@@ -435,11 +435,25 @@ namespace Microsoft.AspNetCore.Sockets.Client
             }
         }
 
+        public async Task AbortAsync(Exception ex) => await DisposeAsyncCore(ex ?? new InvalidOperationException("Connection aborted")).ForceAsync();
+
         public async Task DisposeAsync() => await DisposeAsyncCore().ForceAsync();
 
-        private async Task DisposeAsyncCore()
+        private async Task DisposeAsyncCore(Exception ex = null)
         {
-            _logger.StoppingClient(_connectionId);
+            if (ex != null)
+            {
+                _logger.AbortingClient(ex, _connectionId);
+
+                // Immediately fault the close task. When the transport shuts down,
+                // it will trigger the close task to be completed, so we want to it be
+                // marked faulted before that happens
+                _closedTcs.TrySetException(ex);
+            }
+            else
+            {
+                _logger.StoppingClient(_connectionId);
+            }
 
             if (Interlocked.Exchange(ref _connectionState, ConnectionState.Disconnected) == ConnectionState.Initial)
             {
@@ -472,6 +486,7 @@ namespace Microsoft.AspNetCore.Sockets.Client
                 await _receiveLoopTask;
             }
 
+            // If we haven't already done so, trigger the Closed task.
             _closedTcs.TrySetResult(null);
             _httpClient?.Dispose();
         }

--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/HttpConnection.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/HttpConnection.cs
@@ -443,10 +443,10 @@ namespace Microsoft.AspNetCore.Sockets.Client
         {
             if (ex != null)
             {
-                _logger.AbortingClient(ex, _connectionId);
+                _logger.AbortingClient(_connectionId, ex);
 
                 // Immediately fault the close task. When the transport shuts down,
-                // it will trigger the close task to be completed, so we want to it be
+                // it will trigger the close task to be completed, so we want it to be
                 // marked faulted before that happens
                 _closedTcs.TrySetException(ex);
             }

--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/ITransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/ITransport.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNetCore.Sockets.Client
 {
     public interface ITransport
     {
-        Task StartAsync(Uri url, Channel<byte[], SendMessage> application, TransferMode requestedTransferMode, string connectionId);
+        Task StartAsync(Uri url, Channel<byte[], SendMessage> application, TransferMode requestedTransferMode, string connectionId, IConnection connection);
         Task StopAsync();
         TransferMode? Mode { get; }
     }

--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/Internal/SocketClientLoggerExtensions.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/Internal/SocketClientLoggerExtensions.cs
@@ -153,6 +153,9 @@ namespace Microsoft.AspNetCore.Sockets.Client.Internal
         private static readonly Action<ILogger, DateTime, string, string, Exception> _exceptionThrownFromCallback =
             LoggerMessage.Define<DateTime, string, string>(LogLevel.Error, new EventId(19, nameof(ExceptionThrownFromCallback)), "{time}: Connection Id {connectionId}: An exception was thrown from the '{callback}' callback");
 
+        private static readonly Action<ILogger, DateTime, string, Exception> _abortingClient =
+            LoggerMessage.Define<DateTime, string>(LogLevel.Error, new EventId(20, nameof(AbortingClient)), "{time}: Connection Id {connectionId}: Aborting client.");
+
 
         public static void StartTransport(this ILogger logger, string connectionId, TransferMode transferMode)
         {
@@ -503,6 +506,14 @@ namespace Microsoft.AspNetCore.Sockets.Client.Internal
             if (logger.IsEnabled(LogLevel.Debug))
             {
                 _sendingMessage(logger, DateTime.Now, connectionId, null);
+            }
+        }
+
+        public static void AbortingClient(this ILogger logger, Exception ex, string connectionId)
+        {
+            if (logger.IsEnabled(LogLevel.Information))
+            {
+                _abortingClient(logger, DateTime.Now, connectionId, ex);
             }
         }
 

--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/Internal/SocketClientLoggerExtensions.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/Internal/SocketClientLoggerExtensions.cs
@@ -509,9 +509,9 @@ namespace Microsoft.AspNetCore.Sockets.Client.Internal
             }
         }
 
-        public static void AbortingClient(this ILogger logger, Exception ex, string connectionId)
+        public static void AbortingClient(this ILogger logger, string connectionId, Exception ex)
         {
-            if (logger.IsEnabled(LogLevel.Information))
+            if (logger.IsEnabled(LogLevel.Error))
             {
                 _abortingClient(logger, DateTime.Now, connectionId, ex);
             }

--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/LongPollingTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/LongPollingTransport.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Sockets.Client.Http;
 using Microsoft.AspNetCore.Sockets.Client.Internal;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.AspNetCore.Sockets.Features;
 
 namespace Microsoft.AspNetCore.Sockets.Client
 {
@@ -42,12 +43,14 @@ namespace Microsoft.AspNetCore.Sockets.Client
             _logger = (loggerFactory ?? NullLoggerFactory.Instance).CreateLogger<LongPollingTransport>();
         }
 
-        public Task StartAsync(Uri url, Channel<byte[], SendMessage> application, TransferMode requestedTransferMode, string connectionId)
+        public Task StartAsync(Uri url, Channel<byte[], SendMessage> application, TransferMode requestedTransferMode, string connectionId, IConnection connection)
         {
             if (requestedTransferMode != TransferMode.Binary && requestedTransferMode != TransferMode.Text)
             {
                 throw new ArgumentException("Invalid transfer mode.", nameof(requestedTransferMode));
             }
+
+            connection.Features.Set<IConnectionInherentKeepAliveFeature>(new ConnectionInherentKeepAliveFeature(_httpClient.Timeout));
 
             _application = application;
             Mode = requestedTransferMode;

--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/LongPollingTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/LongPollingTransport.cs
@@ -2,17 +2,16 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
-using System.Threading.Tasks;
 using System.Threading.Channels;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Sockets.Client.Http;
 using Microsoft.AspNetCore.Sockets.Client.Internal;
+using Microsoft.AspNetCore.Sockets.Features;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.AspNetCore.Sockets.Features;
 
 namespace Microsoft.AspNetCore.Sockets.Client
 {

--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/ServerSentEventsTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/ServerSentEventsTransport.cs
@@ -49,7 +49,7 @@ namespace Microsoft.AspNetCore.Sockets.Client
             _logger = (loggerFactory ?? NullLoggerFactory.Instance).CreateLogger<ServerSentEventsTransport>();
         }
 
-        public Task StartAsync(Uri url, Channel<byte[], SendMessage> application, TransferMode requestedTransferMode, string connectionId)
+        public Task StartAsync(Uri url, Channel<byte[], SendMessage> application, TransferMode requestedTransferMode, string connectionId, IConnection connection)
         {
             if (requestedTransferMode != TransferMode.Binary && requestedTransferMode != TransferMode.Text)
             {

--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/WebSocketsTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/WebSocketsTransport.cs
@@ -55,7 +55,7 @@ namespace Microsoft.AspNetCore.Sockets.Client
             _logger = (loggerFactory ?? NullLoggerFactory.Instance).CreateLogger<WebSocketsTransport>();
         }
 
-        public async Task StartAsync(Uri url, Channel<byte[], SendMessage> application, TransferMode requestedTransferMode, string connectionId)
+        public async Task StartAsync(Uri url, Channel<byte[], SendMessage> application, TransferMode requestedTransferMode, string connectionId, IConnection connection)
         {
             if (url == null)
             {

--- a/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/HubConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/HubConnectionTests.cs
@@ -695,7 +695,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
                     {
                         // We should have timed out the other transports.
                         var ex = await Assert.ThrowsAsync<TimeoutException>(async () => await hubConnection.Closed.OrTimeout(milliseconds: 500));
-                        Assert.Equal("Server timeout elapsed without receiving a message from the server.", ex.Message);
+                        Assert.Equal("Server timeout (100.00ms) elapsed without receiving a message from the server.", ex.Message);
                     }
                 }
             }

--- a/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/HubConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/HubConnectionTests.cs
@@ -655,6 +655,56 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
             }
         }
 
+        [Theory]
+        [MemberData(nameof(TransportTypes))]
+        public async Task KeepAliveBehaviorIsCorrect(TransportType transportType)
+        {
+            using (StartLog(out var loggerFactory))
+            {
+                var hubConnection = new HubConnectionBuilder()
+                    .WithUrl(_serverFixture.Url + "/default")
+                    .WithTransport(transportType)
+                    .WithLoggerFactory(loggerFactory)
+                    .WithHeader("X-test", "42")
+                    .WithHeader("X-42", "test")
+                    .Build();
+                hubConnection.ServerTimeout = TimeSpan.FromMilliseconds(100);
+                try
+                {
+                    await hubConnection.StartAsync().OrTimeout();
+                    await hubConnection.InvokeAsync("Echo", "foo");
+                    await Task.Delay(50);
+                    await hubConnection.InvokeAsync("Echo", "foo");
+                    await Task.Delay(50);
+                    await hubConnection.InvokeAsync("Echo", "foo");
+                    await Task.Delay(50);
+                    Assert.False(hubConnection.Closed.IsCompleted);
+
+                    if (transportType != TransportType.LongPolling)
+                    {
+                        var ex = await Assert.ThrowsAsync<TimeoutException>(async () => await hubConnection.Closed.OrTimeout(milliseconds: 500));
+                        Assert.Equal("Server timeout elapsed without receiving a message from the server.", ex.Message);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    loggerFactory.CreateLogger<HubConnectionTests>().LogError(ex, "Exception from test");
+                    throw;
+                }
+                finally
+                {
+                    try
+                    {
+                        await hubConnection.DisposeAsync().OrTimeout();
+                    }
+                    catch (TimeoutException) when (transportType != TransportType.LongPolling)
+                    {
+                        // Already observed this exception!
+                    }
+                }
+            }
+        }
+
         public static IEnumerable<object[]> HubProtocolsAndTransportsAndHubPaths
         {
             get

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.cs
@@ -264,7 +264,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
             var mockTransport = new Mock<ITransport>();
             Channel<byte[], SendMessage> channel = null;
             mockTransport.Setup(t => t.StartAsync(It.IsAny<Uri>(), It.IsAny<Channel<byte[], SendMessage>>(), It.IsAny<TransferMode>(), It.IsAny<string>(), It.IsAny<IConnection>()))
-                .Returns<Uri, Channel<byte[], SendMessage>, TransferMode, string>((url, c, transferMode, connectionId) =>
+                .Returns<Uri, Channel<byte[], SendMessage>, TransferMode, string, IConnection>((url, c, transferMode, connectionId, _) =>
                 {
                     channel = c;
                     return Task.CompletedTask;
@@ -312,7 +312,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
             var mockTransport = new Mock<ITransport>();
             Channel<byte[], SendMessage> channel = null;
             mockTransport.Setup(t => t.StartAsync(It.IsAny<Uri>(), It.IsAny<Channel<byte[], SendMessage>>(), It.IsAny<TransferMode>(), It.IsAny<string>(), It.IsAny<IConnection>()))
-                .Returns<Uri, Channel<byte[], SendMessage>, TransferMode, string>((url, c, transferMode, connectionId) =>
+                .Returns<Uri, Channel<byte[], SendMessage>, TransferMode, string, IConnection>((url, c, transferMode, connectionId, _) =>
                 {
                     channel = c;
                     return Task.CompletedTask;
@@ -369,7 +369,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
             var mockTransport = new Mock<ITransport>();
             Channel<byte[], SendMessage> channel = null;
             mockTransport.Setup(t => t.StartAsync(It.IsAny<Uri>(), It.IsAny<Channel<byte[], SendMessage>>(), It.IsAny<TransferMode>(), It.IsAny<string>(), It.IsAny<IConnection>()))
-                .Returns<Uri, Channel<byte[], SendMessage>, TransferMode, string>((url, c, transferMode, connectionId) =>
+                .Returns<Uri, Channel<byte[], SendMessage>, TransferMode, string, IConnection>((url, c, transferMode, connectionId, _) =>
                 {
                     channel = c;
                     return Task.CompletedTask;
@@ -414,7 +414,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
             var mockTransport = new Mock<ITransport>();
             Channel<byte[], SendMessage> channel = null;
             mockTransport.Setup(t => t.StartAsync(It.IsAny<Uri>(), It.IsAny<Channel<byte[], SendMessage>>(), It.IsAny<TransferMode>(), It.IsAny<string>(), It.IsAny<IConnection>()))
-                .Returns<Uri, Channel<byte[], SendMessage>, TransferMode, string>((url, c, transferMode, connectionId) =>
+                .Returns<Uri, Channel<byte[], SendMessage>, TransferMode, string, IConnection>((url, c, transferMode, connectionId, _) =>
                 {
                     channel = c;
                     return Task.CompletedTask;
@@ -926,7 +926,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
             var mockTransport = new Mock<ITransport>();
             Channel<byte[], SendMessage> channel = null;
             mockTransport.Setup(t => t.StartAsync(It.IsAny<Uri>(), It.IsAny<Channel<byte[], SendMessage>>(), It.IsAny<TransferMode>(), It.IsAny<string>(), It.IsAny<IConnection>()))
-                .Returns<Uri, Channel<byte[], SendMessage>, TransferMode, string>((url, c, transferMode, connectionId) =>
+                .Returns<Uri, Channel<byte[], SendMessage>, TransferMode, string, IConnection>((url, c, transferMode, connectionId, _) =>
                 {
                     channel = c;
                     return Task.CompletedTask;

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.cs
@@ -155,7 +155,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
             releaseDisposeTcs.SetResult(null);
             await disposeTask.OrTimeout();
 
-            transport.Verify(t => t.StartAsync(It.IsAny<Uri>(), It.IsAny<Channel<byte[], SendMessage>>(), It.IsAny<TransferMode>(), It.IsAny<string>()), Times.Never);
+            transport.Verify(t => t.StartAsync(It.IsAny<Uri>(), It.IsAny<Channel<byte[], SendMessage>>(), It.IsAny<TransferMode>(), It.IsAny<string>(), It.IsAny<IConnection>()), Times.Never);
         }
 
         [Fact]
@@ -263,7 +263,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
 
             var mockTransport = new Mock<ITransport>();
             Channel<byte[], SendMessage> channel = null;
-            mockTransport.Setup(t => t.StartAsync(It.IsAny<Uri>(), It.IsAny<Channel<byte[], SendMessage>>(), It.IsAny<TransferMode>(), It.IsAny<string>()))
+            mockTransport.Setup(t => t.StartAsync(It.IsAny<Uri>(), It.IsAny<Channel<byte[], SendMessage>>(), It.IsAny<TransferMode>(), It.IsAny<string>(), It.IsAny<IConnection>()))
                 .Returns<Uri, Channel<byte[], SendMessage>, TransferMode, string>((url, c, transferMode, connectionId) =>
                 {
                     channel = c;
@@ -311,7 +311,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
 
             var mockTransport = new Mock<ITransport>();
             Channel<byte[], SendMessage> channel = null;
-            mockTransport.Setup(t => t.StartAsync(It.IsAny<Uri>(), It.IsAny<Channel<byte[], SendMessage>>(), It.IsAny<TransferMode>(), It.IsAny<string>()))
+            mockTransport.Setup(t => t.StartAsync(It.IsAny<Uri>(), It.IsAny<Channel<byte[], SendMessage>>(), It.IsAny<TransferMode>(), It.IsAny<string>(), It.IsAny<IConnection>()))
                 .Returns<Uri, Channel<byte[], SendMessage>, TransferMode, string>((url, c, transferMode, connectionId) =>
                 {
                     channel = c;
@@ -368,7 +368,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
 
             var mockTransport = new Mock<ITransport>();
             Channel<byte[], SendMessage> channel = null;
-            mockTransport.Setup(t => t.StartAsync(It.IsAny<Uri>(), It.IsAny<Channel<byte[], SendMessage>>(), It.IsAny<TransferMode>(), It.IsAny<string>()))
+            mockTransport.Setup(t => t.StartAsync(It.IsAny<Uri>(), It.IsAny<Channel<byte[], SendMessage>>(), It.IsAny<TransferMode>(), It.IsAny<string>(), It.IsAny<IConnection>()))
                 .Returns<Uri, Channel<byte[], SendMessage>, TransferMode, string>((url, c, transferMode, connectionId) =>
                 {
                     channel = c;
@@ -413,7 +413,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
 
             var mockTransport = new Mock<ITransport>();
             Channel<byte[], SendMessage> channel = null;
-            mockTransport.Setup(t => t.StartAsync(It.IsAny<Uri>(), It.IsAny<Channel<byte[], SendMessage>>(), It.IsAny<TransferMode>(), It.IsAny<string>()))
+            mockTransport.Setup(t => t.StartAsync(It.IsAny<Uri>(), It.IsAny<Channel<byte[], SendMessage>>(), It.IsAny<TransferMode>(), It.IsAny<string>(), It.IsAny<IConnection>()))
                 .Returns<Uri, Channel<byte[], SendMessage>, TransferMode, string>((url, c, transferMode, connectionId) =>
                 {
                     channel = c;
@@ -925,7 +925,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
 
             var mockTransport = new Mock<ITransport>();
             Channel<byte[], SendMessage> channel = null;
-            mockTransport.Setup(t => t.StartAsync(It.IsAny<Uri>(), It.IsAny<Channel<byte[], SendMessage>>(), It.IsAny<TransferMode>(), It.IsAny<string>()))
+            mockTransport.Setup(t => t.StartAsync(It.IsAny<Uri>(), It.IsAny<Channel<byte[], SendMessage>>(), It.IsAny<TransferMode>(), It.IsAny<string>(), It.IsAny<IConnection>()))
                 .Returns<Uri, Channel<byte[], SendMessage>, TransferMode, string>((url, c, transferMode, connectionId) =>
                 {
                     channel = c;
@@ -947,7 +947,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
             await connection.DisposeAsync().OrTimeout();
 
             mockTransport.Verify(t => t.StartAsync(
-                It.IsAny<Uri>(), It.IsAny<Channel<byte[], SendMessage>>(), TransferMode.Text, It.IsAny<string>()), Times.Once);
+                It.IsAny<Uri>(), It.IsAny<Channel<byte[], SendMessage>>(), TransferMode.Text, It.IsAny<string>(), It.IsAny<IConnection>()), Times.Once);
             Assert.NotNull(transferModeFeature);
             Assert.Equal(TransferMode.Binary, transferModeFeature.TransferMode);
         }

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.cs
@@ -236,7 +236,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
 
             hubConnection.ServerTimeout = TimeSpan.FromMilliseconds(100);
 
-            await hubConnection.StartAsync();
+            await hubConnection.StartAsync().OrTimeout();
             try
             {
                 await Task.Delay(300);

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.cs
@@ -195,7 +195,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
 
             hubConnection.ServerTimeout = TimeSpan.FromMilliseconds(100);
 
-            await hubConnection.StartAsync();
+            await hubConnection.StartAsync().OrTimeout();
             var ex = await Assert.ThrowsAsync<TimeoutException>(async () => await hubConnection.Closed.OrTimeout());
             Assert.Equal("Server timeout (100.00ms) elapsed without receiving a message from the server.", ex.Message);
         }

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.cs
@@ -200,54 +200,6 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
             Assert.Equal("Server timeout (100.00ms) elapsed without receiving a message from the server.", ex.Message);
         }
 
-        [Fact(Skip = "Not really able to do this reliably")]
-        public async Task ConnectionNotTerminatedIfServerKeepsSending()
-        {
-            var connection = new TestConnection();
-            var hubConnection = new HubConnection(connection, new JsonHubProtocol(), new LoggerFactory());
-
-            hubConnection.ServerTimeout = TimeSpan.FromMilliseconds(100);
-
-            await hubConnection.StartAsync();
-
-            try
-            {
-                await connection.ReceiveJsonMessage(new { type = HubProtocolConstants.PingMessageType });
-                await Task.Delay(50);
-                await connection.ReceiveJsonMessage(new { type = HubProtocolConstants.PingMessageType });
-                await Task.Delay(50);
-                await connection.ReceiveJsonMessage(new { type = HubProtocolConstants.PingMessageType });
-                await Task.Delay(50);
-
-                Assert.False(hubConnection.Closed.IsCompleted);
-            }
-            finally
-            {
-                await hubConnection.DisposeAsync();
-            }
-        }
-
-        [Fact]
-        public async Task ServerTimeoutIgnoredIfTransportHasInherentKeepAlive()
-        {
-            var connection = new TestConnection();
-            connection.Features.Set<IConnectionInherentKeepAliveFeature>(new ConnectionInherentKeepAliveFeature(TimeSpan.FromSeconds(1)));
-            var hubConnection = new HubConnection(connection, new JsonHubProtocol(), new LoggerFactory());
-
-            hubConnection.ServerTimeout = TimeSpan.FromMilliseconds(100);
-
-            await hubConnection.StartAsync().OrTimeout();
-            try
-            {
-                await Task.Delay(300);
-                Assert.False(hubConnection.Closed.IsCompleted);
-            }
-            finally
-            {
-                await hubConnection.DisposeAsync();
-            }
-        }
-
         // Moq really doesn't handle out parameters well, so to make these tests work I added a manual mock -anurse
         private class MockHubProtocol : IHubProtocol
         {

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.cs
@@ -212,11 +212,11 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
 
             try
             {
-                await connection.ReceiveJsonMessage(new { type = 6 });
+                await connection.ReceiveJsonMessage(new { type = HubProtocolConstants.PingMessageType });
                 await Task.Delay(50);
-                await connection.ReceiveJsonMessage(new { type = 6 });
+                await connection.ReceiveJsonMessage(new { type = HubProtocolConstants.PingMessageType });
                 await Task.Delay(50);
-                await connection.ReceiveJsonMessage(new { type = 6 });
+                await connection.ReceiveJsonMessage(new { type = HubProtocolConstants.PingMessageType });
                 await Task.Delay(50);
 
                 Assert.False(hubConnection.Closed.IsCompleted);

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.cs
@@ -200,7 +200,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
             Assert.Equal("Server timeout (100.00ms) elapsed without receiving a message from the server.", ex.Message);
         }
 
-        [Fact]
+        [Fact(Skip = "Not really able to do this reliably")]
         public async Task ConnectionNotTerminatedIfServerKeepsSending()
         {
             var connection = new TestConnection();

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.cs
@@ -197,7 +197,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
 
             await hubConnection.StartAsync();
             var ex = await Assert.ThrowsAsync<TimeoutException>(async () => await hubConnection.Closed.OrTimeout());
-            Assert.Equal("Server timeout elapsed without receiving a message from the server.", ex.Message);
+            Assert.Equal("Server timeout (100.00ms) elapsed without receiving a message from the server.", ex.Message);
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.cs
@@ -34,6 +34,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
         public async Task DisposeAsyncCallsConnectionStart()
         {
             var connection = new Mock<IConnection>();
+            connection.Setup(m => m.Features).Returns(new FeatureCollection());
             connection.Setup(m => m.StartAsync()).Verifiable();
             var hubConnection = new HubConnection(connection.Object, Mock.Of<IHubProtocol>(), null);
             await hubConnection.DisposeAsync();

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/LongPollingTransportTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/LongPollingTransportTests.cs
@@ -15,6 +15,7 @@ using Microsoft.AspNetCore.Sockets.Internal;
 using Moq;
 using Moq.Protected;
 using Xunit;
+using Microsoft.AspNetCore.SignalR.Client.Tests;
 
 namespace Microsoft.AspNetCore.Client.Tests
 {
@@ -43,7 +44,7 @@ namespace Microsoft.AspNetCore.Client.Tests
                     var connectionToTransport = Channel.CreateUnbounded<SendMessage>();
                     var transportToConnection = Channel.CreateUnbounded<byte[]>();
                     var channelConnection = new ChannelConnection<SendMessage, byte[]>(connectionToTransport, transportToConnection);
-                    await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection, TransferMode.Binary, connectionId: string.Empty, connection: Mock.Of<IConnection>());
+                    await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection, TransferMode.Binary, connectionId: string.Empty, connection: new TestConnection());
 
                     transportActiveTask = longPollingTransport.Running;
 
@@ -79,7 +80,7 @@ namespace Microsoft.AspNetCore.Client.Tests
                     var connectionToTransport = Channel.CreateUnbounded<SendMessage>();
                     var transportToConnection = Channel.CreateUnbounded<byte[]>();
                     var channelConnection = ChannelConnection.Create(connectionToTransport, transportToConnection);
-                    await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection, TransferMode.Binary, connectionId: string.Empty, connection: Mock.Of<IConnection>());
+                    await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection, TransferMode.Binary, connectionId: string.Empty, connection: new TestConnection());
 
                     await longPollingTransport.Running.OrTimeout();
                     Assert.True(transportToConnection.Reader.Completion.IsCompleted);
@@ -132,7 +133,7 @@ namespace Microsoft.AspNetCore.Client.Tests
                     var connectionToTransport = Channel.CreateUnbounded<SendMessage>();
                     var transportToConnection = Channel.CreateUnbounded<byte[]>();
                     var channelConnection = new ChannelConnection<SendMessage, byte[]>(connectionToTransport, transportToConnection);
-                    await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection, TransferMode.Binary, connectionId: string.Empty, connection: Mock.Of<IConnection>());
+                    await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection, TransferMode.Binary, connectionId: string.Empty, connection: new TestConnection());
 
                     var data = await transportToConnection.Reader.ReadAllAsync().OrTimeout();
                     await longPollingTransport.Running.OrTimeout();
@@ -168,7 +169,7 @@ namespace Microsoft.AspNetCore.Client.Tests
                     var connectionToTransport = Channel.CreateUnbounded<SendMessage>();
                     var transportToConnection = Channel.CreateUnbounded<byte[]>();
                     var channelConnection = new ChannelConnection<SendMessage, byte[]>(connectionToTransport, transportToConnection);
-                    await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection, TransferMode.Binary, connectionId: string.Empty, connection: Mock.Of<IConnection>());
+                    await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection, TransferMode.Binary, connectionId: string.Empty, connection: new TestConnection());
 
                     var exception =
                         await Assert.ThrowsAsync<HttpRequestException>(async () => await transportToConnection.Reader.Completion.OrTimeout());
@@ -204,7 +205,7 @@ namespace Microsoft.AspNetCore.Client.Tests
                     var connectionToTransport = Channel.CreateUnbounded<SendMessage>();
                     var transportToConnection = Channel.CreateUnbounded<byte[]>();
                     var channelConnection = new ChannelConnection<SendMessage, byte[]>(connectionToTransport, transportToConnection);
-                    await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection, TransferMode.Binary, connectionId: string.Empty, connection: Mock.Of<IConnection>());
+                    await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection, TransferMode.Binary, connectionId: string.Empty, connection: new TestConnection());
 
                     await connectionToTransport.Writer.WriteAsync(new SendMessage());
 
@@ -245,7 +246,7 @@ namespace Microsoft.AspNetCore.Client.Tests
                     var connectionToTransport = Channel.CreateUnbounded<SendMessage>();
                     var transportToConnection = Channel.CreateUnbounded<byte[]>();
                     var channelConnection = new ChannelConnection<SendMessage, byte[]>(connectionToTransport, transportToConnection);
-                    await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection, TransferMode.Binary, connectionId: string.Empty, connection: Mock.Of<IConnection>());
+                    await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection, TransferMode.Binary, connectionId: string.Empty, connection: new TestConnection());
 
                     connectionToTransport.Writer.Complete();
 
@@ -296,7 +297,7 @@ namespace Microsoft.AspNetCore.Client.Tests
                     var channelConnection = new ChannelConnection<SendMessage, byte[]>(connectionToTransport, transportToConnection);
 
                     // Start the transport
-                    await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection, TransferMode.Binary, connectionId: string.Empty, connection: Mock.Of<IConnection>());
+                    await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection, TransferMode.Binary, connectionId: string.Empty, connection: new TestConnection());
 
                     // Wait for the transport to finish
                     await longPollingTransport.Running.OrTimeout();
@@ -361,7 +362,7 @@ namespace Microsoft.AspNetCore.Client.Tests
                     await connectionToTransport.Writer.WriteAsync(new SendMessage(Encoding.UTF8.GetBytes("World"), tcs2)).OrTimeout();
 
                     // Start the transport
-                    await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection, TransferMode.Binary, connectionId: string.Empty, connection: Mock.Of<IConnection>());
+                    await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection, TransferMode.Binary, connectionId: string.Empty, connection: new TestConnection());
 
                     connectionToTransport.Writer.Complete();
 
@@ -404,7 +405,7 @@ namespace Microsoft.AspNetCore.Client.Tests
                     var channelConnection = new ChannelConnection<SendMessage, byte[]>(connectionToTransport, transportToConnection);
 
                     Assert.Null(longPollingTransport.Mode);
-                    await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection, transferMode, connectionId: string.Empty, connection: Mock.Of<IConnection>());
+                    await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection, transferMode, connectionId: string.Empty, connection: new TestConnection());
                     Assert.Equal(transferMode, longPollingTransport.Mode);
                 }
                 finally
@@ -430,7 +431,7 @@ namespace Microsoft.AspNetCore.Client.Tests
             {
                 var longPollingTransport = new LongPollingTransport(httpClient);
                 var exception = await Assert.ThrowsAsync<ArgumentException>(() =>
-                    longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), null, TransferMode.Text | TransferMode.Binary, connectionId: string.Empty, connection: Mock.Of<IConnection>()));
+                    longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), null, TransferMode.Text | TransferMode.Binary, connectionId: string.Empty, connection: new TestConnection()));
 
                 Assert.Contains("Invalid transfer mode.", exception.Message);
                 Assert.Equal("requestedTransferMode", exception.ParamName);
@@ -468,7 +469,7 @@ namespace Microsoft.AspNetCore.Client.Tests
                     var connectionToTransport = Channel.CreateUnbounded<SendMessage>();
                     var transportToConnection = Channel.CreateUnbounded<byte[]>();
                     var channelConnection = new ChannelConnection<SendMessage, byte[]>(connectionToTransport, transportToConnection);
-                    await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection, TransferMode.Binary, connectionId: string.Empty, connection: Mock.Of<IConnection>());
+                    await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection, TransferMode.Binary, connectionId: string.Empty, connection: new TestConnection());
 
                     var completedTask = await Task.WhenAny(completionTcs.Task, longPollingTransport.Running).OrTimeout();
                     Assert.Equal(completionTcs.Task, completedTask);

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/LongPollingTransportTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/LongPollingTransportTests.cs
@@ -9,13 +9,13 @@ using System.Text;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.SignalR.Client.Tests;
 using Microsoft.AspNetCore.Sockets;
 using Microsoft.AspNetCore.Sockets.Client;
 using Microsoft.AspNetCore.Sockets.Internal;
 using Moq;
 using Moq.Protected;
 using Xunit;
-using Microsoft.AspNetCore.SignalR.Client.Tests;
 
 namespace Microsoft.AspNetCore.Client.Tests
 {

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/LongPollingTransportTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/LongPollingTransportTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.AspNetCore.Client.Tests
                     var connectionToTransport = Channel.CreateUnbounded<SendMessage>();
                     var transportToConnection = Channel.CreateUnbounded<byte[]>();
                     var channelConnection = new ChannelConnection<SendMessage, byte[]>(connectionToTransport, transportToConnection);
-                    await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection, TransferMode.Binary, connectionId: string.Empty);
+                    await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection, TransferMode.Binary, connectionId: string.Empty, connection: Mock.Of<IConnection>());
 
                     transportActiveTask = longPollingTransport.Running;
 
@@ -79,7 +79,7 @@ namespace Microsoft.AspNetCore.Client.Tests
                     var connectionToTransport = Channel.CreateUnbounded<SendMessage>();
                     var transportToConnection = Channel.CreateUnbounded<byte[]>();
                     var channelConnection = ChannelConnection.Create(connectionToTransport, transportToConnection);
-                    await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection, TransferMode.Binary, connectionId: string.Empty);
+                    await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection, TransferMode.Binary, connectionId: string.Empty, connection: Mock.Of<IConnection>());
 
                     await longPollingTransport.Running.OrTimeout();
                     Assert.True(transportToConnection.Reader.Completion.IsCompleted);
@@ -132,7 +132,7 @@ namespace Microsoft.AspNetCore.Client.Tests
                     var connectionToTransport = Channel.CreateUnbounded<SendMessage>();
                     var transportToConnection = Channel.CreateUnbounded<byte[]>();
                     var channelConnection = new ChannelConnection<SendMessage, byte[]>(connectionToTransport, transportToConnection);
-                    await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection, TransferMode.Binary, connectionId: string.Empty);
+                    await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection, TransferMode.Binary, connectionId: string.Empty, connection: Mock.Of<IConnection>());
 
                     var data = await transportToConnection.Reader.ReadAllAsync().OrTimeout();
                     await longPollingTransport.Running.OrTimeout();
@@ -168,7 +168,7 @@ namespace Microsoft.AspNetCore.Client.Tests
                     var connectionToTransport = Channel.CreateUnbounded<SendMessage>();
                     var transportToConnection = Channel.CreateUnbounded<byte[]>();
                     var channelConnection = new ChannelConnection<SendMessage, byte[]>(connectionToTransport, transportToConnection);
-                    await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection, TransferMode.Binary, connectionId: string.Empty);
+                    await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection, TransferMode.Binary, connectionId: string.Empty, connection: Mock.Of<IConnection>());
 
                     var exception =
                         await Assert.ThrowsAsync<HttpRequestException>(async () => await transportToConnection.Reader.Completion.OrTimeout());
@@ -204,7 +204,7 @@ namespace Microsoft.AspNetCore.Client.Tests
                     var connectionToTransport = Channel.CreateUnbounded<SendMessage>();
                     var transportToConnection = Channel.CreateUnbounded<byte[]>();
                     var channelConnection = new ChannelConnection<SendMessage, byte[]>(connectionToTransport, transportToConnection);
-                    await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection, TransferMode.Binary, connectionId: string.Empty);
+                    await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection, TransferMode.Binary, connectionId: string.Empty, connection: Mock.Of<IConnection>());
 
                     await connectionToTransport.Writer.WriteAsync(new SendMessage());
 
@@ -245,7 +245,7 @@ namespace Microsoft.AspNetCore.Client.Tests
                     var connectionToTransport = Channel.CreateUnbounded<SendMessage>();
                     var transportToConnection = Channel.CreateUnbounded<byte[]>();
                     var channelConnection = new ChannelConnection<SendMessage, byte[]>(connectionToTransport, transportToConnection);
-                    await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection, TransferMode.Binary, connectionId: string.Empty);
+                    await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection, TransferMode.Binary, connectionId: string.Empty, connection: Mock.Of<IConnection>());
 
                     connectionToTransport.Writer.Complete();
 
@@ -296,7 +296,7 @@ namespace Microsoft.AspNetCore.Client.Tests
                     var channelConnection = new ChannelConnection<SendMessage, byte[]>(connectionToTransport, transportToConnection);
 
                     // Start the transport
-                    await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection, TransferMode.Binary, connectionId: string.Empty);
+                    await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection, TransferMode.Binary, connectionId: string.Empty, connection: Mock.Of<IConnection>());
 
                     // Wait for the transport to finish
                     await longPollingTransport.Running.OrTimeout();
@@ -361,7 +361,7 @@ namespace Microsoft.AspNetCore.Client.Tests
                     await connectionToTransport.Writer.WriteAsync(new SendMessage(Encoding.UTF8.GetBytes("World"), tcs2)).OrTimeout();
 
                     // Start the transport
-                    await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection, TransferMode.Binary, connectionId: string.Empty);
+                    await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection, TransferMode.Binary, connectionId: string.Empty, connection: Mock.Of<IConnection>());
 
                     connectionToTransport.Writer.Complete();
 
@@ -404,7 +404,7 @@ namespace Microsoft.AspNetCore.Client.Tests
                     var channelConnection = new ChannelConnection<SendMessage, byte[]>(connectionToTransport, transportToConnection);
 
                     Assert.Null(longPollingTransport.Mode);
-                    await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection, transferMode, connectionId: string.Empty);
+                    await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection, transferMode, connectionId: string.Empty, connection: Mock.Of<IConnection>());
                     Assert.Equal(transferMode, longPollingTransport.Mode);
                 }
                 finally
@@ -430,7 +430,7 @@ namespace Microsoft.AspNetCore.Client.Tests
             {
                 var longPollingTransport = new LongPollingTransport(httpClient);
                 var exception = await Assert.ThrowsAsync<ArgumentException>(() =>
-                    longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), null, TransferMode.Text | TransferMode.Binary, connectionId: string.Empty));
+                    longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), null, TransferMode.Text | TransferMode.Binary, connectionId: string.Empty, connection: Mock.Of<IConnection>()));
 
                 Assert.Contains("Invalid transfer mode.", exception.Message);
                 Assert.Equal("requestedTransferMode", exception.ParamName);
@@ -468,7 +468,7 @@ namespace Microsoft.AspNetCore.Client.Tests
                     var connectionToTransport = Channel.CreateUnbounded<SendMessage>();
                     var transportToConnection = Channel.CreateUnbounded<byte[]>();
                     var channelConnection = new ChannelConnection<SendMessage, byte[]>(connectionToTransport, transportToConnection);
-                    await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection, TransferMode.Binary, connectionId: string.Empty);
+                    await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection, TransferMode.Binary, connectionId: string.Empty, connection: Mock.Of<IConnection>());
 
                     var completedTask = await Task.WhenAny(completionTcs.Task, longPollingTransport.Running).OrTimeout();
                     Assert.Equal(completionTcs.Task, completedTask);

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/ServerSentEventsTransportTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/ServerSentEventsTransportTests.cs
@@ -55,7 +55,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                     var transportToConnection = Channel.CreateUnbounded<byte[]>();
                     var channelConnection = new ChannelConnection<SendMessage, byte[]>(connectionToTransport, transportToConnection);
                     await sseTransport.StartAsync(
-                        new Uri("http://fakeuri.org"), channelConnection, TransferMode.Text, connectionId: string.Empty).OrTimeout();
+                        new Uri("http://fakeuri.org"), channelConnection, TransferMode.Text, connectionId: string.Empty, connection: Mock.Of<IConnection>()).OrTimeout();
 
                     await eventStreamTcs.Task.OrTimeout();
                     await sseTransport.StopAsync().OrTimeout();
@@ -108,7 +108,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                     var transportToConnection = Channel.CreateUnbounded<byte[]>();
                     var channelConnection = new ChannelConnection<SendMessage, byte[]>(connectionToTransport, transportToConnection);
                     await sseTransport.StartAsync(
-                        new Uri("http://fakeuri.org"), channelConnection, TransferMode.Text, connectionId: string.Empty).OrTimeout();
+                        new Uri("http://fakeuri.org"), channelConnection, TransferMode.Text, connectionId: string.Empty, connection: Mock.Of<IConnection>()).OrTimeout();
 
                     transportActiveTask = sseTransport.Running;
                     Assert.False(transportActiveTask.IsCompleted);
@@ -156,7 +156,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                 var transportToConnection = Channel.CreateUnbounded<byte[]>();
                 var channelConnection = new ChannelConnection<SendMessage, byte[]>(connectionToTransport, transportToConnection);
                 await sseTransport.StartAsync(
-                    new Uri("http://fakeuri.org"), channelConnection, TransferMode.Text, connectionId: string.Empty).OrTimeout();
+                    new Uri("http://fakeuri.org"), channelConnection, TransferMode.Text, connectionId: string.Empty, connection: Mock.Of<IConnection>()).OrTimeout();
 
                 var exception = await Assert.ThrowsAsync<FormatException>(() => sseTransport.Running.OrTimeout());
                 Assert.Equal("Incomplete message.", exception.Message);
@@ -202,7 +202,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                 var channelConnection = new ChannelConnection<SendMessage, byte[]>(connectionToTransport, transportToConnection);
 
                 await sseTransport.StartAsync(
-                    new Uri("http://fakeuri.org"), channelConnection, TransferMode.Text, connectionId: string.Empty).OrTimeout();
+                    new Uri("http://fakeuri.org"), channelConnection, TransferMode.Text, connectionId: string.Empty, connection: Mock.Of<IConnection>()).OrTimeout();
                 await eventStreamTcs.Task;
 
                 var sendTcs = new TaskCompletionSource<object>();
@@ -249,7 +249,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                 var channelConnection = new ChannelConnection<SendMessage, byte[]>(connectionToTransport, transportToConnection);
 
                 await sseTransport.StartAsync(
-                    new Uri("http://fakeuri.org"), channelConnection, TransferMode.Text, connectionId: string.Empty).OrTimeout();
+                    new Uri("http://fakeuri.org"), channelConnection, TransferMode.Text, connectionId: string.Empty, connection: Mock.Of<IConnection>()).OrTimeout();
                 await eventStreamTcs.Task.OrTimeout();
 
                 connectionToTransport.Writer.TryComplete(null);
@@ -278,7 +278,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                 var transportToConnection = Channel.CreateUnbounded<byte[]>();
                 var channelConnection = new ChannelConnection<SendMessage, byte[]>(connectionToTransport, transportToConnection);
                 await sseTransport.StartAsync(
-                    new Uri("http://fakeuri.org"), channelConnection, TransferMode.Text, connectionId: string.Empty).OrTimeout();
+                    new Uri("http://fakeuri.org"), channelConnection, TransferMode.Text, connectionId: string.Empty, connection: Mock.Of<IConnection>()).OrTimeout();
 
                 var message = await transportToConnection.Reader.ReadAsync().AsTask().OrTimeout();
                 Assert.Equal("3:abc", Encoding.ASCII.GetString(message));
@@ -308,7 +308,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                 var transportToConnection = Channel.CreateUnbounded<byte[]>();
                 var channelConnection = new ChannelConnection<SendMessage, byte[]>(connectionToTransport, transportToConnection);
                 Assert.Null(sseTransport.Mode);
-                await sseTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection, transferMode, connectionId: string.Empty).OrTimeout();
+                await sseTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection, transferMode, connectionId: string.Empty, connection: Mock.Of<IConnection>()).OrTimeout();
                 Assert.Equal(TransferMode.Text, sseTransport.Mode);
                 await sseTransport.StopAsync().OrTimeout();
             }
@@ -333,7 +333,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                 var transportToConnection = Channel.CreateUnbounded<byte[]>();
                 var channelConnection = new ChannelConnection<SendMessage, byte[]>(connectionToTransport, transportToConnection);
                 var exception = await Assert.ThrowsAsync<ArgumentException>(() =>
-                    sseTransport.StartAsync(new Uri("http://fakeuri.org"), null, TransferMode.Text | TransferMode.Binary, connectionId: string.Empty));
+                    sseTransport.StartAsync(new Uri("http://fakeuri.org"), null, TransferMode.Text | TransferMode.Binary, connectionId: string.Empty, connection: Mock.Of<IConnection>()));
 
                 Assert.Contains("Invalid transfer mode.", exception.Message);
                 Assert.Equal("requestedTransferMode", exception.ParamName);

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/TestConnection.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/TestConnection.cs
@@ -48,9 +48,22 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
             _receiveLoop = ReceiveLoopAsync(_receiveShutdownToken.Token);
         }
 
-        public Task DisposeAsync()
+        public Task AbortAsync(Exception ex) => DisposeCoreAsync(ex);
+        public Task DisposeAsync() => DisposeCoreAsync();
+
+        private Task DisposeCoreAsync(Exception ex = null)
         {
-            _disposed.TrySetResult(null);
+            if (ex == null)
+            {
+                _closeTcs.TrySetResult(null);
+                _disposed.TrySetResult(null);
+            }
+            else
+            {
+                _closeTcs.TrySetException(ex);
+                _disposed.TrySetException(ex);
+            }
+
             _receiveShutdownToken.Cancel();
             return _receiveLoop;
         }

--- a/test/Microsoft.AspNetCore.SignalR.Tests/WebSocketsTransportTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/WebSocketsTransportTests.cs
@@ -9,9 +9,9 @@ using Microsoft.AspNetCore.Sockets.Client;
 using Microsoft.AspNetCore.Sockets.Internal;
 using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.Extensions.Logging.Testing;
+using Moq;
 using Xunit;
 using Xunit.Abstractions;
-using Moq;
 
 namespace Microsoft.AspNetCore.SignalR.Tests
 {

--- a/test/Microsoft.AspNetCore.SignalR.Tests/WebSocketsTransportTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/WebSocketsTransportTests.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.Extensions.Logging.Testing;
 using Xunit;
 using Xunit.Abstractions;
+using Moq;
 
 namespace Microsoft.AspNetCore.SignalR.Tests
 {
@@ -41,7 +42,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
 
                 var webSocketsTransport = new WebSocketsTransport(httpOptions: null, loggerFactory: loggerFactory);
                 await webSocketsTransport.StartAsync(new Uri(_serverFixture.WebSocketsUrl + "/echo"), channelConnection,
-                    TransferMode.Binary, connectionId: string.Empty).OrTimeout();
+                    TransferMode.Binary, connectionId: string.Empty, connection: Mock.Of<IConnection>()).OrTimeout();
                 await webSocketsTransport.StopAsync().OrTimeout();
                 await webSocketsTransport.Running.OrTimeout();
             }
@@ -59,7 +60,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
 
                 var webSocketsTransport = new WebSocketsTransport(httpOptions: null, loggerFactory: loggerFactory);
                 await webSocketsTransport.StartAsync(new Uri(_serverFixture.WebSocketsUrl + "/echo"), channelConnection,
-                    TransferMode.Binary, connectionId: string.Empty);
+                    TransferMode.Binary, connectionId: string.Empty, connection: Mock.Of<IConnection>());
                 connectionToTransport.Writer.TryComplete();
                 await webSocketsTransport.Running.OrTimeout(TimeSpan.FromSeconds(10));
             }
@@ -78,7 +79,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                 var channelConnection = new ChannelConnection<SendMessage, byte[]>(connectionToTransport, transportToConnection);
 
                 var webSocketsTransport = new WebSocketsTransport(httpOptions: null, loggerFactory: loggerFactory);
-                await webSocketsTransport.StartAsync(new Uri(_serverFixture.WebSocketsUrl + "/echo"), channelConnection, transferMode, connectionId: string.Empty);
+                await webSocketsTransport.StartAsync(new Uri(_serverFixture.WebSocketsUrl + "/echo"), channelConnection, transferMode, connectionId: string.Empty, connection: Mock.Of<IConnection>());
 
                 var sendTcs = new TaskCompletionSource<object>();
                 connectionToTransport.Writer.TryWrite(new SendMessage(new byte[] { 0x42 }, sendTcs));
@@ -119,7 +120,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
 
                 Assert.Null(webSocketsTransport.Mode);
                 await webSocketsTransport.StartAsync(new Uri(_serverFixture.WebSocketsUrl + "/echo"), channelConnection,
-                    transferMode, connectionId: string.Empty).OrTimeout();
+                    transferMode, connectionId: string.Empty, connection: Mock.Of<IConnection>()).OrTimeout();
                 Assert.Equal(transferMode, webSocketsTransport.Mode);
 
                 await webSocketsTransport.StopAsync().OrTimeout();
@@ -139,7 +140,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
 
                 var webSocketsTransport = new WebSocketsTransport(httpOptions: null, loggerFactory: loggerFactory);
                 var exception = await Assert.ThrowsAsync<ArgumentException>(() =>
-                    webSocketsTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection, TransferMode.Text | TransferMode.Binary, connectionId: string.Empty));
+                    webSocketsTransport.StartAsync(new Uri("http://fakeuri.org"), channelConnection, TransferMode.Text | TransferMode.Binary, connectionId: string.Empty, connection: Mock.Of<IConnection>()));
 
                 Assert.Contains("Invalid transfer mode.", exception.Message);
                 Assert.Equal("requestedTransferMode", exception.ParamName);


### PR DESCRIPTION
Add client timeout to C# client. It is configurable via an option and defaults to 30 seconds (the server ping rate defaults to 15 seconds, so this is effectively 2 server ping intervals).

NOTE: Should not be merged until #1161 is merged since it will immediately break any connection that goes idle for 30 seconds :).

Fixes #1157