### PR TITLE
fix #1199 by suppressing ODE in received callback

### DIFF
--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.cs
@@ -207,6 +207,21 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
             Assert.Equal("Server timeout (100.00ms) elapsed without receiving a message from the server.", exception.Message);
         }
 
+        [Fact]
+        public async Task OnReceivedAfterTimerDisposedDoesNotThrow()
+        {
+            var connection = new TestConnection();
+            var hubConnection = new HubConnection(connection, new JsonHubProtocol(), new LoggerFactory());
+            await hubConnection.StartAsync().OrTimeout();
+            await hubConnection.DisposeAsync().OrTimeout();
+
+            // Fire callbacks, they shouldn't fail
+            foreach(var registration in connection.Callbacks)
+            {
+                await registration.InvokeAsync(new byte[0]);
+            }
+        }
+
         // Moq really doesn't handle out parameters well, so to make these tests work I added a manual mock -anurse
         private class MockHubProtocol : IHubProtocol
         {

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.cs
@@ -216,7 +216,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
             await hubConnection.DisposeAsync().OrTimeout();
 
             // Fire callbacks, they shouldn't fail
-            foreach(var registration in connection.Callbacks)
+            foreach (var registration in connection.Callbacks)
             {
                 await registration.InvokeAsync(new byte[0]);
             }

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/TestConnection.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/TestConnection.cs
@@ -40,7 +40,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
         private bool _closed;
         private object _closedLock = new object();
 
-        private readonly List<ReceiveCallback> _callbacks = new List<ReceiveCallback>();
+        public List<ReceiveCallback> Callbacks { get; } = new List<ReceiveCallback>();
 
         public IFeatureCollection Features { get; } = new FeatureCollection();
 
@@ -130,9 +130,9 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                         while (_receivedMessages.Reader.TryRead(out var message))
                         {
                             ReceiveCallback[] callbackCopies;
-                            lock (_callbacks)
+                            lock (Callbacks)
                             {
-                                callbackCopies = _callbacks.ToArray();
+                                callbackCopies = Callbacks.ToArray();
                             }
 
                             foreach (var callback in callbackCopies)
@@ -170,14 +170,14 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
         public IDisposable OnReceived(Func<byte[], object, Task> callback, object state)
         {
             var receiveCallBack = new ReceiveCallback(callback, state);
-            lock (_callbacks)
+            lock (Callbacks)
             {
-                _callbacks.Add(receiveCallBack);
+                Callbacks.Add(receiveCallBack);
             }
-            return new Subscription(receiveCallBack, _callbacks);
+            return new Subscription(receiveCallBack, Callbacks);
         }
 
-        private class ReceiveCallback
+        public class ReceiveCallback
         {
             private readonly Func<byte[], object, Task> _callback;
             private readonly object _state;


### PR DESCRIPTION
As part of this, I made the list of callbacks in TestConnection public so I could forcibly invoke one. Seems safe as this is purely test code.

Fixes #1199 