### PR TITLE
Fix SocialWeather sample

### DIFF
--- a/samples/SocialWeather/PersistentConnectionLifeTimeManager.cs
+++ b/samples/SocialWeather/PersistentConnectionLifeTimeManager.cs
@@ -22,7 +22,7 @@ namespace SocialWeather
         public void OnConnectedAsync(ConnectionContext connection)
         {
             connection.Metadata["groups"] = new HashSet<string>();
-            connection.Metadata["format"] = "json";
+            connection.Metadata["format"] = connection.GetHttpContext().Request.Query["formatType"].ToString();
             _connectionList.Add(connection);
         }
 

--- a/samples/SocialWeather/Pipe/PipeWeatherStreamFormatter.cs
+++ b/samples/SocialWeather/Pipe/PipeWeatherStreamFormatter.cs
@@ -31,14 +31,14 @@ namespace SocialWeather.Pipe
                 temperature = int.MinValue;
             }
 
-            if (tokens.Length < 2 || !long.TryParse(tokens[1], out reportTime))
-            {
-                temperature = int.MinValue;
-            }
-
-            if (tokens.Length < 3 || !Enum.TryParse<Weather>(tokens[2], out weather))
+            if (tokens.Length < 2 || !Enum.TryParse<Weather>(tokens[1], out weather))
             {
                 weather = (Weather)(-1);
+            }
+
+            if (tokens.Length < 3 || !long.TryParse(tokens[2], out reportTime))
+            {
+                reportTime = int.MinValue;
             }
 
             return new WeatherReport

--- a/samples/SocialWeather/SocialWeatherEndPoint.cs
+++ b/samples/SocialWeather/SocialWeatherEndPoint.cs
@@ -32,7 +32,7 @@ namespace SocialWeather
         public async Task ProcessRequests(ConnectionContext connection)
         {
             var formatter = _formatterResolver.GetFormatter<WeatherReport>(
-                (string)connection.Metadata["formatType"]);
+                (string)connection.Metadata["format"]);
 
             while (await connection.Transport.Reader.WaitToReadAsync())
             {

--- a/samples/SocialWeather/wwwroot/index.html
+++ b/samples/SocialWeather/wwwroot/index.html
@@ -67,7 +67,7 @@
                 span.style.color = color;
             }
 
-            let connectUrl = `ws://${document.location.host}/weather/ws?formatType=json`;
+            let connectUrl = `ws://${document.location.host}/weather?formatType=json`;
             let webSocket = new WebSocket(connectUrl);
             webSocket.onopen = event => {
                 updateStatus('Connected', 'green');


### PR DESCRIPTION
#1310
* Was pointing to old /ws endpoint
* Wasn't using format sent via query-string

Lua and CSharp clients which use the other formats are located https://github.com/moozzyk/SocialWeatherClients/tree/master/src
Not sure what to do about those