### PR TITLE
fix #625 by implementing HubMethodNameAttribute

### DIFF
--- a/src/Microsoft.AspNetCore.SignalR.Core/HubEndPoint.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/HubEndPoint.cs
@@ -598,7 +598,9 @@ namespace Microsoft.AspNetCore.SignalR
 
             foreach (var methodInfo in HubReflectionHelper.GetHubMethods(hubType))
             {
-                var methodName = methodInfo.Name;
+                var methodName =
+                    methodInfo.GetCustomAttribute<HubMethodNameAttribute>()?.Name ??
+                    methodInfo.Name;
 
                 if (_methods.ContainsKey(methodName))
                 {

--- a/src/Microsoft.AspNetCore.SignalR.Core/HubMethodNameAttribute.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/HubMethodNameAttribute.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/src/Microsoft.AspNetCore.SignalR.Core/HubMethodNameAttribute.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/HubMethodNameAttribute.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.AspNetCore.SignalR
+{
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
+    public class HubMethodNameAttribute : Attribute
+    {
+        public string Name { get; }
+
+        public HubMethodNameAttribute(string name)
+        {
+            Name = name;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.SignalR.Core/Microsoft.AspNetCore.SignalR.Core.csproj
+++ b/src/Microsoft.AspNetCore.SignalR.Core/Microsoft.AspNetCore.SignalR.Core.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <Description>Real-time communication framework for ASP.NET Core.</Description>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <RootNamespace>Microsoft.AspNetCore.SignalR</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
8 minutes from `checkout -b` to `Create pull request` @davidfowl ;).

FYI, HubNameAttribute isn't relevant in Core because names are already explicit in routing.

Fixes #625