### PR TITLE
fix version in version.props

### DIFF
--- a/version.props
+++ b/version.props
@@ -1,7 +1,7 @@
 ﻿<Project>
   <PropertyGroup>
     <VersionPrefix>1.0.0</VersionPrefix>
-    <VersionSuffix>preview1</VersionSuffix>
+    <VersionSuffix>preview2</VersionSuffix>
     <PackageVersion Condition="'$(IsFinalBuild)' == 'true' AND '$(VersionSuffix)' == 'rtm' ">$(VersionPrefix)</PackageVersion>
     <PackageVersion Condition="'$(IsFinalBuild)' == 'true' AND '$(VersionSuffix)' != 'rtm' ">$(VersionPrefix)-$(VersionSuffix)-final</PackageVersion>
     <BuildNumber Condition="'$(BuildNumber)' == ''">t000</BuildNumber>


### PR DESCRIPTION
Looks like this didn't get updated when all the versions were updated to preview2. As a result, our `dev` builds are being pushed to MyGet as `1.0.0-preview1-...`

Not sure how that got missed, but we should try to make sure we avoid it in the future, I'll ping some people and check on that. Also, we may need to clean the MyGet feed a bit.