### PR TITLE
Refactor HttpClient and use it in LongPollingTransport

### DIFF
--- a/client-ts/Microsoft.AspNetCore.SignalR.Client.TS.Tests/AbortSignal.ts
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Client.TS.Tests/AbortSignal.ts
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 import { asyncit as it } from "./Utils";
 import { AbortController } from "../Microsoft.AspNetCore.SignalR.Client.TS/AbortController";
 

--- a/client-ts/Microsoft.AspNetCore.SignalR.Client.TS.Tests/AbortSignal.ts
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Client.TS.Tests/AbortSignal.ts
@@ -1,0 +1,28 @@
+import { asyncit as it } from "./Utils";
+import { AbortController } from "../Microsoft.AspNetCore.SignalR.Client.TS/AbortController";
+
+describe("AbortSignal", () => {
+    describe("aborted", () => {
+        it("is false on initialization", () => {
+            expect(new AbortController().signal.aborted).toBe(false);
+        });
+
+        it("is true when aborted", () => {
+            let controller = new AbortController();
+            let signal = controller.signal;
+            controller.abort();
+            expect(signal.aborted).toBe(true);
+        })
+    });
+
+    describe("onabort", () => {
+        it("is called when abort is called", () => {
+            let controller = new AbortController();
+            let signal = controller.signal;
+            let abortCalled = false;
+            signal.onabort = () => abortCalled = true;
+            controller.abort();
+            expect(abortCalled).toBe(true);
+        })
+    })
+});

--- a/client-ts/Microsoft.AspNetCore.SignalR.Client.TS.Tests/HttpClient.spec.ts
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Client.TS.Tests/HttpClient.spec.ts
@@ -1,0 +1,83 @@
+import { asyncit as it } from "./Utils"
+import { TestHttpClient } from "./TestHttpClient";
+import { HttpRequest } from "../Microsoft.AspNetCore.SignalR.Client.TS/index";
+
+describe("HttpClient", () => {
+    describe("get", () => {
+        it("sets the method and URL appropriately", async () => {
+            let request: HttpRequest;
+            let testClient = new TestHttpClient().on(r => {
+                request = r; return "";
+            });
+
+            await testClient.get("http://localhost");
+            expect(request.method).toEqual("GET");
+            expect(request.url).toEqual("http://localhost");
+        });
+
+        it("overrides method and url in options", async () => {
+            let request: HttpRequest;
+            let testClient = new TestHttpClient().on(r => {
+                request = r; return "";
+            });
+
+            await testClient.get("http://localhost", {
+                method: "OPTIONS",
+                url: "http://wrong"
+            });
+            expect(request.method).toEqual("GET");
+            expect(request.url).toEqual("http://localhost");
+        })
+
+        it("copies other options", async () => {
+            let request: HttpRequest;
+            let testClient = new TestHttpClient().on(r => {
+                request = r; return "";
+            });
+
+            await testClient.get("http://localhost", {
+                timeout: 42,
+            });
+            expect(request.timeout).toEqual(42);
+        })
+    });
+
+    describe("post", () => {
+        it("sets the method and URL appropriately", async () => {
+            let request: HttpRequest;
+            let testClient = new TestHttpClient().on(r => {
+                request = r; return "";
+            });
+
+            await testClient.post("http://localhost");
+            expect(request.method).toEqual("POST");
+            expect(request.url).toEqual("http://localhost");
+        });
+
+        it("overrides method and url in options", async () => {
+            let request: HttpRequest;
+            let testClient = new TestHttpClient().on(r => {
+                request = r; return "";
+            });
+
+            await testClient.post("http://localhost", {
+                method: "OPTIONS",
+                url: "http://wrong"
+            });
+            expect(request.method).toEqual("POST");
+            expect(request.url).toEqual("http://localhost");
+        })
+
+        it("copies other options", async () => {
+            let request: HttpRequest;
+            let testClient = new TestHttpClient().on(r => {
+                request = r; return "";
+            });
+
+            await testClient.post("http://localhost", {
+                timeout: 42,
+            });
+            expect(request.timeout).toEqual(42);
+        })
+    });
+});

--- a/client-ts/Microsoft.AspNetCore.SignalR.Client.TS.Tests/HttpClient.spec.ts
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Client.TS.Tests/HttpClient.spec.ts
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 import { asyncit as it } from "./Utils"
 import { TestHttpClient } from "./TestHttpClient";
 import { HttpRequest } from "../Microsoft.AspNetCore.SignalR.Client.TS/index";

--- a/client-ts/Microsoft.AspNetCore.SignalR.Client.TS.Tests/TestHttpClient.ts
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Client.TS.Tests/TestHttpClient.ts
@@ -1,0 +1,87 @@
+import { HttpClient, HttpRequest, HttpResponse } from "../Microsoft.AspNetCore.SignalR.Client.TS/HttpClient"
+
+type TestHttpHandlerResult = HttpResponse | string;
+export type TestHttpHandler = (request: HttpRequest, next?: (request: HttpRequest) => Promise<HttpResponse>) => Promise<TestHttpHandlerResult> | TestHttpHandlerResult;
+
+export class TestHttpClient extends HttpClient {
+    private handler: (request: HttpRequest) => Promise<HttpResponse>;
+
+    constructor() {
+        super();
+        this.handler = (request: HttpRequest) =>
+            Promise.reject(`Request has no handler: ${request.method} ${request.url}`);
+
+    }
+
+    send(request: HttpRequest): Promise<HttpResponse> {
+        return this.handler(request);
+    }
+
+    on(handler: TestHttpHandler): TestHttpClient;
+    on(method: string | RegExp, handler: TestHttpHandler): TestHttpClient;
+    on(method: string | RegExp, url: string, handler: TestHttpHandler): TestHttpClient;
+    on(method: string | RegExp, url: RegExp, handler: TestHttpHandler): TestHttpClient;
+    on(methodOrHandler: string | RegExp | TestHttpHandler, urlOrHandler?: string | RegExp | TestHttpHandler, handler?: TestHttpHandler): TestHttpClient {
+        let method: string | RegExp;
+        let url: string | RegExp;
+        if ((typeof methodOrHandler === "string") || (methodOrHandler instanceof RegExp)) {
+            method = methodOrHandler;
+        }
+        else if (methodOrHandler) {
+            handler = methodOrHandler;
+        }
+
+        if ((typeof urlOrHandler === "string") || (urlOrHandler instanceof RegExp)) {
+            url = urlOrHandler;
+        }
+        else if (urlOrHandler) {
+            handler = urlOrHandler;
+        }
+
+        // TypeScript callers won't be able to do this, because TypeScript checks this for us.
+        if (!handler) {
+            throw new Error("Missing required argument: 'handler'");
+        }
+
+        let oldHandler = this.handler;
+        let newHandler = async (request: HttpRequest) => {
+            if (matches(method, request.method) && matches(url, request.url)) {
+                let promise = handler(request, oldHandler);
+
+                let val: TestHttpHandlerResult;
+                if (promise instanceof Promise) {
+                    val = await promise;
+                } else {
+                    val = promise;
+                }
+
+                if (typeof val === "string") {
+                    return new HttpResponse(200, "OK", val);
+                }
+                else {
+                    return val;
+                }
+            }
+            else {
+                return await oldHandler(request);
+            }
+        };
+        this.handler = newHandler;
+
+        return this;
+    }
+}
+
+function matches(pattern: string | RegExp, actual: string): boolean {
+    // Null or undefined pattern matches all.
+    if (!pattern) {
+        return true;
+    }
+
+    if (typeof pattern === "string") {
+        return actual === pattern;
+    }
+    else {
+        return pattern.test(actual);
+    }
+}

--- a/client-ts/Microsoft.AspNetCore.SignalR.Client.TS.Tests/TestHttpClient.ts
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Client.TS.Tests/TestHttpClient.ts
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 import { HttpClient, HttpRequest, HttpResponse } from "../Microsoft.AspNetCore.SignalR.Client.TS/HttpClient"
 
 type TestHttpHandlerResult = HttpResponse | string;

--- a/client-ts/Microsoft.AspNetCore.SignalR.Client.TS.Tests/Utils.ts
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Client.TS.Tests/Utils.ts
@@ -3,16 +3,20 @@
 
 import { clearTimeout, setTimeout } from "timers";
 
-export function asyncit(expectation: string, assertion?: () => Promise<any>, timeout?: number): void {
+export function asyncit(expectation: string, assertion?: () => Promise<any> | void, timeout?: number): void {
     let testFunction: (done: DoneFn) => void;
     if (assertion) {
         testFunction = done => {
-            assertion()
-                .then(() => done())
-                .catch((err) => {
-                    fail(err);
-                    done();
-                });
+            let promise = assertion();
+            if (promise) {
+                promise.then(() => done())
+                    .catch((err) => {
+                        fail(err);
+                        done();
+                    });
+            } else {
+                done();
+            }
         };
     }
 

--- a/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/AbortController.ts
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/AbortController.ts
@@ -1,0 +1,30 @@
+// Rough polyfill of https://developer.mozilla.org/en-US/docs/Web/API/AbortController
+// We don't actually ever use the API being polyfilled, we always use the polyfill because
+// it's a very new API right now.
+
+export class AbortController implements AbortSignal {
+    private isAborted: boolean = false;
+    public onabort: () => void;
+
+    abort() {
+        if (!this.isAborted) {
+            this.isAborted = true;
+            if (this.onabort) {
+                this.onabort();
+            }
+        }
+    }
+
+    get signal(): AbortSignal {
+        return this;
+    }
+
+    get aborted(): boolean {
+        return this.isAborted;
+    }
+}
+
+export interface AbortSignal {
+    aborted: boolean;
+    onabort: () => void;
+}

--- a/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/AbortController.ts
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/AbortController.ts
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 // Rough polyfill of https://developer.mozilla.org/en-US/docs/Web/API/AbortController
 // We don't actually ever use the API being polyfilled, we always use the polyfill because
 // it's a very new API right now.

--- a/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/Errors.ts
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/Errors.ts
@@ -8,3 +8,9 @@ export class HttpError extends Error {
         this.statusCode = statusCode;
     }
 }
+
+export class TimeoutError extends Error {
+    constructor(errorMessage: string = "A timeout occurred.") {
+        super(errorMessage);
+    }
+}

--- a/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/HttpClient.ts
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/HttpClient.ts
@@ -60,6 +60,10 @@ export class DefaultHttpClient extends HttpClient {
                 request.headers.forEach((value, header) => xhr.setRequestHeader(header, value));
             }
 
+            if (request.responseType) {
+                xhr.responseType = request.responseType;
+            }
+
             if (request.abortSignal) {
                 request.abortSignal.onabort = () => {
                     xhr.abort();

--- a/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/HttpClient.ts
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/HttpClient.ts
@@ -1,36 +1,82 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-import { HttpError } from "./HttpError"
+import { TimeoutError, HttpError } from "./Errors";
+import { AbortSignal } from "./AbortController";
 
-export interface IHttpClient {
-    get(url: string, headers?: Map<string, string>): Promise<string>;
-    post(url: string, content: string, headers?: Map<string, string>): Promise<string>;
+export interface HttpRequest {
+    method?: string,
+    url?: string,
+    content?: string | ArrayBuffer,
+    headers?: Map<string, string>,
+    responseType?: XMLHttpRequestResponseType,
+    abortSignal?: AbortSignal,
+    timeout?: number,
 }
 
-export class HttpClient implements IHttpClient {
-    get(url: string, headers?: Map<string, string>): Promise<string> {
-        return this.xhr("GET", url, headers);
+export class HttpResponse {
+    constructor(statusCode: number, statusText: string, content: string);
+    constructor(statusCode: number, statusText: string, content: ArrayBuffer);
+    constructor(
+        public readonly statusCode: number,
+        public readonly statusText: string,
+        public readonly content: string | ArrayBuffer) {
+    }
+}
+
+export abstract class HttpClient {
+    get(url: string): Promise<HttpResponse>;
+    get(url: string, options: HttpRequest): Promise<HttpResponse>;
+    get(url: string, options?: HttpRequest): Promise<HttpResponse> {
+        return this.send({
+            ...options,
+            method: "GET",
+            url: url,
+        });
     }
 
-    post(url: string, content: string, headers?: Map<string, string>): Promise<string> {
-        return this.xhr("POST", url, headers, content);
+    post(url: string): Promise<HttpResponse>;
+    post(url: string, options: HttpRequest): Promise<HttpResponse>;
+    post(url: string, options?: HttpRequest): Promise<HttpResponse> {
+        return this.send({
+            ...options,
+            method: "POST",
+            url: url,
+        });
     }
 
-    private xhr(method: string, url: string, headers?: Map<string, string>, content?: string): Promise<string> {
-        return new Promise<string>((resolve, reject) => {
+    abstract send(request: HttpRequest): Promise<HttpResponse>;
+}
+
+export class DefaultHttpClient extends HttpClient {
+    send(request: HttpRequest): Promise<HttpResponse> {
+        return new Promise<HttpResponse>((resolve, reject) => {
             let xhr = new XMLHttpRequest();
 
-            xhr.open(method, url, true);
+            xhr.open(request.method, request.url, true);
             xhr.setRequestHeader("X-Requested-With", "XMLHttpRequest");
-            if (headers) {
-                headers.forEach((value, header) => xhr.setRequestHeader(header, value));
+
+            if (request.headers) {
+                request.headers.forEach((value, header) => xhr.setRequestHeader(header, value));
             }
 
-            xhr.send(content);
+            if (request.abortSignal) {
+                request.abortSignal.onabort = () => {
+                    xhr.abort();
+                };
+            }
+
+            if (request.timeout) {
+                xhr.timeout = request.timeout;
+            }
+
             xhr.onload = () => {
+                if (request.abortSignal) {
+                    request.abortSignal.onabort = null;
+                }
+
                 if (xhr.status >= 200 && xhr.status < 300) {
-                    resolve(xhr.response || xhr.responseText);
+                    resolve(new HttpResponse(xhr.status, xhr.statusText, xhr.response || xhr.responseText))
                 }
                 else {
                     reject(new HttpError(xhr.statusText, xhr.status));
@@ -40,6 +86,12 @@ export class HttpClient implements IHttpClient {
             xhr.onerror = () => {
                 reject(new HttpError(xhr.statusText, xhr.status));
             }
+
+            xhr.ontimeout = () => {
+                reject(new TimeoutError());
+            }
+
+            xhr.send(request.content || "");
         });
     }
 }

--- a/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/IHttpConnectionOptions.ts
+++ b/client-ts/Microsoft.AspNetCore.SignalR.Client.TS/IHttpConnectionOptions.ts
@@ -1,12 +1,12 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-import { IHttpClient } from "./HttpClient"
+import { HttpClient } from "./HttpClient"
 import { TransportType, ITransport } from "./Transports"
 import { ILogger, LogLevel } from "./ILogger";
 
 export interface IHttpConnectionOptions {
-    httpClient?: IHttpClient;
+    httpClient?: HttpClient;
     transport?: TransportType | ITransport;
     logger?: ILogger | LogLevel;
     accessToken?: () => string;

--- a/samples/SocketsSample/wwwroot/hubs.html
+++ b/samples/SocketsSample/wwwroot/hubs.html
@@ -1,9 +1,11 @@
 <!DOCTYPE html>
 <html>
+
 <head>
     <meta charset="utf-8" />
     <title></title>
 </head>
+
 <body>
     <h1 id="head1"></h1>
     <div>
@@ -48,16 +50,15 @@
 
     <ul id="message-list"></ul>
 </body>
+
 </html>
 <script type="text/javascript">
-    if (typeof Promise === 'undefined')
-    {
+    if (typeof Promise === 'undefined') {
         document.write(
             '<script type="text/javascript" src="lib/signalr-client/signalr-clientES5.js"><\/script>' +
             '<script type="text/javascript" src="lib/signalr-client/signalr-msgpackprotocolES5.js"><\/script>');
     }
-    else
-    {
+    else {
         document.write(
             '<script type="text/javascript" src="lib/signalr-client/signalr-client.js"><\/script>' +
             '<script type="text/javascript" src="lib/signalr-client/signalr-msgpackprotocol.js"><\/script>');
@@ -65,102 +66,102 @@
 </script>
 <script src="utils.js"></script>
 <script>
-var isConnected = false;
-function invoke(connection, method) {
-    if (!isConnected) {
-        return;
-    }
-    var argsArray = Array.prototype.slice.call(arguments);
-    connection.invoke.apply(connection, argsArray.slice(1))
-            .then(function(result) {
+    var isConnected = false;
+    function invoke(connection, method) {
+        if (!isConnected) {
+            return;
+        }
+        var argsArray = Array.prototype.slice.call(arguments);
+        connection.invoke.apply(connection, argsArray.slice(1))
+            .then(function (result) {
                 console.log("invocation completed successfully: " + (result === null ? '(null)' : result));
 
                 if (result) {
                     addLine('message-list', result);
                 }
             })
-            .catch(function(err) {
+            .catch(function (err) {
                 addLine('message-list', err, 'red');
             });
-}
+    }
 
-function getText(id) {
-    return document.getElementById(id).value;
-}
+    function getText(id) {
+        return document.getElementById(id).value;
+    }
 
-let transportType = signalR.TransportType[getParameterByName('transport')] || signalR.TransportType.WebSockets;
-let logger = new signalR.ConsoleLogger(signalR.LogLevel.Information);
-let hubRoute = getParameterByName('hubType') || "default";
-console.log('Hub Route:' + hubRoute);
+    let transportType = signalR.TransportType[getParameterByName('transport')] || signalR.TransportType.WebSockets;
+    let logger = new signalR.ConsoleLogger(signalR.LogLevel.Trace);
+    let hubRoute = getParameterByName('hubType') || "default";
+    console.log('Hub Route:' + hubRoute);
 
-document.getElementById('head1').innerHTML = signalR.TransportType[transportType];
+    document.getElementById('head1').innerHTML = signalR.TransportType[transportType];
 
-let connectButton = document.getElementById('connect');
-let disconnectButton = document.getElementById('disconnect');
-disconnectButton.disabled = true;
-var connection;
-
-click('connect', function(event) {
-    connectButton.disabled = true;
-    disconnectButton.disabled = false;
-    console.log('http://' + document.location.host + '/' + hubRoute);
-    connection = new signalR.HubConnection(hubRoute, { transport: transportType, logging: logger });
-    connection.on('Send', function(msg) {
-        addLine('message-list', msg);
-    });
-
-    connection.onclose(function(e) {
-        if (e) {
-            addLine('message-list', 'Connection closed with error: ' + e, 'red');
-        }
-        else {
-            addLine('message-list', 'Disconnected', 'green');
-        }
-    });
-
-    connection.start()
-        .then(function() {
-            isConnected = true;
-            addLine('message-list', 'Connected successfully', 'green');
-        })
-        .catch(function(err) {
-            addLine('message-list', err, 'red');
-        });
-});
-
-click('disconnect', function(event) {
-    connectButton.disabled = false;
+    let connectButton = document.getElementById('connect');
+    let disconnectButton = document.getElementById('disconnect');
     disconnectButton.disabled = true;
-    connection.stop()
-        .then(function() {
-            isConnected = false;
+    var connection;
+
+    click('connect', function (event) {
+        connectButton.disabled = true;
+        disconnectButton.disabled = false;
+        console.log('http://' + document.location.host + '/' + hubRoute);
+        connection = new signalR.HubConnection(hubRoute, { transport: transportType, logging: logger });
+        connection.on('Send', function (msg) {
+            addLine('message-list', msg);
         });
-});
 
-click('broadcast', function(event) {
-    let data = getText('message-text');
-    invoke(connection, 'Send', data);
-});
+        connection.onclose(function (e) {
+            if (e) {
+                addLine('message-list', 'Connection closed with error: ' + e, 'red');
+            }
+            else {
+                addLine('message-list', 'Disconnected', 'green');
+            }
+        });
 
-click('join-group', function(event) {
-    let groupName = getText('message-text');
-    invoke(connection, 'JoinGroup', groupName);
-});
+        connection.start()
+            .then(function () {
+                isConnected = true;
+                addLine('message-list', 'Connected successfully', 'green');
+            })
+            .catch(function (err) {
+                addLine('message-list', err, 'red');
+            });
+    });
 
-click('leave-group', function(event) {
-    let groupName = getText('message-text');
-    invoke(connection, 'LeaveGroup', groupName);
-});
+    click('disconnect', function (event) {
+        connectButton.disabled = false;
+        disconnectButton.disabled = true;
+        connection.stop()
+            .then(function () {
+                isConnected = false;
+            });
+    });
 
-click('groupmsg', function(event) {
-    let groupName = getText('target');
-    let message = getText('private-message-text');
-    invoke(connection, 'SendToGroup', groupName, message);
-});
+    click('broadcast', function (event) {
+        let data = getText('message-text');
+        invoke(connection, 'Send', data);
+    });
 
-click('send', function(event) {
-    let data = getText('me-message-text');
-    invoke(connection, 'Echo', data);
-});
+    click('join-group', function (event) {
+        let groupName = getText('message-text');
+        invoke(connection, 'JoinGroup', groupName);
+    });
+
+    click('leave-group', function (event) {
+        let groupName = getText('message-text');
+        invoke(connection, 'LeaveGroup', groupName);
+    });
+
+    click('groupmsg', function (event) {
+        let groupName = getText('target');
+        let message = getText('private-message-text');
+        invoke(connection, 'SendToGroup', groupName, message);
+    });
+
+    click('send', function (event) {
+        let data = getText('me-message-text');
+        invoke(connection, 'Echo', data);
+    });
 
 </script>

--- a/samples/SocketsSample/wwwroot/sockets.html
+++ b/samples/SocketsSample/wwwroot/sockets.html
@@ -1,9 +1,11 @@
 <!DOCTYPE html>
 <html>
+
 <head>
     <meta charset="utf-8" />
     <title></title>
 </head>
+
 <body>
     <h1 id="transportName">Unknown Transport</h1>
 
@@ -14,43 +16,42 @@
 
     <ul id="messages"></ul>
     <script type="text/javascript">
-        if (typeof Promise === 'undefined')
-        {
+        if (typeof Promise === 'undefined') {
             document.write('<script type="text/javascript" src="lib/signalr-client/signalr-clientES5.js"><\/script>');
         }
-        else
-        {
+        else {
             document.write('<script type="text/javascript" src="lib/signalr-client/signalr-client.js"><\/script>');
         }
     </script>
     <script src="utils.js"></script>
     <script>
-        document.addEventListener('DOMContentLoaded', function() {
+        document.addEventListener('DOMContentLoaded', function () {
             let transportType = signalR.TransportType[getParameterByName('transport')] || signalR.TransportType.WebSockets;
 
             document.getElementById('transportName').innerHTML = signalR.TransportType[transportType];
 
             let url = 'http://' + document.location.host + '/chat';
-            let connection = new signalR.HttpConnection(url, { transport: transportType, logging: new signalR.ConsoleLogger(signalR.LogLevel.Information) });
+            let connection = new signalR.HttpConnection(url, { transport: transportType, logging: new signalR.ConsoleLogger(signalR.LogLevel.Trace) });
 
-            connection.onreceive =  function(data) {
+            connection.onreceive = function (data) {
                 let child = document.createElement('li');
                 child.innerText = data;
                 document.getElementById('messages').appendChild(child);
             };
 
-            document.getElementById('sendmessage').addEventListener('submit', function(event) {
+            document.getElementById('sendmessage').addEventListener('submit', function (event) {
                 let data = document.getElementById('data').value;
                 connection.send(data);
                 event.preventDefault();
             });
 
-            connection.start().then(function() {
+            connection.start().then(function () {
                 console.log("Opened");
-            }, function() {
+            }, function () {
                 console.log("Error opening connection");
             });
         });
     </script>
 </body>
+
 </html>

--- a/samples/SocketsSample/wwwroot/streaming.html
+++ b/samples/SocketsSample/wwwroot/streaming.html
@@ -1,9 +1,11 @@
 <!DOCTYPE html>
 <html>
+
 <head>
     <meta charset="utf-8" />
     <title></title>
 </head>
+
 <body>
     <h1 id="transportName">Unknown Transport</h1>
 
@@ -24,14 +26,12 @@
 
     <ul id="messages"></ul>
     <script type="text/javascript">
-        if (typeof Promise === 'undefined')
-        {
+        if (typeof Promise === 'undefined') {
             document.write(
                 '<script type="text/javascript" src="lib/signalr-client/signalr-clientES5.js"><\/script>' +
                 '<script type="text/javascript" src="lib/signalr-client/signalr-msgpackprotocolES5.js"><\/script>');
         }
-        else
-        {
+        else {
             document.write(
                 '<script type="text/javascript" src="lib/signalr-client/signalr-client.js"><\/script>' +
                 '<script type="text/javascript" src="lib/signalr-client/signalr-msgpackprotocol.js"><\/script>');
@@ -39,7 +39,7 @@
     </script>
     <script src="utils.js"></script>
     <script>
-        document.addEventListener('DOMContentLoaded', function() {
+        document.addEventListener('DOMContentLoaded', function () {
             let resultsList = document.getElementById('resultsList');
             let channelButton = document.getElementById('channelButton');
             let observableButton = document.getElementById('observableButton');
@@ -48,7 +48,7 @@
             let connectButton = document.getElementById('connectButton');
             let disconnectButton = document.getElementById('disconnectButton');
 
-            let logger = new signalR.ConsoleLogger(signalR.LogLevel.Information);
+            let logger = new signalR.ConsoleLogger(signalR.LogLevel.Trace);
             let transportType = signalR.TransportType[getParameterByName('transport')] || signalR.TransportType.WebSockets;
 
             let invocationCounter = 0;
@@ -107,11 +107,12 @@
                         addLine('resultsList', method + '(' + id + '):' + err, 'red');
                     },
                     complete: function () {
-                        addLine('resultsList', method + '(' +  id + '): complete', 'green');
+                        addLine('resultsList', method + '(' + id + '): complete', 'green');
                     }
                 });
             }
         });
     </script>
 </body>
+
 </html>


### PR DESCRIPTION
This refactors the HttpClient abstraction a bit and changes LongPollingTransport to use it. This will allow us to add better unit tests of the LongPolling transport. Next I'll look at a similar abstraction for WebSocket and EventSource so we can test all the transports.

Note: I haven't actually added any new tests for LongPolling, but I added some tests for additional things.

To handle cancellation of Http requests, I whipped up my own version of [`AbortController` and friends](https://developer.mozilla.org/en-US/docs/Web/API/AbortController), an recently-specified JavaScript API that's similar to `CancellationTokenSource` and friends. Rather than doing it as a polyfill, since it's so simple, I don't even bother looking for the real one. It turns out that's a little tricky to do from within your own TypeScript module (since you have to mess with globals).