### PR TITLE
Enable 'release/' branches on Travis and AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,7 +4,7 @@ init:
 branches:
   only:
     - master
-    - release
+    - /release\/.*/
     - dev
     - /^(.*\/)?ci-.*$/
     - /^rel\/.*/

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ addons:
 branches:
   only:
     - master
-    - release
+    - /release\/.*/
     - dev
     - /^(.*\/)?ci-.*$/
     - /^rel\/.*/


### PR DESCRIPTION
Infrastructure only change, preview1 @muratg ?

Travis and AppVeyor aren't building `release/2.1` PRs because of this config. Noticed it in WebSockets and fixed it there and then saw SignalR PRs doing the same. Emailing folks about a more org-wide patch as well.