### PR TITLE
Make MapHub and MapEndpoint consistent with other ASP.NET Core APIs (use PathString) #1188

### DIFF
--- a/client-ts/Microsoft.AspNetCore.SignalR.Test.Server/Startup.cs
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Test.Server/Startup.cs
@@ -77,10 +77,10 @@ namespace Microsoft.AspNetCore.SignalR.Test.Server
             }
 
             app.UseFileServer();
-            app.UseSockets(options => options.MapEndPoint<EchoEndPoint>("echo"));
-            app.UseSignalR(options => options.MapHub<TestHub>("testhub"));
-            app.UseSignalR(options => options.MapHub<UncreatableHub>("uncreatable"));
-            app.UseSignalR(options => options.MapHub<HubWithAuthorization>("authorizedhub"));
+            app.UseSockets(options => options.MapEndPoint<EchoEndPoint>("/echo"));
+            app.UseSignalR(options => options.MapHub<TestHub>("/testhub"));
+            app.UseSignalR(options => options.MapHub<UncreatableHub>("/uncreatable"));
+            app.UseSignalR(options => options.MapHub<HubWithAuthorization>("/authorizedhub"));
 
             app.Use(next => async (context) =>
             {

--- a/samples/ChatSample/Startup.cs
+++ b/samples/ChatSample/Startup.cs
@@ -88,7 +88,7 @@ namespace ChatSample
 
             app.UseSignalR(routes =>
             {
-                routes.MapHub<Chat>("chat");
+                routes.MapHub<Chat>("/chat");
             });
 
             app.UseMvc(routes =>

--- a/samples/JwtSample/Startup.cs
+++ b/samples/JwtSample/Startup.cs
@@ -66,7 +66,7 @@ namespace JwtSample
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
             app.UseFileServer();
-            app.UseSignalR(options => options.MapHub<Broadcaster>("broadcast"));
+            app.UseSignalR(options => options.MapHub<Broadcaster>("/broadcast"));
 
             var routeBuilder = new RouteBuilder(app);
             routeBuilder.MapGet("generatetoken", c => c.Response.WriteAsync(GenerateToken(c)));

--- a/samples/SocialWeather/Startup.cs
+++ b/samples/SocialWeather/Startup.cs
@@ -32,7 +32,7 @@ namespace SocialWeather
                 app.UseDeveloperExceptionPage();
             }
 
-            app.UseSockets(o => { o.MapEndPoint<SocialWeatherEndPoint>("weather"); });
+            app.UseSockets(o => { o.MapEndPoint<SocialWeatherEndPoint>("/weather"); });
             app.UseFileServer();
 
             var formatterResolver = app.ApplicationServices.GetRequiredService<FormatterResolver>();

--- a/samples/SocketsSample/Startup.cs
+++ b/samples/SocketsSample/Startup.cs
@@ -52,15 +52,15 @@ namespace SocketsSample
 
             app.UseSignalR(routes =>
             {
-                routes.MapHub<DynamicChat>("dynamic");
-                routes.MapHub<Chat>("default");
-                routes.MapHub<Streaming>("streaming");
-                routes.MapHub<HubTChat>("hubT");
+                routes.MapHub<DynamicChat>("/dynamic");
+                routes.MapHub<Chat>("/default");
+                routes.MapHub<Streaming>("/streaming");
+                routes.MapHub<HubTChat>("/hubT");
             });
 
             app.UseSockets(routes =>
             {
-                routes.MapEndPoint<MessagesEndPoint>("chat");
+                routes.MapEndPoint<MessagesEndPoint>("/chat");
             });
         }
     }

--- a/src/Microsoft.AspNetCore.SignalR/HubRouteBuilder.cs
+++ b/src/Microsoft.AspNetCore.SignalR/HubRouteBuilder.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Reflection;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Sockets;
 
 namespace Microsoft.AspNetCore.SignalR
@@ -19,10 +20,10 @@ namespace Microsoft.AspNetCore.SignalR
 
         public void MapHub<THub>(string path) where THub : Hub
         {
-            MapHub<THub>(path, socketOptions: null);
+            MapHub<THub>(new PathString(path), socketOptions: null);
         }
 
-        public void MapHub<THub>(string path, Action<HttpSocketOptions> socketOptions) where THub : Hub
+        public void MapHub<THub>(PathString path, Action<HttpSocketOptions> socketOptions) where THub : Hub
         {
             // find auth attributes
             var authorizeAttributes = typeof(THub).GetCustomAttributes<AuthorizeAttribute>(inherit: true);

--- a/src/Microsoft.AspNetCore.SignalR/HubRouteBuilder.cs
+++ b/src/Microsoft.AspNetCore.SignalR/HubRouteBuilder.cs
@@ -23,6 +23,11 @@ namespace Microsoft.AspNetCore.SignalR
             MapHub<THub>(new PathString(path), socketOptions: null);
         }
 
+        public void MapHub<THub>(PathString path) where THub : Hub
+        {
+            MapHub<THub>(path, socketOptions: null);
+        }
+
         public void MapHub<THub>(PathString path, Action<HttpSocketOptions> socketOptions) where THub : Hub
         {
             // find auth attributes

--- a/src/Microsoft.AspNetCore.Sockets.Http/SocketRouteBuilder.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Http/SocketRouteBuilder.cs
@@ -23,6 +23,9 @@ namespace Microsoft.AspNetCore.Sockets
         public void MapSocket(string path, Action<ISocketBuilder> socketConfig) =>
             MapSocket(new PathString(path), new HttpSocketOptions(), socketConfig);
 
+        public void MapSocket(PathString path, Action<ISocketBuilder> socketConfig) =>
+            MapSocket(path, new HttpSocketOptions(), socketConfig);
+
         public void MapSocket(PathString path, HttpSocketOptions options, Action<ISocketBuilder> socketConfig)
         {
             var socketBuilder = new SocketBuilder(_routes.ServiceProvider);
@@ -35,6 +38,11 @@ namespace Microsoft.AspNetCore.Sockets
         public void MapEndPoint<TEndPoint>(string path) where TEndPoint : EndPoint
         {
             MapEndPoint<TEndPoint>(new PathString(path), socketOptions: null);
+        }
+
+        public void MapEndPoint<TEndPoint>(PathString path) where TEndPoint : EndPoint
+        {
+            MapEndPoint<TEndPoint>(path, socketOptions: null);
         }
 
         public void MapEndPoint<TEndPoint>(PathString path, Action<HttpSocketOptions> socketOptions) where TEndPoint : EndPoint

--- a/src/Microsoft.AspNetCore.Sockets.Http/SocketRouteBuilder.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Http/SocketRouteBuilder.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Reflection;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 
 namespace Microsoft.AspNetCore.Sockets
@@ -20,9 +21,9 @@ namespace Microsoft.AspNetCore.Sockets
         }
 
         public void MapSocket(string path, Action<ISocketBuilder> socketConfig) =>
-            MapSocket(path, new HttpSocketOptions(), socketConfig);
+            MapSocket(new PathString(path), new HttpSocketOptions(), socketConfig);
 
-        public void MapSocket(string path, HttpSocketOptions options, Action<ISocketBuilder> socketConfig)
+        public void MapSocket(PathString path, HttpSocketOptions options, Action<ISocketBuilder> socketConfig)
         {
             var socketBuilder = new SocketBuilder(_routes.ServiceProvider);
             socketConfig(socketBuilder);
@@ -33,10 +34,10 @@ namespace Microsoft.AspNetCore.Sockets
 
         public void MapEndPoint<TEndPoint>(string path) where TEndPoint : EndPoint
         {
-            MapEndPoint<TEndPoint>(path, socketOptions: null);
+            MapEndPoint<TEndPoint>(new PathString(path), socketOptions: null);
         }
 
-        public void MapEndPoint<TEndPoint>(string path, Action<HttpSocketOptions> socketOptions) where TEndPoint : EndPoint
+        public void MapEndPoint<TEndPoint>(PathString path, Action<HttpSocketOptions> socketOptions) where TEndPoint : EndPoint
         {
             var authorizeAttributes = typeof(TEndPoint).GetCustomAttributes<AuthorizeAttribute>(inherit: true);
             var options = new HttpSocketOptions();

--- a/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/Startup.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/Startup.cs
@@ -49,10 +49,10 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
 
             app.UseSignalR(routes =>
             {
-                routes.MapHub<TestHub>("default");
-                routes.MapHub<DynamicTestHub>("dynamic");
-                routes.MapHub<TestHubT>("hubT");
-                routes.MapHub<HubWithAuthorization>("authorizedhub");
+                routes.MapHub<TestHub>("/default");
+                routes.MapHub<DynamicTestHub>("/dynamic");
+                routes.MapHub<TestHubT>("/hubT");
+                routes.MapHub<HubWithAuthorization>("/authorizedhub");
             });
 
             app.Run(async (context) =>

--- a/test/Microsoft.AspNetCore.SignalR.Redis.Tests/Startup.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Redis.Tests/Startup.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
 
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
-            app.UseSignalR(options => options.MapHub<EchoHub>("echo"));
+            app.UseSignalR(options => options.MapHub<EchoHub>("/echo"));
         }
     }
 }

--- a/test/Microsoft.AspNetCore.SignalR.Tests/MapSignalRTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/MapSignalRTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
         {
             var ex = Assert.Throws<NotSupportedException>(() =>
             {
-                using (var builder = BuildWebHost(options => options.MapHub<InvalidHub>("overloads")))
+                using (var builder = BuildWebHost(options => options.MapHub<InvalidHub>("/overloads")))
                 {
                     builder.Start();
                 }
@@ -27,7 +27,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
         public void MapHubFindsAuthAttributeOnHub()
         {
             var authCount = 0;
-            using (var builder = BuildWebHost(options => options.MapHub<AuthHub>("path", httpSocketOptions =>
+            using (var builder = BuildWebHost(options => options.MapHub<AuthHub>("/path", httpSocketOptions =>
             {
                 authCount += httpSocketOptions.AuthorizationData.Count;
             })))
@@ -42,7 +42,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
         public void MapHubFindsAuthAttributeOnInheritedHub()
         {
             var authCount = 0;
-            using (var builder = BuildWebHost(options => options.MapHub<InheritedAuthHub>("path", httpSocketOptions =>
+            using (var builder = BuildWebHost(options => options.MapHub<InheritedAuthHub>("/path", httpSocketOptions =>
             {
                 authCount += httpSocketOptions.AuthorizationData.Count;
             })))
@@ -57,7 +57,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
         public void MapHubFindsMultipleAuthAttributesOnDoubleAuthHub()
         {
             var authCount = 0;
-            using (var builder = BuildWebHost(options => options.MapHub<DoubleAuthHub>("path", httpSocketOptions =>
+            using (var builder = BuildWebHost(options => options.MapHub<DoubleAuthHub>("/path", httpSocketOptions =>
             {
                 authCount += httpSocketOptions.AuthorizationData.Count;
             })))

--- a/test/Microsoft.AspNetCore.SignalR.Tests/Startup.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/Startup.cs
@@ -18,8 +18,8 @@ namespace Microsoft.AspNetCore.SignalR.Tests
 
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
-            app.UseSockets(options => options.MapEndPoint<EchoEndPoint>("echo"));
-            app.UseSignalR(options => options.MapHub<UncreatableHub>("uncreatable"));
+            app.UseSockets(options => options.MapEndPoint<EchoEndPoint>("/echo"));
+            app.UseSignalR(options => options.MapHub<UncreatableHub>("/uncreatable"));
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Sockets.Tests/MapEndPointTests.cs
+++ b/test/Microsoft.AspNetCore.Sockets.Tests/MapEndPointTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNetCore.Sockets.Tests
         public void MapEndPointFindsAuthAttributeOnEndPoint()
         {
             var authCount = 0;
-            using (var builder = BuildWebHost<AuthEndPoint>("auth",
+            using (var builder = BuildWebHost<AuthEndPoint>("/auth",
                 options => authCount += options.AuthorizationData.Count))
             {
                 builder.Start();
@@ -44,7 +44,7 @@ namespace Microsoft.AspNetCore.Sockets.Tests
         public void MapEndPointFindsAuthAttributeOnInheritedEndPoint()
         {
             var authCount = 0;
-            using (var builder = BuildWebHost<InheritedAuthEndPoint>("auth",
+            using (var builder = BuildWebHost<InheritedAuthEndPoint>("/auth",
                 options => authCount += options.AuthorizationData.Count))
             {
                 builder.Start();
@@ -57,7 +57,7 @@ namespace Microsoft.AspNetCore.Sockets.Tests
         public void MapEndPointFindsAuthAttributesOnDoubleAuthEndPoint()
         {
             var authCount = 0;
-            using (var builder = BuildWebHost<DoubleAuthEndPoint>("auth",
+            using (var builder = BuildWebHost<DoubleAuthEndPoint>("/auth",
                 options => authCount += options.AuthorizationData.Count))
             {
                 builder.Start();
@@ -70,7 +70,7 @@ namespace Microsoft.AspNetCore.Sockets.Tests
         [OSSkipCondition(OperatingSystems.Windows, WindowsVersions.Win7, WindowsVersions.Win2008R2, SkipReason = "No WebSockets Client for this platform")]
         public async Task MapEndPointWithWebSocketSubProtocolSetsProtocol()
         {
-            var host = BuildWebHost<MyEndPoint>("socket",
+            var host = BuildWebHost<MyEndPoint>("/socket",
                 options => options.WebSockets.SubProtocol = "protocol1");
 
             await host.StartAsync();


### PR DESCRIPTION
Hi @anurse 

This PR Makes MapHub and MapEndpoint consistent with other ASP.NET Core APIs using PathString. #1188

Thanks for your help!