### PR TITLE
Reduce LongPolling timeout to accommodate Cloudflare's timeout

### DIFF
--- a/src/Microsoft.AspNetCore.Sockets.Http/LongPollingOptions.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Http/LongPollingOptions.cs
@@ -6,6 +6,6 @@ namespace Microsoft.AspNetCore.Sockets
 {
     public class LongPollingOptions
     {
-        public TimeSpan PollTimeout { get; set; } = TimeSpan.FromSeconds(110);
+        public TimeSpan PollTimeout { get; set; } = TimeSpan.FromSeconds(90);
     }
 }

--- a/test/Microsoft.AspNetCore.Sockets.Tests/LongPollingTests.cs
+++ b/test/Microsoft.AspNetCore.Sockets.Tests/LongPollingTests.cs
@@ -101,5 +101,12 @@ namespace Microsoft.AspNetCore.Sockets.Tests
             var payload = ms.ToArray();
             Assert.Equal("Hello World", Encoding.UTF8.GetString(payload));
         }
+
+        [Fact]
+        public void CheckLongPollingTimeoutValue()
+        {
+            var options = new HttpSocketOptions();
+            Assert.Equal(options.LongPolling.PollTimeout, TimeSpan.FromSeconds(90));
+        }
     }
 }


### PR DESCRIPTION
Issue: https://github.com/aspnet/SignalR/issues/1357
Cloudflare has a timeout of only 100 seconds after which they close the connection. Detailed here: https://support.cloudflare.com/hc/en-us/articles/200171926-Error-524-A-timeout-occurred