### PR TITLE
Increase ServerFixture startup timeout

### DIFF
--- a/SignalR.sln
+++ b/SignalR.sln
@@ -81,11 +81,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "JwtClientSample", "samples\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.SignalR.Tests.Utils", "test\Microsoft.AspNetCore.SignalR.Tests.Utils\Microsoft.AspNetCore.SignalR.Tests.Utils.csproj", "{0A0A6135-EA24-4307-95C2-CE1B7E164A5E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.AspNetCore.SignalR.Protocols.MsgPack", "src\Microsoft.AspNetCore.SignalR.Protocols.MsgPack\Microsoft.AspNetCore.SignalR.Protocols.MsgPack.csproj", "{55DB4B6F-12E5-4A27-97F4-E97E135470FF}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.SignalR.Protocols.MsgPack", "src\Microsoft.AspNetCore.SignalR.Protocols.MsgPack\Microsoft.AspNetCore.SignalR.Protocols.MsgPack.csproj", "{55DB4B6F-12E5-4A27-97F4-E97E135470FF}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.AspNetCore.SignalR.MsgPack", "src\Microsoft.AspNetCore.SignalR.MsgPack\Microsoft.AspNetCore.SignalR.MsgPack.csproj", "{FDDB4E1F-2FD2-49E8-B0FF-874B0931369A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.SignalR.MsgPack", "src\Microsoft.AspNetCore.SignalR.MsgPack\Microsoft.AspNetCore.SignalR.MsgPack.csproj", "{FDDB4E1F-2FD2-49E8-B0FF-874B0931369A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.AspNetCore.SignalR.Client.MsgPack", "src\Microsoft.AspNetCore.SignalR.Client.MsgPack\Microsoft.AspNetCore.SignalR.Client.MsgPack.csproj", "{4DBF918E-BD37-4309-B448-BA68C935944D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.SignalR.Client.MsgPack", "src\Microsoft.AspNetCore.SignalR.Client.MsgPack\Microsoft.AspNetCore.SignalR.Client.MsgPack.csproj", "{4DBF918E-BD37-4309-B448-BA68C935944D}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FunctionalTests", "client-ts\FunctionalTests\FunctionalTests.csproj", "{D0C7B22E-B0B6-4D62-BF7D-79EE4AAF1981}"
 EndProject

--- a/SignalR.sln
+++ b/SignalR.sln
@@ -81,11 +81,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "JwtClientSample", "samples\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.SignalR.Tests.Utils", "test\Microsoft.AspNetCore.SignalR.Tests.Utils\Microsoft.AspNetCore.SignalR.Tests.Utils.csproj", "{0A0A6135-EA24-4307-95C2-CE1B7E164A5E}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.SignalR.Protocols.MsgPack", "src\Microsoft.AspNetCore.SignalR.Protocols.MsgPack\Microsoft.AspNetCore.SignalR.Protocols.MsgPack.csproj", "{55DB4B6F-12E5-4A27-97F4-E97E135470FF}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.AspNetCore.SignalR.Protocols.MsgPack", "src\Microsoft.AspNetCore.SignalR.Protocols.MsgPack\Microsoft.AspNetCore.SignalR.Protocols.MsgPack.csproj", "{55DB4B6F-12E5-4A27-97F4-E97E135470FF}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.SignalR.MsgPack", "src\Microsoft.AspNetCore.SignalR.MsgPack\Microsoft.AspNetCore.SignalR.MsgPack.csproj", "{FDDB4E1F-2FD2-49E8-B0FF-874B0931369A}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.AspNetCore.SignalR.MsgPack", "src\Microsoft.AspNetCore.SignalR.MsgPack\Microsoft.AspNetCore.SignalR.MsgPack.csproj", "{FDDB4E1F-2FD2-49E8-B0FF-874B0931369A}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.SignalR.Client.MsgPack", "src\Microsoft.AspNetCore.SignalR.Client.MsgPack\Microsoft.AspNetCore.SignalR.Client.MsgPack.csproj", "{4DBF918E-BD37-4309-B448-BA68C935944D}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.AspNetCore.SignalR.Client.MsgPack", "src\Microsoft.AspNetCore.SignalR.Client.MsgPack\Microsoft.AspNetCore.SignalR.Client.MsgPack.csproj", "{4DBF918E-BD37-4309-B448-BA68C935944D}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FunctionalTests", "client-ts\FunctionalTests\FunctionalTests.csproj", "{D0C7B22E-B0B6-4D62-BF7D-79EE4AAF1981}"
 EndProject

--- a/test/Microsoft.AspNetCore.SignalR.Tests.Utils/LogRecord.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests.Utils/LogRecord.cs
@@ -1,0 +1,21 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Extensions.Logging.Testing;
+
+namespace Microsoft.AspNetCore.SignalR.Tests
+{
+    // WriteContext, but with a timestamp...
+    internal class LogRecord
+    {
+        public DateTime Timestamp { get; }
+        public WriteContext Write { get; }
+
+        public LogRecord(DateTime timestamp, WriteContext write)
+        {
+            Timestamp = timestamp;
+            Write = write;
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.SignalR.Tests.Utils/ServerFixture.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests.Utils/ServerFixture.cs
@@ -61,7 +61,9 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             var t = Task.Run(() => _host.Start());
             _logger.LogInformation("Starting test server...");
             _lifetime = _host.Services.GetRequiredService<IApplicationLifetime>();
-            if (!_lifetime.ApplicationStarted.WaitHandle.WaitOne(TimeSpan.FromSeconds(5)))
+
+            // This only happens once per fixture, so we can afford to wait a little bit on it.
+            if (!_lifetime.ApplicationStarted.WaitHandle.WaitOne(TimeSpan.FromSeconds(20)))
             {
                 // t probably faulted
                 if (t.IsFaulted)

--- a/test/Microsoft.AspNetCore.SignalR.Tests.Utils/ServerFixture.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests.Utils/ServerFixture.cs
@@ -51,7 +51,9 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             var url = "http://127.0.0.1:0";
 
             _host = new WebHostBuilder()
-                .ConfigureLogging(builder => builder.AddProvider(_logSinkProvider))
+                .ConfigureLogging(builder => builder
+                    .AddProvider(_logSinkProvider)
+                    .AddProvider(new ForwardingLoggerProvider(_loggerFactory)))
                 .UseStartup(typeof(TStartup))
                 .UseKestrel()
                 .UseUrls(url)
@@ -109,6 +111,25 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             _logger.LogInformation("Shutting down test server");
             _host.Dispose();
             _loggerFactory.Dispose();
+        }
+
+        private class ForwardingLoggerProvider : ILoggerProvider
+        {
+            private readonly ILoggerFactory _loggerFactory;
+
+            public ForwardingLoggerProvider(ILoggerFactory loggerFactory)
+            {
+                _loggerFactory = loggerFactory;
+            }
+
+            public void Dispose()
+            {
+            }
+
+            public ILogger CreateLogger(string categoryName)
+            {
+                return _loggerFactory.CreateLogger(categoryName);
+            }
         }
 
         // TestSink doesn't seem to be thread-safe :(.

--- a/test/Microsoft.AspNetCore.SignalR.Tests.Utils/ServerFixture.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests.Utils/ServerFixture.cs
@@ -39,7 +39,6 @@ namespace Microsoft.AspNetCore.SignalR.Tests
 
             var testLog = AssemblyTestLog.ForAssembly(typeof(TStartup).Assembly);
             _logToken = testLog.StartTestLog(null, $"{nameof(ServerFixture<TStartup>)}_{typeof(TStartup).Name}", out _loggerFactory, "ServerFixture");
-            _loggerFactory.AddProvider(_logSinkProvider);
             _logger = _loggerFactory.CreateLogger<ServerFixture<TStartup>>();
 
             StartServer();
@@ -74,7 +73,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                 }
 
                 var logs = _logSinkProvider.GetLogs();
-                throw new TimeoutException($"Timed out waiting for application to start. {Environment.NewLine}Startup Logs:{Environment.NewLine}{RenderLogs(logs)}");
+                throw new TimeoutException($"Timed out waiting for application to start.{Environment.NewLine}Startup Logs:{Environment.NewLine}{RenderLogs(logs)}");
             }
             _logger.LogInformation("Test Server started");
 

--- a/test/Microsoft.AspNetCore.SignalR.Tests.Utils/ServerFixture.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests.Utils/ServerFixture.cs
@@ -144,7 +144,6 @@ namespace Microsoft.AspNetCore.SignalR.Tests
 
             public void Dispose()
             {
-                throw new NotImplementedException();
             }
 
             public IList<LogRecord> GetLogs() => _logs.ToList();

--- a/test/Microsoft.AspNetCore.SignalR.Tests.Utils/ServerFixture.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests.Utils/ServerFixture.cs
@@ -2,11 +2,16 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Sockets;
+using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Testing;
@@ -22,24 +27,31 @@ namespace Microsoft.AspNetCore.SignalR.Tests
         private IApplicationLifetime _lifetime;
         private readonly IDisposable _logToken;
 
+        private readonly LogSinkProvider _logSinkProvider;
+
         public string WebSocketsUrl => Url.Replace("http", "ws");
 
         public string Url { get; private set; }
 
         public ServerFixture()
         {
+            _logSinkProvider = new LogSinkProvider();
+
             var testLog = AssemblyTestLog.ForAssembly(typeof(TStartup).Assembly);
             _logToken = testLog.StartTestLog(null, $"{nameof(ServerFixture<TStartup>)}_{typeof(TStartup).Name}", out _loggerFactory, "ServerFixture");
+            _loggerFactory.AddProvider(_logSinkProvider);
             _logger = _loggerFactory.CreateLogger<ServerFixture<TStartup>>();
-            // We're using 127.0.0.1 instead of localhost to ensure that we use IPV4 across different OSes
-            Url = "http://127.0.0.1:" + GetNextPort();
 
-            StartServer(Url);
+            StartServer();
         }
 
-        private void StartServer(string url)
+        private void StartServer()
         {
+            // We're using 127.0.0.1 instead of localhost to ensure that we use IPV4 across different OSes
+            var url = "http://127.0.0.1:0";
+
             _host = new WebHostBuilder()
+                .ConfigureLogging(builder => builder.AddProvider(_logSinkProvider))
                 .UseStartup(typeof(TStartup))
                 .UseKestrel()
                 .UseUrls(url)
@@ -56,15 +68,38 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                 {
                     throw t.Exception.InnerException;
                 }
-                throw new TimeoutException("Timed out waiting for application to start.");
+
+                var logs = _logSinkProvider.GetLogs();
+                throw new TimeoutException($"Timed out waiting for application to start. {Environment.NewLine}Startup Logs:{Environment.NewLine}{RenderLogs(logs)}");
             }
             _logger.LogInformation("Test Server started");
+
+            // Get the URL from the server
+            Url = _host.ServerFeatures.Get<IServerAddressesFeature>().Addresses.Single();
 
             _lifetime.ApplicationStopped.Register(() =>
             {
                 _logger.LogInformation("Test server shut down");
                 _logToken.Dispose();
             });
+        }
+
+        private string RenderLogs(IList<LogRecord> logs)
+        {
+            var builder = new StringBuilder();
+            foreach (var log in logs)
+            {
+                builder.AppendLine($"{log.Timestamp:O} {log.Write.LoggerName} {log.Write.LogLevel}: {log.Write.Formatter(log.Write.State, log.Write.Exception)}");
+                if (log.Write.Exception != null)
+                {
+                    var message = log.Write.Exception.ToString();
+                    foreach (var line in message.Split(new[] { Environment.NewLine }, StringSplitOptions.None))
+                    {
+                        builder.AppendLine($"| {line}");
+                    }
+                }
+            }
+            return builder.ToString();
         }
 
         public void Dispose()
@@ -74,18 +109,64 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             _loggerFactory.Dispose();
         }
 
-        // Copied from https://github.com/aspnet/KestrelHttpServer/blob/47f1db20e063c2da75d9d89653fad4eafe24446c/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/AddressRegistrationTests.cs#L508
-        private static int GetNextPort()
+        // TestSink doesn't seem to be thread-safe :(.
+        private class LogSinkProvider : ILoggerProvider
         {
-            using (var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            private ConcurrentQueue<LogRecord> _logs = new ConcurrentQueue<LogRecord>();
+
+            public ILogger CreateLogger(string categoryName)
             {
-                // Let the OS assign the next available port. Unless we cycle through all ports
-                // on a test run, the OS will always increment the port number when making these calls.
-                // This prevents races in parallel test runs where a test is already bound to
-                // a given port, and a new test is able to bind to the same port due to port
-                // reuse being enabled by default by the OS.
-                socket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
-                return ((IPEndPoint)socket.LocalEndPoint).Port;
+                return new LogSinkLogger(categoryName, this);
+            }
+
+            public void Dispose()
+            {
+                throw new NotImplementedException();
+            }
+
+            public IList<LogRecord> GetLogs() => _logs.ToList();
+
+            public void Log<TState>(string categoryName, LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+            {
+                var record = new LogRecord(
+                    DateTime.Now,
+                    new WriteContext()
+                    {
+                        LoggerName = categoryName,
+                        LogLevel = logLevel,
+                        EventId = eventId,
+                        State = state,
+                        Exception = exception,
+                        Formatter = (o, e) => formatter((TState)o, e),
+                    });
+                _logs.Enqueue(record);
+            }
+
+            private class LogSinkLogger : ILogger
+            {
+                private string _categoryName;
+                private LogSinkProvider _logSinkProvider;
+
+                public LogSinkLogger(string categoryName, LogSinkProvider logSinkProvider)
+                {
+                    _categoryName = categoryName;
+                    _logSinkProvider = logSinkProvider;
+                }
+
+                public IDisposable BeginScope<TState>(TState state)
+                {
+                    return null;
+                }
+
+                public bool IsEnabled(LogLevel logLevel)
+                {
+                    return true;
+                }
+
+                public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+                {
+                    _logSinkProvider.Log(_categoryName, logLevel, eventId, state, exception, formatter);
+                }
             }
         }
     }

--- a/test/Microsoft.AspNetCore.SignalR.Tests.Utils/ServerFixture.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests.Utils/ServerFixture.cs
@@ -5,12 +5,10 @@ using System;
 using System.IO;
 using System.Net;
 using System.Net.Sockets;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Logging.Testing;
 
 namespace Microsoft.AspNetCore.SignalR.Tests
@@ -23,7 +21,6 @@ namespace Microsoft.AspNetCore.SignalR.Tests
         private IWebHost _host;
         private IApplicationLifetime _lifetime;
         private readonly IDisposable _logToken;
-        private AsyncForwardingLoggerProvider _asyncLoggerProvider;
 
         public string WebSocketsUrl => Url.Replace("http", "ws");
 
@@ -31,11 +28,8 @@ namespace Microsoft.AspNetCore.SignalR.Tests
 
         public ServerFixture()
         {
-            _asyncLoggerProvider = new AsyncForwardingLoggerProvider();
-
             var testLog = AssemblyTestLog.ForAssembly(typeof(TStartup).Assembly);
             _logToken = testLog.StartTestLog(null, $"{nameof(ServerFixture<TStartup>)}_{typeof(TStartup).Name}", out _loggerFactory, "ServerFixture");
-            _loggerFactory.AddProvider(_asyncLoggerProvider);
             _logger = _loggerFactory.CreateLogger<ServerFixture<TStartup>>();
             // We're using 127.0.0.1 instead of localhost to ensure that we use IPV4 across different OSes
             Url = "http://127.0.0.1:" + GetNextPort();
@@ -43,15 +37,9 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             StartServer(Url);
         }
 
-        public void SetTestLoggerFactory(ILoggerFactory loggerFactory)
-        {
-            _asyncLoggerProvider.SetLoggerFactory(loggerFactory);
-        }
-
         private void StartServer(string url)
         {
             _host = new WebHostBuilder()
-                .ConfigureLogging(builder => builder.AddProvider(new ForwardingLoggerProvider(_loggerFactory)))
                 .UseStartup(typeof(TStartup))
                 .UseKestrel()
                 .UseUrls(url)
@@ -84,81 +72,6 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             _logger.LogInformation("Shutting down test server");
             _host.Dispose();
             _loggerFactory.Dispose();
-        }
-
-        private class AsyncForwardingLoggerProvider : ILoggerProvider
-        {
-            private AsyncLocal<ILoggerFactory> _localLogger = new AsyncLocal<ILoggerFactory>();
-
-            public ILogger CreateLogger(string categoryName)
-            {
-                return new AsyncLocalForwardingLogger(categoryName, _localLogger);
-            }
-
-            public void Dispose()
-            {
-            }
-
-            public void SetLoggerFactory(ILoggerFactory loggerFactory)
-            {
-                _localLogger.Value = loggerFactory;
-            }
-
-            private class AsyncLocalForwardingLogger : ILogger
-            {
-                private string _categoryName;
-                private AsyncLocal<ILoggerFactory> _localLoggerFactory;
-
-                public AsyncLocalForwardingLogger(string categoryName, AsyncLocal<ILoggerFactory> localLoggerFactory)
-                {
-                    _categoryName = categoryName;
-                    _localLoggerFactory = localLoggerFactory;
-                }
-
-                public IDisposable BeginScope<TState>(TState state)
-                {
-                    return GetLocalLogger().BeginScope(state);
-                }
-
-                public bool IsEnabled(LogLevel logLevel)
-                {
-                    return GetLocalLogger().IsEnabled(logLevel);
-                }
-
-                public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
-                {
-                    GetLocalLogger().Log(logLevel, eventId, state, exception, formatter);
-                }
-
-                private ILogger GetLocalLogger()
-                {
-                    var factory = _localLoggerFactory.Value;
-                    if (factory == null)
-                    {
-                        return NullLogger.Instance;
-                    }
-                    return factory.CreateLogger(_categoryName);
-                }
-            }
-        }
-
-        private class ForwardingLoggerProvider : ILoggerProvider
-        {
-            private readonly ILoggerFactory _loggerFactory;
-
-            public ForwardingLoggerProvider(ILoggerFactory loggerFactory)
-            {
-                _loggerFactory = loggerFactory;
-            }
-
-            public void Dispose()
-            {
-            }
-
-            public ILogger CreateLogger(string categoryName)
-            {
-                return _loggerFactory.CreateLogger(categoryName);
-            }
         }
 
         // Copied from https://github.com/aspnet/KestrelHttpServer/blob/47f1db20e063c2da75d9d89653fad4eafe24446c/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/AddressRegistrationTests.cs#L508

--- a/test/Microsoft.AspNetCore.SignalR.Tests/EndToEndTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/EndToEndTests.cs
@@ -326,8 +326,6 @@ namespace Microsoft.AspNetCore.SignalR.Tests
         {
             using (StartLog(out var loggerFactory, testName: $"ConnectionCanSendAndReceiveMessages_{transportType.ToString()}"))
             {
-                _serverFixture.SetTestLoggerFactory(loggerFactory);
-
                 var logger = loggerFactory.CreateLogger<EndToEndTests>();
 
                 var url = _serverFixture.Url + "/uncreatable";

--- a/test/Microsoft.AspNetCore.SignalR.Tests/Startup.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/Startup.cs
@@ -1,9 +1,11 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Threading;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.SignalR.Tests
 {
@@ -16,7 +18,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             services.AddEndPoint<EchoEndPoint>();
         }
 
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILogger<Startup> logger)
         {
             app.UseSockets(options => options.MapEndPoint<EchoEndPoint>("/echo"));
             app.UseSignalR(options => options.MapHub<UncreatableHub>("/uncreatable"));

--- a/test/Microsoft.AspNetCore.SignalR.Tests/Startup.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/Startup.cs
@@ -1,11 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Threading;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.SignalR.Tests
 {

--- a/test/Microsoft.AspNetCore.SignalR.Tests/Startup.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/Startup.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             services.AddEndPoint<EchoEndPoint>();
         }
 
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILogger<Startup> logger)
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
             app.UseSockets(options => options.MapEndPoint<EchoEndPoint>("/echo"));
             app.UseSignalR(options => options.MapHub<UncreatableHub>("/uncreatable"));


### PR DESCRIPTION
Also adds some code to capture logs during startup and add them to the exception message if the startup times out.

It looks like it just sometimes takes longer than 5 seconds to start up on AppVeyor. Given my own tests on a 2 core Azure VM, this isn't terribly surprising.

Also, switched to using port `0` when creating the server to auto-allocate a port.