### PR TITLE
fix #1171 by teaching HttpConnection to be restartable in TypeScript

### DIFF
--- a/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/HubConnection.ts
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/HubConnection.ts
@@ -154,6 +154,9 @@ export class HubConnection {
     }
 
     stop(): void {
+        if (this.timeoutHandle) {
+            clearTimeout(this.timeoutHandle);
+        }
         return this.connection.stop();
     }
 

--- a/client-ts/Microsoft.AspNetCore.SignalR.Test.Server/wwwroot/connectionTests.html
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Test.Server/wwwroot/connectionTests.html
@@ -1,6 +1,6 @@
-﻿
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html>
+
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width">
@@ -22,15 +22,13 @@
             return decodeURIComponent(results[2].replace(/\+/g, " "));
         }
 
-        var minified = getParameterByName('debug') !== 'true' ? '.min' : '';
-        if (typeof Promise === 'undefined')
-        {
+        var minified = getParameterByName('release') === 'true' ? '.min' : '';
+        if (typeof Promise === 'undefined') {
             document.write(
                 '<script type="text/javascript" src="lib/signalr/signalr-clientES5' + minified + '.js"><\/script>' +
                 '<script type="text/javascript" src="lib/signalr/signalr-msgpackprotocolES5' + minified + '.js"><\/script>');
         }
-        else
-        {
+        else {
             document.write(
                 '<script type="text/javascript" src="lib/signalr/signalr-client' + minified + '.js"><\/script>' +
                 '<script type="text/javascript" src="lib/signalr/signalr-msgpackprotocol' + minified + '.js"><\/script>');
@@ -42,6 +40,8 @@
     <script src="js/connectionTests.js"></script>
     <script src="js/hubConnectionTests.js"></script>
 </head>
+
 <body>
 </body>
+
 </html>

--- a/client-ts/Microsoft.AspNetCore.SignalR.Test.Server/wwwroot/js/hubConnectionTests.js
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Test.Server/wwwroot/js/hubConnectionTests.js
@@ -258,13 +258,13 @@ describe('hubConnection', function () {
                 hubConnection.start().then(function () {
                     return hubConnection.invoke('InvokeWithString', message);
                 })
-                .then(function () {
-                    return hubConnection.stop();
-                })
-                .catch(function (e) {
-                    fail(e);
-                    done();
-                });
+                    .then(function () {
+                        return hubConnection.stop();
+                    })
+                    .catch(function (e) {
+                        fail(e);
+                        done();
+                    });
             });
 
             it('closed with error if hub cannot be created', function (done) {
@@ -315,28 +315,76 @@ describe('hubConnection', function () {
                 hubConnection.start().then(function () {
                     return hubConnection.invoke('EchoComplexObject', complexObject);
                 })
-                .then(function (value) {
-                    if (protocol.name === "messagepack") {
-                        // msgpack creates a Buffer for byte arrays and jasmine fails to compare a Buffer
-                        // and a Uint8Array even though Buffer instances are also Uint8Array instances
-                        value.ByteArray = new Uint8Array(value.ByteArray);
+                    .then(function (value) {
+                        if (protocol.name === "messagepack") {
+                            // msgpack creates a Buffer for byte arrays and jasmine fails to compare a Buffer
+                            // and a Uint8Array even though Buffer instances are also Uint8Array instances
+                            value.ByteArray = new Uint8Array(value.ByteArray);
 
-                        // GUIDs are serialized as raw type which is a string containing bytes which need to
-                        // be extracted. Note that with msgpack5 the original bytes will be encoded with utf8
-                        // and needs to be decoded. To not go into utf8 encoding intricacies the test uses values
-                        // less than 0x80.
-                        let guidBytes = [];
-                        for (let i = 0; i < value.GUID.length; i++) {
-                            guidBytes.push(value.GUID.charCodeAt(i));
+                            // GUIDs are serialized as raw type which is a string containing bytes which need to
+                            // be extracted. Note that with msgpack5 the original bytes will be encoded with utf8
+                            // and needs to be decoded. To not go into utf8 encoding intricacies the test uses values
+                            // less than 0x80.
+                            let guidBytes = [];
+                            for (let i = 0; i < value.GUID.length; i++) {
+                                guidBytes.push(value.GUID.charCodeAt(i));
+                            }
+                            value.GUID = new Uint8Array(guidBytes);
                         }
-                        value.GUID = new Uint8Array(guidBytes);
+                        expect(value).toEqual(complexObject);
+                    })
+                    .then(function () {
+                        hubConnection.stop();
+                    })
+                    .catch(function (e) {
+                        fail(e);
+                        done();
+                    });
+            });
+
+            it('can be restarted', function (done) {
+                var message = '你好，世界！';
+
+                var options = {
+                    transport: transportType,
+                    protocol: protocol,
+                    logging: signalR.LogLevel.Trace
+                };
+                var hubConnection = new signalR.HubConnection(TESTHUBENDPOINT_URL, options);
+
+                let closeCount = 0;
+                hubConnection.onclose(function (error) {
+                    expect(error).toBe(undefined);
+
+                    // Start and invoke again
+                    if (closeCount === 0) {
+                        closeCount += 1;
+                        hubConnection.start().then(function () {
+                            hubConnection.invoke('Echo', message).then(function (result) {
+                                expect(result).toBe(message);
+                            }).catch(function (e) {
+                                fail(e);
+                            }).then(function () {
+                                hubConnection.stop()
+                            });
+                        }).catch(function (e) {
+                            fail(e);
+                            done();
+                        });
+                    } else {
+                        done();
                     }
-                    expect(value).toEqual(complexObject);
-                })
-                .then(function () {
-                    hubConnection.stop();
-                })
-                .catch(function (e) {
+                });
+
+                hubConnection.start().then(function () {
+                    hubConnection.invoke('Echo', message).then(function (result) {
+                        expect(result).toBe(message);
+                    }).catch(function (e) {
+                        fail(e);
+                    }).then(function () {
+                        hubConnection.stop()
+                    });
+                }).catch(function (e) {
                     fail(e);
                     done();
                 });

--- a/client-ts/Microsoft.AspNetCore.SignalR.Test.Server/wwwroot/js/hubConnectionTests.js
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Test.Server/wwwroot/js/hubConnectionTests.js
@@ -255,9 +255,10 @@ describe('hubConnection', function () {
                     done();
                 });
 
-                hubConnection.start().then(function () {
-                    return hubConnection.invoke('InvokeWithString', message);
-                })
+                hubConnection.start()
+                    .then(function () {
+                        return hubConnection.invoke('InvokeWithString', message);
+                    })
                     .then(function () {
                         return hubConnection.stop();
                     })
@@ -370,9 +371,10 @@ describe('hubConnection', function () {
                         : new Uint8Array([0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01, 0x00])
                 };
 
-                hubConnection.start().then(function () {
-                    return hubConnection.invoke('EchoComplexObject', complexObject);
-                })
+                hubConnection.start()
+                    .then(function () {
+                        return hubConnection.invoke('EchoComplexObject', complexObject);
+                    })
                     .then(function (value) {
                         if (protocol.name === "messagepack") {
                             // msgpack creates a Buffer for byte arrays and jasmine fails to compare a Buffer


### PR DESCRIPTION
I'm not super happy with the tests, but I don't see a better way to do them without major refactoring. I'll file a new bug to do that refactoring. We're missing a lot of abstractions in the TS client (WebSocket/EventSource aren't abstracted, Long Polling uses XHR directly rather than IHttpClient, etc.)