### PR TITLE
Don't expose Channel from HubConnectionContext

### DIFF
--- a/src/Microsoft.AspNetCore.SignalR.Core/HubEndPoint.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/HubEndPoint.cs
@@ -275,19 +275,9 @@ namespace Microsoft.AspNetCore.SignalR
             }
         }
 
-        private async Task SendMessageAsync(HubConnectionContext connection, HubMessage hubMessage)
+        private Task SendMessageAsync(HubConnectionContext connection, HubMessage hubMessage)
         {
-            while (await connection.Output.Writer.WaitToWriteAsync())
-            {
-                if (connection.Output.Writer.TryWrite(hubMessage))
-                {
-                    return;
-                }
-            }
-
-            // Output is closed. Cancel this invocation completely
-            _logger.OutboundChannelClosed();
-            throw new OperationCanceledException("Outbound channel was closed while trying to write hub message");
+            return connection.WriteAsync(hubMessage, throwOnFailure: true);
         }
 
         private async Task Invoke(HubMethodDescriptor descriptor, HubConnectionContext connection,

--- a/test/Microsoft.AspNetCore.SignalR.Tests.Utils/HubConnectionContextUtils.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests.Utils/HubConnectionContextUtils.cs
@@ -15,11 +15,16 @@ namespace Microsoft.AspNetCore.SignalR.Tests
     {
         public static HubConnectionContext Create(DefaultConnectionContext connection, Channel<HubMessage> replacementOutput = null)
         {
-            var context = new HubConnectionContext(connection, TimeSpan.FromSeconds(15), NullLoggerFactory.Instance);
+            HubConnectionContext context = null;
             if (replacementOutput != null)
             {
-                context.Output = replacementOutput;
+                context = new HubConnectionContext(connection, TimeSpan.FromSeconds(15), NullLoggerFactory.Instance, replacementOutput);
             }
+            else
+            {
+                context = new HubConnectionContext(connection, TimeSpan.FromSeconds(15), NullLoggerFactory.Instance);
+            }
+
             context.ProtocolReaderWriter = new HubProtocolReaderWriter(new JsonHubProtocol(), new PassThroughEncoder());
 
             _ = context.StartAsync();


### PR DESCRIPTION
- Change HubEndPoint to call WriteAsync
- Fixed assert  for protocol reader writer