### PR TITLE
WIP: Allocate the HubCallerContext and HubCallerClients per connection

### DIFF
--- a/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionContext.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionContext.cs
@@ -38,13 +38,15 @@ namespace Microsoft.AspNetCore.SignalR
         private long _lastSendTimestamp = Stopwatch.GetTimestamp();
         private byte[] _pingMessage;
 
-        public HubConnectionContext(ConnectionContext connectionContext, TimeSpan keepAliveInterval, ILoggerFactory loggerFactory)
+        public HubConnectionContext(ConnectionContext connectionContext, IHubClients clients, TimeSpan keepAliveInterval, ILoggerFactory loggerFactory)
         {
             Output = Channel.CreateUnbounded<HubMessage>();
             _connectionContext = connectionContext;
             _logger = loggerFactory.CreateLogger<HubConnectionContext>();
             ConnectionAbortedToken = _connectionAbortedTokenSource.Token;
             _keepAliveDuration = (int)keepAliveInterval.TotalMilliseconds * (Stopwatch.Frequency / 1000);
+            CallerContext = new HubCallerContext(this);
+            CallerClients = new HubCallerClients(clients, ConnectionId);
         }
 
         public virtual CancellationToken ConnectionAbortedToken { get; }
@@ -64,6 +66,10 @@ namespace Microsoft.AspNetCore.SignalR
         public string UserIdentifier { get; private set; }
 
         internal virtual Channel<HubMessage> Output { get; set; }
+
+        internal HubCallerContext CallerContext { get; private set; }
+
+        internal HubCallerClients CallerClients { get; private set; }
 
         internal ExceptionDispatchInfo AbortException { get; private set; }
 

--- a/src/Microsoft.AspNetCore.SignalR.Core/HubEndPoint.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/HubEndPoint.cs
@@ -58,7 +58,7 @@ namespace Microsoft.AspNetCore.SignalR
 
         public async Task OnConnectedAsync(ConnectionContext connection)
         {
-            var connectionContext = new HubConnectionContext(connection, _hubOptions.KeepAliveInterval, _loggerFactory);
+            var connectionContext = new HubConnectionContext(connection, _hubContext.Clients, _hubOptions.KeepAliveInterval, _loggerFactory);
 
             if (!await connectionContext.NegotiateAsync(_hubOptions.NegotiateTimeout, _protocolResolver, _userIdProvider))
             {
@@ -368,8 +368,8 @@ namespace Microsoft.AspNetCore.SignalR
 
         private void InitializeHub(THub hub, HubConnectionContext connection)
         {
-            hub.Clients = new HubCallerClients(_hubContext.Clients, connection.ConnectionId);
-            hub.Context = new HubCallerContext(connection);
+            hub.Clients = connection.CallerClients;
+            hub.Context = connection.CallerContext;
             hub.Groups = _hubContext.Groups;
         }
 


### PR DESCRIPTION
- It's actually only less overall allocations if we're doing invocations. If not then we have
2 extra long lived objects.
- I also don't like keeping this internal but I don't want it to be exposed in the hub