### PR TITLE
Fix #1140 by plumbing WebSocketOptions up to HttpOptions

### DIFF
--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/HttpOptions.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/HttpOptions.cs
@@ -1,9 +1,10 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Net.WebSockets;
 
 namespace Microsoft.AspNetCore.Sockets.Client.Http
 {
@@ -12,5 +13,15 @@ namespace Microsoft.AspNetCore.Sockets.Client.Http
         public HttpMessageHandler HttpMessageHandler { get; set; }
         public IReadOnlyCollection<KeyValuePair<string, string>> Headers { get; set; }
         public Func<string> JwtBearerTokenFactory { get; set; }
+
+        /// <summary>
+        /// Gets or sets a delegate that will be invoked with the <see cref="ClientWebSocketOptions"/> object used
+        /// by the <see cref="WebSocketsTransport"/> to configure the WebSocket.
+        /// </summary>
+        /// <remarks>
+        /// This delegate is invoked AFTER headers from <see cref="Headers"/> and the JWT bearer token from <see cref="JwtBearerTokenFactory"/>
+        /// has been applied.
+        /// </remarks>
+        public Action<ClientWebSocketOptions> WebSocketOptions { get; set; }
     }
 }

--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/HttpOptions.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/HttpOptions.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Http
         /// by the <see cref="WebSocketsTransport"/> to configure the WebSocket.
         /// </summary>
         /// <remarks>
-        /// This delegate is invoked AFTER headers from <see cref="Headers"/> and the JWT bearer token from <see cref="JwtBearerTokenFactory"/>
+        /// This delegate is invoked after headers from <see cref="Headers"/> and the JWT bearer token from <see cref="JwtBearerTokenFactory"/>
         /// has been applied.
         /// </remarks>
         public Action<ClientWebSocketOptions> WebSocketOptions { get; set; }

--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/WebSocketsTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/WebSocketsTransport.cs
@@ -36,6 +36,7 @@ namespace Microsoft.AspNetCore.Sockets.Client
         public WebSocketsTransport(HttpOptions httpOptions, ILoggerFactory loggerFactory)
         {
             _webSocket = new ClientWebSocket();
+
             if (httpOptions?.Headers != null)
             {
                 foreach (var header in httpOptions.Headers)
@@ -48,6 +49,8 @@ namespace Microsoft.AspNetCore.Sockets.Client
             {
                 _webSocket.Options.SetRequestHeader("Authorization", $"Bearer {httpOptions.JwtBearerTokenFactory()}");
             }
+
+            httpOptions?.WebSocketOptions?.Invoke(_webSocket.Options);
 
             _logger = (loggerFactory ?? NullLoggerFactory.Instance).CreateLogger<WebSocketsTransport>();
         }

--- a/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/HubConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/HubConnectionTests.cs
@@ -6,8 +6,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Threading;
-using System.Threading.Tasks;
 using System.Threading.Channels;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR.Internal.Protocol;
 using Microsoft.AspNetCore.SignalR.Tests.Common;
 using Microsoft.AspNetCore.Sockets;
@@ -16,7 +16,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Testing;
 using Xunit;
 using Xunit.Abstractions;
-using Microsoft.AspNetCore.Sockets.Client.Http;
 
 namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
 {

--- a/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/HubConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/HubConnectionTests.cs
@@ -631,13 +631,13 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
                 // System.Net has a TransportType type which means we need to fully-qualify this rather than 'use' the namespace
                 var cookieJar = new System.Net.CookieContainer();
                 cookieJar.Add(new System.Net.Cookie("Foo", "Bar", "/", new Uri(_serverFixture.Url).Host));
-                var httpOptions = new HttpOptions()
-                {
-                    WebSocketOptions = options => options.Cookies = cookieJar
-                };
 
-                var httpConnection = new HttpConnection(new Uri(_serverFixture.Url + "/default"), TransportType.WebSockets, loggerFactory: null, httpOptions);
-                var hubConnection = new HubConnection(httpConnection, new JsonHubProtocol(), loggerFactory: null);
+                var hubConnection = new HubConnectionBuilder()
+                    .WithUrl(_serverFixture.Url + "/default")
+                    .WithTransport(TransportType.WebSockets)
+                    .WithLoggerFactory(loggerFactory)
+                    .WithWebSocketOptions(options => options.Cookies = cookieJar)
+                    .Build();
                 try
                 {
                     await hubConnection.StartAsync().OrTimeout();

--- a/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/Hubs.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/Hubs.cs
@@ -39,6 +39,11 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
             var headers = Context.Connection.GetHttpContext().Request.Headers;
             return headerNames.Select(h => (string)headers[h]);
         }
+
+        public string GetCookieValue(string cookieName)
+        {
+            return Context.Connection.GetHttpContext().Request.Cookies[cookieName];
+        }
     }
 
     public class DynamicTestHub : DynamicHub

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.cs
@@ -6,8 +6,8 @@ using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
 using System.Threading.Channels;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Client.Tests;
 using Microsoft.AspNetCore.SignalR.Tests.Common;
 using Microsoft.AspNetCore.Sockets.Client.Http;
@@ -286,10 +286,10 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
 
             var onReceivedInvoked = false;
             connection.OnReceived(_ =>
-           {
-               onReceivedInvoked = true;
-               return Task.CompletedTask;
-           });
+            {
+                onReceivedInvoked = true;
+                return Task.CompletedTask;
+            });
 
             await connection.StartAsync();
             await connection.DisposeAsync();
@@ -433,9 +433,9 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
             var connection = new HttpConnection(new Uri("http://fakeuri.org/"), new TestTransportFactory(mockTransport.Object), loggerFactory: null,
                 httpOptions: new HttpOptions { HttpMessageHandler = mockHttpHandler.Object });
             connection.OnReceived(_ =>
-               {
-                   throw new OperationCanceledException();
-               });
+            {
+                throw new OperationCanceledException();
+            });
 
             await connection.StartAsync();
             channel.Writer.TryWrite(Array.Empty<byte>());

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.cs
@@ -285,11 +285,11 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
                 httpOptions: new HttpOptions { HttpMessageHandler = mockHttpHandler.Object });
 
             var onReceivedInvoked = false;
-            connection.OnReceived( _ =>
-            {
-                onReceivedInvoked = true;
-                return Task.CompletedTask;
-            });
+            connection.OnReceived(_ =>
+           {
+               onReceivedInvoked = true;
+               return Task.CompletedTask;
+           });
 
             await connection.StartAsync();
             await connection.DisposeAsync();
@@ -432,10 +432,10 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
 
             var connection = new HttpConnection(new Uri("http://fakeuri.org/"), new TestTransportFactory(mockTransport.Object), loggerFactory: null,
                 httpOptions: new HttpOptions { HttpMessageHandler = mockHttpHandler.Object });
-            connection.OnReceived( _ =>
-                {
-                    throw new OperationCanceledException();
-                });
+            connection.OnReceived(_ =>
+               {
+                   throw new OperationCanceledException();
+               });
 
             await connection.StartAsync();
             channel.Writer.TryWrite(Array.Empty<byte>());
@@ -960,7 +960,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Tests
         [InlineData("http://fakeuri.org/endpoint", "http://fakeuri.org/endpoint/negotiate")]
         [InlineData("http://fakeuri.org/endpoint/", "http://fakeuri.org/endpoint/negotiate")]
         [InlineData("http://fakeuri.org/endpoint?q=1/0", "http://fakeuri.org/endpoint/negotiate?q=1/0")]
-        public async Task query(string requested, string expectedNegotiate)
+        public async Task CorrectlyHandlesQueryStringWhenAppendingNegotiateToUrl(string requested, string expectedNegotiate)
         {
             var mockHttpHandler = new Mock<HttpMessageHandler>();
             mockHttpHandler.Protected()


### PR DESCRIPTION
Unfortunately `WebSocketOptions` has a private constructor, so we have to do ye-olde `Action<T>` configurator trick.

This allows users to configure the WebSocketOptions type and set Cookies, Proxies and other HTTP goodness when using the WebSocket transport.

Fixes #1140 