### PR TITLE
Throw InvalidDataException instead of FormatException in NegotationProtocol

### DIFF
--- a/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/JsonHubProtocol.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/JsonHubProtocol.cs
@@ -93,7 +93,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
 
                     if (token == null || token.Type != JTokenType.Object)
                     {
-                        throw new FormatException($"Unexpected JSON Token Type '{token?.Type}'. Expected a JSON Object.");
+                        throw new InvalidDataException($"Unexpected JSON Token Type '{token?.Type}'. Expected a JSON Object.");
                     }
 
                     var json = (JObject)token;
@@ -115,12 +115,12 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
                         case HubProtocolConstants.PingMessageType:
                             return PingMessage.Instance;
                         default:
-                            throw new FormatException($"Unknown message type: {type}");
+                            throw new InvalidDataException($"Unknown message type: {type}");
                     }
                 }
                 catch (JsonReaderException jrex)
                 {
-                    throw new FormatException("Error reading JSON.", jrex);
+                    throw new InvalidDataException("Error reading JSON.", jrex);
                 }
             }
         }
@@ -291,7 +291,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
             var arguments = new object[args.Count];
             if (paramTypes.Length != arguments.Length)
             {
-                throw new FormatException($"Invocation provides {arguments.Length} argument(s) but target expects {paramTypes.Length}.");
+                throw new InvalidDataException($"Invocation provides {arguments.Length} argument(s) but target expects {paramTypes.Length}.");
             }
 
             try
@@ -306,7 +306,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
             }
             catch (Exception ex)
             {
-                throw new FormatException("Error binding arguments. Make sure that the types of the provided values match the types of the hub method being invoked.", ex);
+                throw new InvalidDataException("Error binding arguments. Make sure that the types of the provided values match the types of the hub method being invoked.", ex);
             }
         }
 
@@ -327,7 +327,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
 
             if (error != null && resultProp != null)
             {
-                throw new FormatException("The 'error' and 'result' properties are mutually exclusive.");
+                throw new InvalidDataException("The 'error' and 'result' properties are mutually exclusive.");
             }
 
             if (resultProp == null)

--- a/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/JsonUtils.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/JsonUtils.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.IO;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
@@ -26,7 +27,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
 
             if (prop == null)
             {
-                throw new FormatException($"Missing required property '{property}'.");
+                throw new InvalidDataException($"Missing required property '{property}'.");
             }
 
             return GetValue<T>(property, expectedType, prop);
@@ -36,7 +37,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
         {
             if (expectedType != JTokenType.None && prop.Type != expectedType)
             {
-                throw new FormatException($"Expected '{property}' to be of type {expectedType}.");
+                throw new InvalidDataException($"Expected '{property}' to be of type {expectedType}.");
             }
             return prop.Value<T>();
         }

--- a/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/NegotiationProtocol.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/NegotiationProtocol.cs
@@ -33,7 +33,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
         {
             if (!TextMessageParser.TryParseMessage(ref input, out var payload))
             {
-                throw new FormatException("Unable to parse payload as a negotiation message.");
+                throw new InvalidDataException("Unable to parse payload as a negotiation message.");
             }
 
             using (var memoryStream = new MemoryStream(payload.ToArray()))
@@ -43,7 +43,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
                     var token = JToken.ReadFrom(reader);
                     if (token == null || token.Type != JTokenType.Object)
                     {
-                        throw new FormatException($"Unexpected JSON Token Type '{token?.Type}'. Expected a JSON Object.");
+                        throw new InvalidDataException($"Unexpected JSON Token Type '{token?.Type}'. Expected a JSON Object.");
                     }
 
                     var negotiationJObject = (JObject)token;

--- a/test/Microsoft.AspNetCore.SignalR.Common.Tests/Internal/Protocol/JsonHubProtocolTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Common.Tests/Internal/Protocol/JsonHubProtocolTests.cs
@@ -142,7 +142,7 @@ namespace Microsoft.AspNetCore.SignalR.Common.Tests.Internal.Protocol
 
             var binder = new TestBinder();
             var protocol = new JsonHubProtocol();
-            var ex = Assert.Throws<FormatException>(() => protocol.TryParseMessages(Encoding.UTF8.GetBytes(input), binder, out var messages));
+            var ex = Assert.Throws<InvalidDataException>(() => protocol.TryParseMessages(Encoding.UTF8.GetBytes(input), binder, out var messages));
             Assert.Equal(expectedMessage, ex.Message);
         }
 
@@ -158,7 +158,7 @@ namespace Microsoft.AspNetCore.SignalR.Common.Tests.Internal.Protocol
             var binder = new TestBinder(paramTypes: new[] { typeof(int), typeof(string) }, returnType: typeof(bool));
             var protocol = new JsonHubProtocol();
             protocol.TryParseMessages(Encoding.UTF8.GetBytes(input), binder, out var messages);
-            var ex = Assert.Throws<FormatException>(() => ((HubMethodInvocationMessage)messages[0]).Arguments);
+            var ex = Assert.Throws<InvalidDataException>(() => ((HubMethodInvocationMessage)messages[0]).Arguments);
             Assert.Equal(expectedMessage, ex.Message);
         }
 

--- a/test/Microsoft.AspNetCore.SignalR.Common.Tests/Internal/Protocol/NegotiationProtocolTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Common.Tests/Internal/Protocol/NegotiationProtocolTests.cs
@@ -30,6 +30,7 @@ namespace Microsoft.AspNetCore.SignalR.Common.Tests.Internal.Protocol
         [InlineData("42\u001e", "Unexpected JSON Token Type 'Integer'. Expected a JSON Object.")]
         [InlineData("\"42\"\u001e", "Unexpected JSON Token Type 'String'. Expected a JSON Object.")]
         [InlineData("null\u001e", "Unexpected JSON Token Type 'Null'. Expected a JSON Object.")]
+        [InlineData("{}\u001e", "Missing required property 'protocol'.")]
         [InlineData("[]\u001e", "Unexpected JSON Token Type 'Array'. Expected a JSON Object.")]
         public void ParsingNegotiationMessageThrowsForInvalidMessages(string payload, string expectedMessage)
         {

--- a/test/Microsoft.AspNetCore.SignalR.Common.Tests/Internal/Protocol/NegotiationProtocolTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Common.Tests/Internal/Protocol/NegotiationProtocolTests.cs
@@ -30,13 +30,12 @@ namespace Microsoft.AspNetCore.SignalR.Common.Tests.Internal.Protocol
         [InlineData("42\u001e", "Unexpected JSON Token Type 'Integer'. Expected a JSON Object.")]
         [InlineData("\"42\"\u001e", "Unexpected JSON Token Type 'String'. Expected a JSON Object.")]
         [InlineData("null\u001e", "Unexpected JSON Token Type 'Null'. Expected a JSON Object.")]
-        [InlineData("{}\u001e", "Missing required property 'protocol'.")]
         [InlineData("[]\u001e", "Unexpected JSON Token Type 'Array'. Expected a JSON Object.")]
         public void ParsingNegotiationMessageThrowsForInvalidMessages(string payload, string expectedMessage)
         {
             var message = Encoding.UTF8.GetBytes(payload);
 
-            var exception = Assert.Throws<FormatException>(() =>
+            var exception = Assert.Throws<InvalidDataException>(() =>
                 Assert.True(NegotiationProtocol.TryParseMessage(message, out var deserializedMessage)));
 
             Assert.Equal(expectedMessage, exception.Message);


### PR DESCRIPTION
Throw InvalidDataException instead of FormatException in NegotationProtocol

 - Modify NegotiationProtocol to throw InvalidDataException
 - Update NegotiationProtocolTests expectations
 - Remove test case for InlineData "Missing required property 'protocol'"

Addresses #1203

@anurse It took me a minute to figure out why one case failed for `[InlineData("{}\u001e", "Missing required property 'protocol'.")]`, it was because the test was expecting a FormatException from JsonUtils.GetRequiredProperty (which is still a valid case). 

I've removed it for now, but removing test cases is usually frowned upon. So I can account for the FormatException from JsonUtils.GetRequiredProperty and re-work the test some if you want.