### PR TITLE
Refactor HubContext

### DIFF
--- a/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/BroadcastBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/BroadcastBenchmark.cs
@@ -42,7 +42,7 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
         [Benchmark]
         public Task InvokeAsyncAll()
         {
-            return _hubContext.All.InvokeAsync("Method");
+            return _hubContext.Clients.All.InvokeAsync("Method");
         }
     }
 }

--- a/src/Microsoft.AspNetCore.SignalR.Core/HubClients.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/HubClients.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.AspNetCore.SignalR
+{
+    public class HubClients<THub> : IHubClients
+    {
+        private readonly HubLifetimeManager<THub> _lifetimeManager;
+
+        public HubClients(HubLifetimeManager<THub> lifetimeManager)
+        {
+            _lifetimeManager = lifetimeManager;
+            All = new AllClientProxy<THub>(_lifetimeManager);
+        }
+
+        public IClientProxy All { get; }
+
+        public IClientProxy AllExcept(IReadOnlyList<string> excludedIds)
+        {
+            return new AllClientsExceptProxy<THub>(_lifetimeManager, excludedIds);
+        }
+
+        public IClientProxy Client(string connectionId)
+        {
+            return new SingleClientProxy<THub>(_lifetimeManager, connectionId);
+        }
+
+        public IClientProxy Group(string groupName)
+        {
+            return new GroupProxy<THub>(_lifetimeManager, groupName);
+        }
+
+        public IClientProxy GroupExcept(string groupName, IReadOnlyList<string> excludeIds)
+        {
+            return new GroupExceptProxy<THub>(_lifetimeManager, groupName, excludeIds);
+        }
+
+        public IClientProxy MultipleClients(IReadOnlyList<string> connectionIds)
+        {
+            return new MultipleClientProxy<THub>(_lifetimeManager, connectionIds);
+        }
+
+        public IClientProxy User(string userId)
+        {
+            return new UserProxy<THub>(_lifetimeManager, userId);
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.SignalR.Core/HubClients.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/HubClients.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace Microsoft.AspNetCore.SignalR
 {

--- a/src/Microsoft.AspNetCore.SignalR.Core/HubClients`T.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/HubClients`T.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNetCore.SignalR
 
         public T MultipleClients(IReadOnlyList<string> connectionIds)
         {
-            throw new NotImplementedException();
+            return TypedClientBuilder<T>.Build(new MultipleClientProxy<THub>(_lifetimeManager, connectionIds));
         }
 
         public virtual T Group(string groupName)

--- a/src/Microsoft.AspNetCore.SignalR.Core/HubClients`T.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/HubClients`T.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.AspNetCore.SignalR
+{
+    public class HubClients<THub, T> : IHubClients<T>
+    {
+        private readonly HubLifetimeManager<THub> _lifetimeManager;
+
+        public HubClients(HubLifetimeManager<THub> lifetimeManager)
+        {
+            _lifetimeManager = lifetimeManager;
+            All = TypedClientBuilder<T>.Build(new AllClientProxy<THub>(_lifetimeManager));
+        }
+
+        public T All { get; }
+
+        public T AllExcept(IReadOnlyList<string> excludedIds)
+        {
+            return TypedClientBuilder<T>.Build(new AllClientsExceptProxy<THub>(_lifetimeManager, excludedIds));
+        }
+
+        public virtual T Client(string connectionId)
+        {
+            return TypedClientBuilder<T>.Build(new SingleClientProxy<THub>(_lifetimeManager, connectionId));
+        }
+
+        public T MultipleClients(IReadOnlyList<string> connectionIds)
+        {
+            throw new NotImplementedException();
+        }
+
+        public virtual T Group(string groupName)
+        {
+            return TypedClientBuilder<T>.Build(new GroupProxy<THub>(_lifetimeManager, groupName));
+        }
+
+        public T GroupExcept(string groupName, IReadOnlyList<string> excludeIds)
+        {
+            return TypedClientBuilder<T>.Build(new GroupExceptProxy<THub>(_lifetimeManager, groupName, excludeIds));
+        }
+
+        public virtual T User(string userId)
+        {
+            return TypedClientBuilder<T>.Build(new UserProxy<THub>(_lifetimeManager, userId));
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.SignalR.Core/HubContext.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/HubContext.cs
@@ -5,51 +5,18 @@ using System.Collections.Generic;
 
 namespace Microsoft.AspNetCore.SignalR
 {
-    public class HubContext<THub> : IHubContext<THub>, IHubClients where THub : Hub
+    public class HubContext<THub> : IHubContext<THub> where THub : Hub
     {
         private readonly HubLifetimeManager<THub> _lifetimeManager;
 
         public HubContext(HubLifetimeManager<THub> lifetimeManager)
         {
             _lifetimeManager = lifetimeManager;
-            All = new AllClientProxy<THub>(_lifetimeManager);
             Groups = new GroupManager<THub>(lifetimeManager);
         }
 
-        public IHubClients Clients => this;
-
-        public virtual IClientProxy All { get; }
+        public IHubClients Clients => new HubClients<THub>(_lifetimeManager);
 
         public virtual IGroupManager Groups { get; }
-
-        public IClientProxy AllExcept(IReadOnlyList<string> excludedIds)
-        {
-            return new AllClientsExceptProxy<THub>(_lifetimeManager, excludedIds);
-        }
-
-        public virtual IClientProxy Client(string connectionId)
-        {
-            return new SingleClientProxy<THub>(_lifetimeManager, connectionId);
-        }
-
-        public virtual IClientProxy Group(string groupName)
-        {
-            return new GroupProxy<THub>(_lifetimeManager, groupName);
-        }
-
-        public IClientProxy GroupExcept(string groupName, IReadOnlyList<string> excludeIds)
-        {
-            return new GroupExceptProxy<THub>(_lifetimeManager, groupName, excludeIds);
-        }
-
-        public virtual IClientProxy User(string userId)
-        {
-            return new UserProxy<THub>(_lifetimeManager, userId);
-        }
-
-        public virtual IClientProxy MultipleClients(IReadOnlyList<string> connectionIds)
-        {
-            return new MultipleClientProxy<THub>(_lifetimeManager, connectionIds);
-        }
     }
 }

--- a/src/Microsoft.AspNetCore.SignalR.Core/HubContext.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/HubContext.cs
@@ -8,14 +8,16 @@ namespace Microsoft.AspNetCore.SignalR
     public class HubContext<THub> : IHubContext<THub> where THub : Hub
     {
         private readonly HubLifetimeManager<THub> _lifetimeManager;
+        private readonly IHubClients _clients;
 
         public HubContext(HubLifetimeManager<THub> lifetimeManager)
         {
             _lifetimeManager = lifetimeManager;
+            _clients = new HubClients<THub>(_lifetimeManager);
             Groups = new GroupManager<THub>(lifetimeManager);
         }
 
-        public IHubClients Clients => new HubClients<THub>(_lifetimeManager);
+        public IHubClients Clients => _clients;
 
         public virtual IGroupManager Groups { get; }
     }

--- a/src/Microsoft.AspNetCore.SignalR.Core/HubContext.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/HubContext.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
-
 namespace Microsoft.AspNetCore.SignalR
 {
     public class HubContext<THub> : IHubContext<THub> where THub : Hub

--- a/src/Microsoft.AspNetCore.SignalR.Core/HubContext`T.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/HubContext`T.cs
@@ -5,53 +5,22 @@ using System.Collections.Generic;
 
 namespace Microsoft.AspNetCore.SignalR
 {
-	public class HubContext<THub, T> : IHubContext<THub, T>, IHubClients<T>
+	public class HubContext<THub, T> : IHubContext<THub, T>
         where THub : Hub<T>
         where T : class
     {
         private readonly HubLifetimeManager<THub> _lifetimeManager;
+        private readonly IHubClients<T> _clients;
 
         public HubContext(HubLifetimeManager<THub> lifetimeManager)
         {
             _lifetimeManager = lifetimeManager;
-            All = TypedClientBuilder<T>.Build(new AllClientProxy<THub>(_lifetimeManager));
+            _clients = new HubClients<THub, T>(_lifetimeManager);
             Groups = new GroupManager<THub>(lifetimeManager);
         }
 
-        public IHubClients<T> Clients => this;
-
-        public virtual T All { get; }
+        public IHubClients<T> Clients => _clients;
 
         public virtual IGroupManager Groups { get; }
-
-        public T AllExcept(IReadOnlyList<string> excludedIds)
-        {
-            return TypedClientBuilder<T>.Build(new AllClientsExceptProxy<THub>(_lifetimeManager, excludedIds));
-        }
-
-        public virtual T Client(string connectionId)
-        {
-            return TypedClientBuilder<T>.Build(new SingleClientProxy<THub>(_lifetimeManager, connectionId));
-        }
-
-        public T MultipleClients(IReadOnlyList<string> connectionIds)
-        {
-            return TypedClientBuilder<T>.Build(new MultipleClientProxy<THub>(_lifetimeManager, connectionIds));
-        }
-
-        public virtual T Group(string groupName)
-        {
-            return TypedClientBuilder<T>.Build(new GroupProxy<THub>(_lifetimeManager, groupName));
-        }
-
-        public T GroupExcept(string groupName, IReadOnlyList<string> excludeIds)
-        {
-            return TypedClientBuilder<T>.Build(new GroupExceptProxy<THub>(_lifetimeManager, groupName, excludeIds));
-        }
-
-        public virtual T User(string userId)
-        {
-            return TypedClientBuilder<T>.Build(new UserProxy<THub>(_lifetimeManager, userId));
-        }
     }
 }


### PR DESCRIPTION
Changing HubContext to not implement IHubClients. Instead we'll introduce another type that will be exposed through the `Clients` property.
This allows us to rename some of the IHubClients properties (`MultipleConnections` -> `Clients`, `MultipleGroups` -> `Groups` etc).