### PR TITLE
Workaround flakiness in compiling the ChatSample

### DIFF
--- a/samples/ChatSample/ChatSample.csproj
+++ b/samples/ChatSample/ChatSample.csproj
@@ -5,6 +5,8 @@
     <UserSecretsId>aspnet-ChatSample-f11cf018-e0a8-49fa-b749-4c0eb5c9150b</UserSecretsId>
     <!-- Don't create a NuGet package -->
     <IsPackable>false</IsPackable>
+    <!-- Ensures the minification only runs on one target framework - avoids race in MSBuild. -->
+    <RunBundleMinify Condition=" '$(TargetFramework)' == 'net461' OR '$(CI)' == 'true' ">false</RunBundleMinify>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Compilation fails sometimes because it's trying to bundle/minify twice at the same time.


> C:\b\w\4ae60d3b5c30e105\modules\SignalR\samples\ChatSample\wwwroot\css\site.min.css : Bundler & Minifier error 0: The process cannot access the file 'C:\b\w\4ae60d3b5c30e105\modules\SignalR\samples\ChatSample\wwwroot\css\site.min.css' because it is being used by another process.
