### PR TITLE
Move AppVeyor artifact publishing to on_finish to ensure it runs on failed builds too

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,6 +10,7 @@ branches:
     - /^rel\/.*/
 build_script:
   - ps: .\run.ps1 default-build
+after_build:
   - ps: "7z a testlogs.zip testlogs"
 artifacts:
   - path: testlogs.zip

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,12 +10,9 @@ branches:
     - /^rel\/.*/
 build_script:
   - ps: .\run.ps1 default-build
-after_build:
+on_finish:
   - ps: "7z a testlogs.zip testlogs"
-artifacts:
-  - path: testlogs.zip
-    name: TestLogs
-    type: Zip
+  - ps: "Push-AppveyorArtifact testlogs.zip"
 install:
   - ps: Install-Product node 8
 clone_depth: 1

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/LongPollingTransportTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/LongPollingTransportTests.cs
@@ -90,9 +90,6 @@ namespace Microsoft.AspNetCore.Client.Tests
                     await longPollingTransport.StopAsync();
                 }
             }
-
-            // TODO: Just to verify that I'm right, will remove before merge.
-            Assert.False(true, "Boom");
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/LongPollingTransportTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/LongPollingTransportTests.cs
@@ -90,6 +90,9 @@ namespace Microsoft.AspNetCore.Client.Tests
                     await longPollingTransport.StopAsync();
                 }
             }
+
+            // TODO: Just to verify that I'm right, will remove before merge.
+            Assert.False(true, "Boom");
         }
 
         [Fact]


### PR DESCRIPTION
I think the `7z` command won't run when the `run.ps1` script fails, so the test logs won't be packaged when the tests fail. I think we can fix this, so I'm opening this PR to verify and fix this.