### PR TITLE
MultipleClients -> Clients

### DIFF
--- a/src/Microsoft.AspNetCore.SignalR.Core/DynamicHubClients.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/DynamicHubClients.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNetCore.SignalR
         public dynamic AllExcept(IReadOnlyList<string> excludedIds) => new DynamicClientProxy(_clients.AllExcept(excludedIds));
         public dynamic Caller => new DynamicClientProxy(_clients.Caller);
         public dynamic Client(string connectionId) => new DynamicClientProxy(_clients.Client(connectionId));
-        public dynamic MultipleClients(IReadOnlyList<string> connectionIds) => new DynamicClientProxy(_clients.MultipleClients(connectionIds));
+        public dynamic Clients(IReadOnlyList<string> connectionIds) => new DynamicClientProxy(_clients.Clients(connectionIds));
         public dynamic Group(string groupName) => new DynamicClientProxy(_clients.Group(groupName));
         public dynamic GroupExcept(string groupName, IReadOnlyList<string> excludedIds) => new DynamicClientProxy(_clients.GroupExcept(groupName, excludedIds));
         public dynamic OthersInGroup(string groupName) => new DynamicClientProxy(_clients.OthersInGroup(groupName));

--- a/src/Microsoft.AspNetCore.SignalR.Core/HubCallerClients.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/HubCallerClients.cs
@@ -54,9 +54,9 @@ namespace Microsoft.AspNetCore.SignalR
            return _hubClients.User(userId);
         }
 
-        public IClientProxy MultipleClients(IReadOnlyList<string> connectionIds)
+        public IClientProxy Clients(IReadOnlyList<string> connectionIds)
         {
-            return _hubClients.MultipleClients(connectionIds);
+            return _hubClients.Clients(connectionIds);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.SignalR.Core/HubClients.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/HubClients.cs
@@ -37,7 +37,7 @@ namespace Microsoft.AspNetCore.SignalR
             return new GroupExceptProxy<THub>(_lifetimeManager, groupName, excludeIds);
         }
 
-        public IClientProxy MultipleClients(IReadOnlyList<string> connectionIds)
+        public IClientProxy Clients(IReadOnlyList<string> connectionIds)
         {
             return new MultipleClientProxy<THub>(_lifetimeManager, connectionIds);
         }

--- a/src/Microsoft.AspNetCore.SignalR.Core/HubClients`T.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/HubClients`T.cs
@@ -29,7 +29,7 @@ namespace Microsoft.AspNetCore.SignalR
             return TypedClientBuilder<T>.Build(new SingleClientProxy<THub>(_lifetimeManager, connectionId));
         }
 
-        public T MultipleClients(IReadOnlyList<string> connectionIds)
+        public T Clients(IReadOnlyList<string> connectionIds)
         {
             return TypedClientBuilder<T>.Build(new MultipleClientProxy<THub>(_lifetimeManager, connectionIds));
         }

--- a/src/Microsoft.AspNetCore.SignalR.Core/IHubClients`T.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/IHubClients`T.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.SignalR
 
         T Client(string connectionId);
 
-        T MultipleClients(IReadOnlyList<string> connectionIds);
+        T Clients(IReadOnlyList<string> connectionIds);
 
         T Group(string groupName);
 

--- a/src/Microsoft.AspNetCore.SignalR.Core/TypedHubClients.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/TypedHubClients.cs
@@ -37,9 +37,9 @@ namespace Microsoft.AspNetCore.SignalR
             return TypedClientBuilder<T>.Build(_hubClients.GroupExcept(groupName, excludeIds));
         }
 
-        public T MultipleClients(IReadOnlyList<string> connectionIds)
+        public T Clients(IReadOnlyList<string> connectionIds)
         {
-            return TypedClientBuilder<T>.Build(_hubClients.MultipleClients(connectionIds));
+            return TypedClientBuilder<T>.Build(_hubClients.Clients(connectionIds));
         }
 
         public T OthersInGroup(string groupName)

--- a/test/Microsoft.AspNetCore.SignalR.Tests/HubEndpointTestUtils/Hubs.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/HubEndpointTestUtils/Hubs.cs
@@ -29,7 +29,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests.HubEndpointTestUtils
 
         public Task SendToMultipleClients(string message, IReadOnlyList<string> connectionIds)
         {
-            return Clients.MultipleClients(connectionIds).InvokeAsync("Send", message);
+            return Clients.Clients(connectionIds).InvokeAsync("Send", message);
         }
 
         public Task GroupAddMethod(string groupName)
@@ -183,7 +183,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests.HubEndpointTestUtils
 
         public Task SendToMultipleClients(string message, IReadOnlyList<string> connectionIds)
         {
-            return Clients.MultipleClients(connectionIds).Send(message);
+            return Clients.Clients(connectionIds).Send(message);
         }
 
         public Task GroupAddMethod(string groupName)
@@ -253,7 +253,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests.HubEndpointTestUtils
 
         public Task SendToMultipleClients(string message, IReadOnlyList<string> connectionIds)
         {
-            return Clients.MultipleClients(connectionIds).Send(message);
+            return Clients.Clients(connectionIds).Send(message);
         }
 
         public async Task DelayedSend(string connectionId, string message)


### PR DESCRIPTION
Renaming `MultipleClients `to `Clients `is now possible after the `HubContext `refactor 6baee8b7a98f32bc7fc7c448a068eda74c237296
  