### PR TITLE
Rename JwtBearer to AccessToken in C# Client

### DIFF
--- a/samples/JwtClientSample/Program.cs
+++ b/samples/JwtClientSample/Program.cs
@@ -31,7 +31,7 @@ namespace JwtClientSample
             var hubConnection = new HubConnectionBuilder()
                 .WithUrl(ServerUrl + "/broadcast")
                 .WithTransport(transportType)
-                .WithJwtBearer(() => _tokens[userId])
+                .WithAccessToken(() => _tokens[userId])
                 .Build();
 
             var closedTcs = new TaskCompletionSource<object>();

--- a/src/Microsoft.AspNetCore.SignalR.Client/HubConnectionBuilderHttpExtensions.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client/HubConnectionBuilderHttpExtensions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.SignalR.Client
         public static readonly string TransportTypeKey = "TransportType";
         public static readonly string HttpMessageHandlerKey = "HttpMessageHandler";
         public static readonly string HeadersKey = "Headers";
-        public static readonly string JwtBearerTokenFactoryKey = "JwtBearerTokenFactory";
+        public static readonly string AccessTokenFactoryKey = "AccessTokenFactory";
         public static readonly string WebSocketOptionsKey = "WebSocketOptions";
 
         public static IHubConnectionBuilder WithUrl(this IHubConnectionBuilder hubConnectionBuilder, string url)
@@ -44,7 +44,7 @@ namespace Microsoft.AspNetCore.SignalR.Client
                 {
                     HttpMessageHandler = hubConnectionBuilder.GetMessageHandler(),
                     Headers = headers != null ? new ReadOnlyDictionary<string, string>(headers) : null,
-                    JwtBearerTokenFactory = hubConnectionBuilder.GetJwtBearerTokenFactory(),
+                    AccessTokenFactory = hubConnectionBuilder.GetAccessTokenFactory(),
                     WebSocketOptions = hubConnectionBuilder.GetWebSocketOptions(),
                 };
 
@@ -87,14 +87,14 @@ namespace Microsoft.AspNetCore.SignalR.Client
             return hubConnectionBuilder;
         }
 
-        public static IHubConnectionBuilder WithJwtBearer(this IHubConnectionBuilder hubConnectionBuilder, Func<string> jwtBearerTokenFactory)
+        public static IHubConnectionBuilder WithAccessToken(this IHubConnectionBuilder hubConnectionBuilder, Func<string> accessTokenFactory)
         {
-            if (jwtBearerTokenFactory == null)
+            if (accessTokenFactory == null)
             {
-                throw new ArgumentNullException(nameof(jwtBearerTokenFactory));
+                throw new ArgumentNullException(nameof(accessTokenFactory));
             }
 
-            hubConnectionBuilder.AddSetting(JwtBearerTokenFactoryKey, jwtBearerTokenFactory);
+            hubConnectionBuilder.AddSetting(AccessTokenFactoryKey, accessTokenFactory);
 
             return hubConnectionBuilder;
         }
@@ -137,9 +137,9 @@ namespace Microsoft.AspNetCore.SignalR.Client
             return null;
         }
 
-        public static Func<string> GetJwtBearerTokenFactory(this IHubConnectionBuilder hubConnectionBuilder)
+        public static Func<string> GetAccessTokenFactory(this IHubConnectionBuilder hubConnectionBuilder)
         {
-            if (hubConnectionBuilder.TryGetSetting<Func<string>>(JwtBearerTokenFactoryKey, out var factory))
+            if (hubConnectionBuilder.TryGetSetting<Func<string>>(AccessTokenFactoryKey, out var factory))
             {
                 return factory;
             }

--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/HttpOptions.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/HttpOptions.cs
@@ -12,14 +12,14 @@ namespace Microsoft.AspNetCore.Sockets.Client.Http
     {
         public HttpMessageHandler HttpMessageHandler { get; set; }
         public IReadOnlyCollection<KeyValuePair<string, string>> Headers { get; set; }
-        public Func<string> JwtBearerTokenFactory { get; set; }
+        public Func<string> AccessTokenFactory { get; set; }
 
         /// <summary>
         /// Gets or sets a delegate that will be invoked with the <see cref="ClientWebSocketOptions"/> object used
         /// by the <see cref="WebSocketsTransport"/> to configure the WebSocket.
         /// </summary>
         /// <remarks>
-        /// This delegate is invoked after headers from <see cref="Headers"/> and the JWT bearer token from <see cref="JwtBearerTokenFactory"/>
+        /// This delegate is invoked after headers from <see cref="Headers"/> and the access token from <see cref="AccessTokenFactory"/>
         /// has been applied.
         /// </remarks>
         public Action<ClientWebSocketOptions> WebSocketOptions { get; set; }

--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/SendUtils.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/SendUtils.cs
@@ -119,9 +119,9 @@ namespace Microsoft.AspNetCore.Sockets.Client
             }
             request.Headers.UserAgent.Add(Constants.UserAgentHeader);
 
-            if (httpOptions?.JwtBearerTokenFactory != null)
+            if (httpOptions?.AccessTokenFactory != null)
             {
-                request.Headers.Add("Authorization", $"Bearer {httpOptions.JwtBearerTokenFactory()}");
+                request.Headers.Add("Authorization", $"Bearer {httpOptions.AccessTokenFactory()}");
             }
         }
     }

--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/WebSocketsTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/WebSocketsTransport.cs
@@ -44,9 +44,9 @@ namespace Microsoft.AspNetCore.Sockets.Client
                 }
             }
 
-            if (httpOptions?.JwtBearerTokenFactory != null)
+            if (httpOptions?.AccessTokenFactory != null)
             {
-                _webSocket.Options.SetRequestHeader("Authorization", $"Bearer {httpOptions.JwtBearerTokenFactory()}");
+                _webSocket.Options.SetRequestHeader("Authorization", $"Bearer {httpOptions.AccessTokenFactory()}");
             }
 
             httpOptions?.WebSocketOptions?.Invoke(_webSocket.Options);

--- a/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/HubConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/HubConnectionTests.cs
@@ -672,7 +672,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
                     .WithUrl(_serverFixture.Url + "/authorizedhub")
                     .WithTransport(transportType)
                     .WithLoggerFactory(loggerFactory)
-                    .WithJwtBearer(() => token)
+                    .WithAccessToken(() => token)
                     .Build();
                 try
                 {


### PR DESCRIPTION
Somehow we missed this one when changing the TS client