### PR TITLE
fix #1155 by renaming signalRTokenHeader to access_token

### DIFF
--- a/client-ts/FunctionalTests/Startup.cs
+++ b/client-ts/FunctionalTests/Startup.cs
@@ -58,12 +58,12 @@ namespace FunctionalTests
                     {
                         OnMessageReceived = context =>
                         {
-                            var signalRTokenHeader = context.Request.Query["signalRTokenHeader"];
+                            var signalRTokenHeader = context.Request.Query["access_token"];
 
                             if (!string.IsNullOrEmpty(signalRTokenHeader) &&
                                 (context.HttpContext.WebSockets.IsWebSocketRequest || context.Request.Headers["Accept"] == "text/event-stream"))
                             {
-                                context.Token = context.Request.Query["signalRTokenHeader"];
+                                context.Token = context.Request.Query["access_token"];
                             }
                             return Task.CompletedTask;
                         }

--- a/client-ts/FunctionalTests/ts/HubConnectionTests.ts
+++ b/client-ts/FunctionalTests/ts/HubConnectionTests.ts
@@ -476,7 +476,7 @@ describe('hubConnection', function () {
                         hubConnection = new HubConnection('/authorizedhub', {
                             transport: transportType,
                             logger: LogLevel.Trace,
-                            accessToken: () => jwtToken
+                            accessTokenFactory: () => jwtToken
                         });
                         hubConnection.onclose(function (error) {
                             expect(error).toBe(undefined);

--- a/client-ts/signalr/spec/HubConnection.spec.ts
+++ b/client-ts/signalr/spec/HubConnection.spec.ts
@@ -13,12 +13,16 @@ import { MessageType } from "../src/IHubProtocol"
 import { asyncit as it, captureException, delay, PromiseSource } from './Utils';
 import { IHubConnectionOptions } from "../src/HubConnection";
 
+const commonOptions: IHubConnectionOptions = {
+    logger: null,
+}
+
 describe("HubConnection", () => {
 
     describe("start", () => {
         it("sends negotiation message", async () => {
             let connection = new TestConnection();
-            let hubConnection = new HubConnection(connection, { logger: null });
+            let hubConnection = new HubConnection(connection, commonOptions);
             await hubConnection.start();
             expect(connection.sentData.length).toBe(1)
             expect(JSON.parse(connection.sentData[0])).toEqual({
@@ -32,7 +36,7 @@ describe("HubConnection", () => {
         it("sends a non blocking invocation", async () => {
             let connection = new TestConnection();
 
-            let hubConnection = new HubConnection(connection, { logger: null });
+            let hubConnection = new HubConnection(connection, commonOptions);
             let invokePromise = hubConnection.send("testMethod", "arg", 42)
                 .catch((_) => { }); // Suppress exception and unhandled promise rejection warning.
 
@@ -56,7 +60,7 @@ describe("HubConnection", () => {
         it("sends an invocation", async () => {
             let connection = new TestConnection();
 
-            let hubConnection = new HubConnection(connection, { logger: null });
+            let hubConnection = new HubConnection(connection, commonOptions);
             let invokePromise = hubConnection.invoke("testMethod", "arg", 42)
                 .catch((_) => { }); // Suppress exception and unhandled promise rejection warning.
 
@@ -79,7 +83,7 @@ describe("HubConnection", () => {
         it("rejects the promise when an error is received", async () => {
             let connection = new TestConnection();
 
-            let hubConnection = new HubConnection(connection, { logger: null });
+            let hubConnection = new HubConnection(connection, commonOptions);
             let invokePromise = hubConnection.invoke("testMethod", "arg", 42);
 
             connection.receive({ type: MessageType.Completion, invocationId: connection.lastInvocationId, error: "foo" });
@@ -91,7 +95,7 @@ describe("HubConnection", () => {
         it("resolves the promise when a result is received", async () => {
             let connection = new TestConnection();
 
-            let hubConnection = new HubConnection(connection, { logger: null });
+            let hubConnection = new HubConnection(connection, commonOptions);
             let invokePromise = hubConnection.invoke("testMethod", "arg", 42);
 
             connection.receive({ type: MessageType.Completion, invocationId: connection.lastInvocationId, result: "foo" });
@@ -102,7 +106,7 @@ describe("HubConnection", () => {
         it("completes pending invocations when stopped", async () => {
             let connection = new TestConnection();
 
-            let hubConnection = new HubConnection(connection, { logger: null });
+            let hubConnection = new HubConnection(connection, commonOptions);
             let invokePromise = hubConnection.invoke("testMethod");
             hubConnection.stop();
 
@@ -113,7 +117,7 @@ describe("HubConnection", () => {
         it("completes pending invocations when connection is lost", async () => {
             let connection = new TestConnection();
 
-            let hubConnection = new HubConnection(connection, { logger: null });
+            let hubConnection = new HubConnection(connection, commonOptions);
             let invokePromise = hubConnection.invoke("testMethod");
             // Typically this would be called by the transport
             connection.onclose(new Error("Connection lost"));
@@ -149,7 +153,7 @@ describe("HubConnection", () => {
 
         it("callback invoked when servers invokes a method on the client", async () => {
             let connection = new TestConnection();
-            let hubConnection = new HubConnection(connection, { logger: null });
+            let hubConnection = new HubConnection(connection, commonOptions);
             let value = "";
             hubConnection.on("message", v => value = v);
 
@@ -166,7 +170,7 @@ describe("HubConnection", () => {
 
         it("can have multiple callbacks", async () => {
             let connection = new TestConnection();
-            let hubConnection = new HubConnection(connection, { logger: null });
+            let hubConnection = new HubConnection(connection, commonOptions);
             let numInvocations1 = 0;
             let numInvocations2 = 0;
             hubConnection.on("message", () => numInvocations1++);
@@ -186,7 +190,7 @@ describe("HubConnection", () => {
 
         it("can unsubscribe from on", async () => {
             let connection = new TestConnection();
-            let hubConnection = new HubConnection(connection, { logger: null });
+            let hubConnection = new HubConnection(connection, commonOptions);
 
             var numInvocations = 0;
             var callback = () => numInvocations++;
@@ -215,7 +219,7 @@ describe("HubConnection", () => {
 
         it("unsubscribing from non-existing callbacks no-ops", async () => {
             let connection = new TestConnection();
-            let hubConnection = new HubConnection(connection, { logger: null });
+            let hubConnection = new HubConnection(connection, commonOptions);
 
             hubConnection.off("_", () => { });
             hubConnection.on("message", t => { });
@@ -267,7 +271,7 @@ describe("HubConnection", () => {
         it("sends an invocation", async () => {
             let connection = new TestConnection();
 
-            let hubConnection = new HubConnection(connection, { logger: null });
+            let hubConnection = new HubConnection(connection, commonOptions);
             let invokePromise = hubConnection.stream("testStream", "arg", 42);
 
             // Verify the message is sent
@@ -289,7 +293,7 @@ describe("HubConnection", () => {
         it("completes with an error when an error is yielded", async () => {
             let connection = new TestConnection();
 
-            let hubConnection = new HubConnection(connection, { logger: null });
+            let hubConnection = new HubConnection(connection, commonOptions);
             let observer = new TestObserver();
             hubConnection.stream<any>("testMethod", "arg", 42)
                 .subscribe(observer);
@@ -303,7 +307,7 @@ describe("HubConnection", () => {
         it("completes the observer when a completion is received", async () => {
             let connection = new TestConnection();
 
-            let hubConnection = new HubConnection(connection, { logger: null });
+            let hubConnection = new HubConnection(connection, commonOptions);
             let observer = new TestObserver();
             hubConnection.stream<any>("testMethod", "arg", 42)
                 .subscribe(observer);
@@ -316,7 +320,7 @@ describe("HubConnection", () => {
         it("completes pending streams when stopped", async () => {
             let connection = new TestConnection();
 
-            let hubConnection = new HubConnection(connection, { logger: null });
+            let hubConnection = new HubConnection(connection, commonOptions);
             let observer = new TestObserver();
             hubConnection.stream<any>("testMethod")
                 .subscribe(observer);
@@ -329,7 +333,7 @@ describe("HubConnection", () => {
         it("completes pending streams when connection is lost", async () => {
             let connection = new TestConnection();
 
-            let hubConnection = new HubConnection(connection, { logger: null });
+            let hubConnection = new HubConnection(connection, commonOptions);
             let observer = new TestObserver();
             hubConnection.stream<any>("testMethod")
                 .subscribe(observer);
@@ -344,7 +348,7 @@ describe("HubConnection", () => {
         it("yields items as they arrive", async () => {
             let connection = new TestConnection();
 
-            let hubConnection = new HubConnection(connection, { logger: null });
+            let hubConnection = new HubConnection(connection, commonOptions);
             let observer = new TestObserver();
             hubConnection.stream<any>("testMethod")
                 .subscribe(observer);
@@ -365,7 +369,7 @@ describe("HubConnection", () => {
         it("does not require error function registered", async () => {
             let connection = new TestConnection();
 
-            let hubConnection = new HubConnection(connection, { logger: null });
+            let hubConnection = new HubConnection(connection, commonOptions);
             let observer = hubConnection.stream("testMethod").subscribe({
                 next: val => { }
             });
@@ -378,7 +382,7 @@ describe("HubConnection", () => {
         it("does not require complete function registered", async () => {
             let connection = new TestConnection();
 
-            let hubConnection = new HubConnection(connection, { logger: null });
+            let hubConnection = new HubConnection(connection, commonOptions);
             let observer = hubConnection.stream("testMethod").subscribe({
                 next: val => { }
             });
@@ -391,7 +395,7 @@ describe("HubConnection", () => {
         it("can be canceled", () => {
             let connection = new TestConnection();
 
-            let hubConnection = new HubConnection(connection, { logger: null });
+            let hubConnection = new HubConnection(connection, commonOptions);
             let observer = new TestObserver();
             let subscription = hubConnection.stream("testMethod")
                 .subscribe(observer);
@@ -417,7 +421,7 @@ describe("HubConnection", () => {
     describe("onClose", () => {
         it("can have multiple callbacks", async () => {
             let connection = new TestConnection();
-            let hubConnection = new HubConnection(connection, { logger: null });
+            let hubConnection = new HubConnection(connection, commonOptions);
             let invocations = 0;
             hubConnection.onclose(e => invocations++);
             hubConnection.onclose(e => invocations++);
@@ -428,7 +432,7 @@ describe("HubConnection", () => {
 
         it("callbacks receive error", async () => {
             let connection = new TestConnection();
-            let hubConnection = new HubConnection(connection, { logger: null });
+            let hubConnection = new HubConnection(connection, commonOptions);
             let error: Error;
             hubConnection.onclose(e => error = e);
 
@@ -439,7 +443,7 @@ describe("HubConnection", () => {
 
         it("ignores null callbacks", async () => {
             let connection = new TestConnection();
-            let hubConnection = new HubConnection(connection, { logger: null });
+            let hubConnection = new HubConnection(connection, commonOptions);
             hubConnection.onclose(null);
             hubConnection.onclose(undefined);
             // Typically this would be called by the transport
@@ -453,7 +457,7 @@ describe("HubConnection", () => {
             // Receive the ping mid-invocation so we can see that the rest of the flow works fine
 
             let connection = new TestConnection();
-            let hubConnection = new HubConnection(connection, { logger: null });
+            let hubConnection = new HubConnection(connection, commonOptions);
             let invokePromise = hubConnection.invoke("testMethod", "arg", 42);
 
             connection.receive({ type: MessageType.Ping });
@@ -464,7 +468,7 @@ describe("HubConnection", () => {
 
         it("does not terminate if messages are received", async () => {
             let connection = new TestConnection();
-            let hubConnection = new HubConnection(connection, { timeoutInMilliseconds: 100, logger: null });
+            let hubConnection = new HubConnection(connection, { ...commonOptions, timeoutInMilliseconds: 100 });
 
             let p = new PromiseSource<Error>();
             hubConnection.onclose(error => p.resolve(error));
@@ -489,7 +493,7 @@ describe("HubConnection", () => {
 
         it("terminates if no messages received within timeout interval", async () => {
             let connection = new TestConnection();
-            let hubConnection = new HubConnection(connection, { timeoutInMilliseconds: 100, logger: null });
+            let hubConnection = new HubConnection(connection, { ...commonOptions, timeoutInMilliseconds: 100 });
 
             let p = new PromiseSource<Error>();
             hubConnection.onclose(error => p.resolve(error));

--- a/client-ts/signalr/src/HttpConnection.ts
+++ b/client-ts/signalr/src/HttpConnection.ts
@@ -42,7 +42,10 @@ export class HttpConnection implements IConnection {
     constructor(url: string, options: IHttpConnectionOptions = {}) {
         this.logger = LoggerFactory.createLogger(options.logger);
         this.baseUrl = this.resolveUrl(url);
+
         options = options || {};
+        options.accessTokenFactory = options.accessTokenFactory || (() => null);
+
         this.httpClient = options.httpClient || new DefaultHttpClient();
         this.connectionState = ConnectionState.Disconnected;
         this.options = options;
@@ -68,9 +71,10 @@ export class HttpConnection implements IConnection {
             }
             else {
                 let headers;
-                if (this.options.accessTokenFactory) {
+                let token = this.options.accessTokenFactory();
+                if (token) {
                     headers = new Map<string, string>();
-                    headers.set("Authorization", `Bearer ${this.options.accessTokenFactory()}`);
+                    headers.set("Authorization", `Bearer ${token}`);
                 }
 
                 let negotiatePayload = await this.httpClient.post(this.resolveNegotiateUrl(this.baseUrl), {

--- a/client-ts/signalr/src/HttpConnection.ts
+++ b/client-ts/signalr/src/HttpConnection.ts
@@ -12,7 +12,7 @@ export interface IHttpConnectionOptions {
     httpClient?: HttpClient;
     transport?: TransportType | ITransport;
     logger?: ILogger | LogLevel;
-    accessToken?: () => string;
+    accessTokenFactory?: () => string;
 }
 
 const enum ConnectionState {
@@ -68,9 +68,9 @@ export class HttpConnection implements IConnection {
             }
             else {
                 let headers;
-                if (this.options.accessToken) {
+                if (this.options.accessTokenFactory) {
                     headers = new Map<string, string>();
-                    headers.set("Authorization", `Bearer ${this.options.accessToken()}`);
+                    headers.set("Authorization", `Bearer ${this.options.accessTokenFactory()}`);
                 }
 
                 let negotiatePayload = await this.httpClient.post(this.resolveNegotiateUrl(this.baseUrl), {
@@ -119,13 +119,13 @@ export class HttpConnection implements IConnection {
             transport = TransportType[availableTransports[0]];
         }
         if (transport === TransportType.WebSockets && availableTransports.indexOf(TransportType[transport]) >= 0) {
-            return new WebSocketTransport(this.options.accessToken, this.logger);
+            return new WebSocketTransport(this.options.accessTokenFactory, this.logger);
         }
         if (transport === TransportType.ServerSentEvents && availableTransports.indexOf(TransportType[transport]) >= 0) {
-            return new ServerSentEventsTransport(this.httpClient, this.options.accessToken, this.logger);
+            return new ServerSentEventsTransport(this.httpClient, this.options.accessTokenFactory, this.logger);
         }
         if (transport === TransportType.LongPolling && availableTransports.indexOf(TransportType[transport]) >= 0) {
-            return new LongPollingTransport(this.httpClient, this.options.accessToken, this.logger);
+            return new LongPollingTransport(this.httpClient, this.options.accessTokenFactory, this.logger);
         }
 
         if (this.isITransport(transport)) {

--- a/client-ts/signalr/src/Transports.ts
+++ b/client-ts/signalr/src/Transports.ts
@@ -29,21 +29,21 @@ export interface ITransport {
 
 export class WebSocketTransport implements ITransport {
     private readonly logger: ILogger;
-    private readonly accessToken: () => string;
+    private readonly accessTokenFactory: () => string;
     private webSocket: WebSocket;
 
-    constructor(accessToken: () => string, logger: ILogger) {
+    constructor(accessTokenFactory: () => string, logger: ILogger) {
         this.logger = logger;
-        this.accessToken = accessToken;
+        this.accessTokenFactory = accessTokenFactory;
     }
 
     connect(url: string, requestedTransferMode: TransferMode, connection: IConnection): Promise<TransferMode> {
 
         return new Promise<TransferMode>((resolve, reject) => {
             url = url.replace(/^http/, "ws");
-            if (this.accessToken) {
-                let token = this.accessToken();
-                url += (url.indexOf("?") < 0 ? "?" : "&") + `signalRTokenHeader=${token}`;
+            if (this.accessTokenFactory) {
+                let token = this.accessTokenFactory();
+                url += (url.indexOf("?") < 0 ? "?" : "&") + `access_token=${token}`;
             }
 
             let webSocket = new WebSocket(url);
@@ -105,14 +105,14 @@ export class WebSocketTransport implements ITransport {
 
 export class ServerSentEventsTransport implements ITransport {
     private readonly httpClient: HttpClient;
-    private readonly accessToken: () => string;
+    private readonly accessTokenFactory: () => string;
     private readonly logger: ILogger;
     private eventSource: EventSource;
     private url: string;
 
-    constructor(httpClient: HttpClient, accessToken: () => string, logger: ILogger) {
+    constructor(httpClient: HttpClient, accessTokenFactory: () => string, logger: ILogger) {
         this.httpClient = httpClient;
-        this.accessToken = accessToken;
+        this.accessTokenFactory = accessTokenFactory;
         this.logger = logger;
     }
 
@@ -123,9 +123,9 @@ export class ServerSentEventsTransport implements ITransport {
 
         this.url = url;
         return new Promise<TransferMode>((resolve, reject) => {
-            if (this.accessToken) {
-                let token = this.accessToken();
-                url += (url.indexOf("?") < 0 ? "?" : "&") + `signalRTokenHeader=${token}`;
+            if (this.accessTokenFactory) {
+                let token = this.accessTokenFactory();
+                url += (url.indexOf("?") < 0 ? "?" : "&") + `access_token=${token}`;
             }
 
             let eventSource = new EventSource(url);
@@ -168,7 +168,7 @@ export class ServerSentEventsTransport implements ITransport {
     }
 
     async send(data: any): Promise<void> {
-        return send(this.httpClient, this.url, this.accessToken, data);
+        return send(this.httpClient, this.url, this.accessTokenFactory, data);
     }
 
     stop(): Promise<void> {
@@ -293,11 +293,11 @@ export class LongPollingTransport implements ITransport {
     onclose: TransportClosed;
 }
 
-async function send(httpClient: HttpClient, url: string, accessToken: () => string, content: string | ArrayBuffer): Promise<void> {
+async function send(httpClient: HttpClient, url: string, accessTokenFactory: () => string, content: string | ArrayBuffer): Promise<void> {
     let headers;
-    if (accessToken) {
+    if (accessTokenFactory) {
         headers = new Map<string, string>();
-        headers.set("Authorization", `Bearer ${accessToken()}`)
+        headers.set("Authorization", `Bearer ${accessTokenFactory()}`)
     }
 
     await httpClient.post(url, {

--- a/samples/JwtSample/Startup.cs
+++ b/samples/JwtSample/Startup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -50,12 +50,12 @@ namespace JwtSample
                     {
                         OnMessageReceived = context =>
                         {
-                            var signalRTokenHeader = context.Request.Query["signalRTokenHeader"];
+                            var accessToken = context.Request.Query["access_token"];
 
-                            if (!string.IsNullOrEmpty(signalRTokenHeader) &&
+                            if (!string.IsNullOrEmpty(accessToken) &&
                                 (context.HttpContext.WebSockets.IsWebSocketRequest || context.Request.Headers["Accept"] == "text/event-stream"))
                             {
-                                context.Token = context.Request.Query["signalRTokenHeader"];
+                                context.Token = context.Request.Query["access_token"];
                             }
                             return Task.CompletedTask;
                         }

--- a/samples/JwtSample/wwwroot/index.html
+++ b/samples/JwtSample/wwwroot/index.html
@@ -68,7 +68,7 @@
             .then(function () {
                 var options = {
                     transport: transportType,
-                    accessToken: function () { return tokens[clientId]; }
+                    accessTokenFactory: function () { return tokens[clientId]; }
                 };
 
                 connection = new signalR.HubConnection('/broadcast', options);


### PR DESCRIPTION
I actually started this on `release/2.1` because to be honest, it's pretty simple and I feel comfortable taking it in preview 1 if @muratg is OK with that. It's low-hanging fruit, and it's "public" API surface (kinda) so front-loading it would be nice. Also, I was reviewing the OAuth spec and noticed that it calls out how to pass access tokens via the query string in the spec (https://tools.ietf.org/html/rfc6750#section-2.3), including the query string name to use, `access_token` (as @PinpointTownes referenced in the issue #1155).

Browser functional tests have been updated and run (next up on my plate is to automate those ;)). JwtSample has also been updated and verified. The C# client doesn't ever use the query string, so the only product changes are in the Jwt sample (since we haven't decided what to "build in" for this yet) and the TS client.

Anyway, this PR is on `dev` right now. If @muratg signs off on pulling it up to preview 1, I'll retarget to `release/2.1`