### PR TITLE
Publish test logs to AppVeyor Artifacts

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,6 +10,11 @@ branches:
     - /^rel\/.*/
 build_script:
   - ps: .\run.ps1 default-build
+  - ps: '7z a testlogs.zip .testlogs'
+artifacts:
+  - path: testlogs.zip
+    name: TestLogs
+    type: Zip
 install:
   - ps: Install-Product node 8
 clone_depth: 1
@@ -17,6 +22,7 @@ environment:
   global:
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
     DOTNET_CLI_TELEMETRY_OPTOUT: 1
+    ASPNETCORE_TEST_LOG_DIR: "$(APPVEYOR_BUILD_FOLDER)\.testlogs"
 test: off
 deploy: off
 os: Visual Studio 2017

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,7 +10,7 @@ branches:
     - /^rel\/.*/
 build_script:
   - ps: .\run.ps1 default-build
-  - ps: '7z a testlogs.zip .testlogs'
+  - ps: "7z a testlogs.zip .testlogs"
 artifacts:
   - path: testlogs.zip
     name: TestLogs
@@ -22,7 +22,7 @@ environment:
   global:
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
     DOTNET_CLI_TELEMETRY_OPTOUT: 1
-    ASPNETCORE_TEST_LOG_DIR: "$(APPVEYOR_BUILD_FOLDER)\.testlogs"
+    ASPNETCORE_TEST_LOG_DIR: "$(APPVEYOR_BUILD_FOLDER)\\.testlogs"
 test: off
 deploy: off
 os: Visual Studio 2017

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,7 +10,7 @@ branches:
     - /^rel\/.*/
 build_script:
   - ps: .\run.ps1 default-build
-  - ps: "7z a testlogs.zip .testlogs"
+  - ps: "7z a testlogs.zip testlogs"
 artifacts:
   - path: testlogs.zip
     name: TestLogs
@@ -22,7 +22,7 @@ environment:
   global:
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
     DOTNET_CLI_TELEMETRY_OPTOUT: 1
-    ASPNETCORE_TEST_LOG_DIR: "$(APPVEYOR_BUILD_FOLDER)\\.testlogs"
+    ASPNETCORE_TEST_LOG_DIR: "$(APPVEYOR_BUILD_FOLDER)\\testlogs"
 test: off
 deploy: off
 os: Visual Studio 2017


### PR DESCRIPTION
https://www.appveyor.com/docs/packaging-artifacts/

<img width="986" alt="screen shot 2018-02-06 at 10 02 29 am" src="https://user-images.githubusercontent.com/7574/35875746-15b2ed9e-0b25-11e8-94e6-199667bedd39.png">

<img width="1239" alt="screen shot 2018-02-06 at 10 03 54 am" src="https://user-images.githubusercontent.com/7574/35875747-15c94e86-0b25-11e8-9f58-4c4b2d3aafa5.png">

This gives us test logs as artifacts in AppVeyor which makes it way easier to review flaky test failures.

TODO:
* [x] The `.testlogs` directory means that the zip contains a `.testlogs` directory, which is a pain on Unix. I'm going to remove the leading `.` and verify that it still works fine.