### PR TITLE
expand ping test expectations to avoid flakiness

### DIFF
--- a/test/Microsoft.AspNetCore.SignalR.Tests/HubEndpointTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/HubEndpointTests.cs
@@ -1454,7 +1454,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                     counter += 1;
                     Assert.Same(PingMessage.Instance, message);
                 }
-                Assert.InRange(counter, 1, 10);
+                Assert.InRange(counter, 1, Int32.MaxValue);
             }
         }
 


### PR DESCRIPTION
As discussed with @davidfowl . Simple test fix. We don't care exactly how many pings we get, just that we get at least one.