### PR TITLE
Exit receive loop faster when connection closed

### DIFF
--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/HttpConnection.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/HttpConnection.cs
@@ -422,6 +422,7 @@ namespace Microsoft.AspNetCore.Sockets.Client
                 }
 
                 await Input.Completion;
+                _transportChannel = null;
             }
             catch (Exception ex)
             {

--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/HttpConnection.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/HttpConnection.cs
@@ -379,14 +379,12 @@ namespace Microsoft.AspNetCore.Sockets.Client
             {
                 _logger.HttpReceiveStarted();
 
-                while (await Input.WaitToReadAsync())
+                while (!Input.Completion.IsCompleted && await Input.WaitToReadAsync())
                 {
                     if (_connectionState != ConnectionState.Connected)
                     {
                         _logger.SkipRaisingReceiveEvent();
-                        // drain
-                        Input.TryRead(out _);
-                        continue;
+                        break;
                     }
 
                     if (Input.TryRead(out var buffer))

--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/HttpConnection.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/HttpConnection.cs
@@ -383,6 +383,8 @@ namespace Microsoft.AspNetCore.Sockets.Client
                 _logger.HttpReceiveStarted();
                 var closingToken = _closingTokenSource.Token;
 
+                // Need to manually check token in the loop because of a bug in Channel
+                // We can remove it once we have a fixed build
                 while (!closingToken.IsCancellationRequested && await Input.WaitToReadAsync(closingToken))
                 {
                     if (_connectionState != ConnectionState.Connected)

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/TaskQueueTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/TaskQueueTests.cs
@@ -55,7 +55,7 @@ namespace Microsoft.AspNetCore.Client.Tests
         }
 
         [Fact]
-        public void DrainWillNotRunCallbacksAlreadyInTheQueue()
+        public async Task DrainWillNotRunCallbacksAlreadyInTheQueue()
         {
             var queue = new TaskQueue();
             var waitHandle = new ManualResetEvent(false);
@@ -68,7 +68,7 @@ namespace Microsoft.AspNetCore.Client.Tests
             });
 
             var n = 0;
-            _ = queue.Enqueue(() =>
+            var task = queue.Enqueue(() =>
             {
                 n = 1;
                 return Task.CompletedTask;
@@ -77,6 +77,13 @@ namespace Microsoft.AspNetCore.Client.Tests
             inCallbackHandle.WaitOne();
             _ = queue.Drain();
             waitHandle.Set();
+            try
+            {
+                await task;
+                Assert.True(false);
+            }
+            catch (OperationCanceledException) { }
+
             Assert.Equal(0, n);
         }
     }


### PR DESCRIPTION
The issue is, under high load, the client would have a large queue of items in the Channel and it would take a long time to drain the items on close. There is no need to drain (that I know of), we can just exit and let GC clean it up