### PR TITLE
Client pipelines

### DIFF
--- a/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.cs
@@ -430,6 +430,8 @@ namespace Microsoft.AspNetCore.SignalR.Client
                 return;
             }
 
+            _logger.LogDebug("Dispatching invocation: {invocation}", invocation);
+
             //TODO: Optimize this!
             // Copying the callbacks to avoid concurrency issues
             InvocationHandler[] copiedHandlers;

--- a/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.cs
@@ -19,6 +19,7 @@ using Microsoft.AspNetCore.Sockets.Features;
 using Microsoft.AspNetCore.Sockets.Internal;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using System.Text;
 
 namespace Microsoft.AspNetCore.SignalR.Client
 {
@@ -344,10 +345,15 @@ namespace Microsoft.AspNetCore.SignalR.Client
         private async Task OnDataReceivedAsync(byte[] data)
         {
             ResetTimeoutTimer();
+            _logger.LogDebug("Received {count} bytes. OnDataReceived({payload})", data.Length, Encoding.UTF8.GetString(data));
+
             if (_protocolReaderWriter.ReadMessages(data, _binder, out var messages))
             {
+                _logger.LogDebug("Parsed {count} messages.", messages.Count);
+
                 foreach (var message in messages)
                 {
+                    _logger.LogDebug("Processing {message}", message);
                     InvocationRequest irq;
                     switch (message)
                     {
@@ -381,6 +387,10 @@ namespace Microsoft.AspNetCore.SignalR.Client
                             throw new InvalidOperationException($"Unexpected message type: {message.GetType().FullName}");
                     }
                 }
+            }
+            else
+            {
+                _logger.LogDebug("No messages parsed");
             }
         }
 

--- a/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.cs
@@ -19,7 +19,6 @@ using Microsoft.AspNetCore.Sockets.Features;
 using Microsoft.AspNetCore.Sockets.Internal;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using System.Text;
 
 namespace Microsoft.AspNetCore.SignalR.Client
 {
@@ -345,7 +344,6 @@ namespace Microsoft.AspNetCore.SignalR.Client
         private async Task OnDataReceivedAsync(byte[] data)
         {
             ResetTimeoutTimer();
-
             if (_protocolReaderWriter.ReadMessages(data, _binder, out var messages))
             {
                 foreach (var message in messages)

--- a/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.cs
@@ -345,15 +345,11 @@ namespace Microsoft.AspNetCore.SignalR.Client
         private async Task OnDataReceivedAsync(byte[] data)
         {
             ResetTimeoutTimer();
-            _logger.LogDebug("Received {count} bytes. OnDataReceived({payload})", data.Length, Encoding.UTF8.GetString(data));
 
             if (_protocolReaderWriter.ReadMessages(data, _binder, out var messages))
             {
-                _logger.LogDebug("Parsed {count} messages.", messages.Count);
-
                 foreach (var message in messages)
                 {
-                    _logger.LogDebug("Processing {message}", message);
                     InvocationRequest irq;
                     switch (message)
                     {
@@ -387,10 +383,6 @@ namespace Microsoft.AspNetCore.SignalR.Client
                             throw new InvalidOperationException($"Unexpected message type: {message.GetType().FullName}");
                     }
                 }
-            }
-            else
-            {
-                _logger.LogDebug("No messages parsed");
             }
         }
 
@@ -440,9 +432,7 @@ namespace Microsoft.AspNetCore.SignalR.Client
                 return;
             }
 
-            _logger.LogDebug("Dispatching invocation: {invocation}", invocation);
-
-            //TODO: Optimize this!
+            // TODO: Optimize this!
             // Copying the callbacks to avoid concurrency issues
             InvocationHandler[] copiedHandlers;
             lock (handlers)

--- a/src/Microsoft.AspNetCore.SignalR.Common/Internal/Encoders/Base64Encoder.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Common/Internal/Encoders/Base64Encoder.cs
@@ -10,16 +10,17 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Encoders
 {
     public class Base64Encoder : IDataEncoder
     {
-        public ReadOnlySpan<byte> Decode(byte[] payload)
+        public bool TryDecode(ref ReadOnlySpan<byte> buffer, out ReadOnlySpan<byte> data)
         {
-            ReadOnlySpan<byte> buffer = payload;
-            LengthPrefixedTextMessageParser.TryParseMessage(ref buffer, out var message);
-
-            Span<byte> decoded = new byte[Base64.GetMaxDecodedFromUtf8Length(message.Length)];
-            var status = Base64.DecodeFromUtf8(message, decoded, out _, out var written);
-            Debug.Assert(status == OperationStatus.Done);
-
-            return decoded.Slice(0, written);
+            if (LengthPrefixedTextMessageParser.TryParseMessage(ref buffer, out var message))
+            {
+                Span<byte> decoded = new byte[Base64.GetMaxDecodedFromUtf8Length(message.Length)];
+                var status = Base64.DecodeFromUtf8(message, decoded, out _, out var written);
+                Debug.Assert(status == OperationStatus.Done);
+                data = decoded.Slice(0, written);
+                return true;
+            }
+            return false;
         }
 
         private const int Int32OverflowLength = 10;

--- a/src/Microsoft.AspNetCore.SignalR.Common/Internal/Encoders/IDataEncoder.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Common/Internal/Encoders/IDataEncoder.cs
@@ -8,6 +8,6 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Encoders
     public interface IDataEncoder
     {
         byte[] Encode(byte[] payload);
-        ReadOnlySpan<byte> Decode(byte[] payload);
+        bool TryDecode(ref ReadOnlySpan<byte> buffer, out ReadOnlySpan<byte> data);
     }
 }

--- a/src/Microsoft.AspNetCore.SignalR.Common/Internal/Encoders/PassThroughEncoder.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Common/Internal/Encoders/PassThroughEncoder.cs
@@ -7,9 +7,11 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Encoders
 {
     public class PassThroughEncoder : IDataEncoder
     {
-        public ReadOnlySpan<byte> Decode(byte[] payload)
+        public bool TryDecode(ref ReadOnlySpan<byte> buffer, out ReadOnlySpan<byte> data)
         {
-            return payload;
+            data = buffer;
+            buffer = Array.Empty<byte>();
+            return true;
         }
 
         public byte[] Encode(byte[] payload)

--- a/src/Microsoft.AspNetCore.SignalR.Common/Internal/HubProtocolReaderWriter.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Common/Internal/HubProtocolReaderWriter.cs
@@ -37,7 +37,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal
             ReadOnlySpan<byte> span = input;
             while (span.Length > 0 && _dataEncoder.TryDecode(ref span, out var data))
             {
-                _hubProtocol.TryParseMessages(data, binder, out messages);
+                _hubProtocol.TryParseMessages(data, binder, messages);
             }
             return messages.Count > 0;
         }

--- a/src/Microsoft.AspNetCore.SignalR.Common/Internal/HubProtocolReaderWriter.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Common/Internal/HubProtocolReaderWriter.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Buffers;
 using System.Collections;
 using System.Collections.Generic;
@@ -32,8 +33,13 @@ namespace Microsoft.AspNetCore.SignalR.Internal
 
         public bool ReadMessages(byte[] input, IInvocationBinder binder, out IList<HubMessage> messages)
         {
-            var buffer = _dataEncoder.Decode(input);
-            return _hubProtocol.TryParseMessages(buffer, binder, out messages);
+            messages = new List<HubMessage>();
+            ReadOnlySpan<byte> span = input;
+            while (span.Length > 0 && _dataEncoder.TryDecode(ref span, out var data))
+            {
+                _hubProtocol.TryParseMessages(data, binder, out messages);
+            }
+            return messages.Count > 0;
         }
 
         public byte[] WriteMessage(HubMessage hubMessage)

--- a/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/IHubProtocol.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/IHubProtocol.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
 
         ProtocolType Type { get; }
 
-        bool TryParseMessages(ReadOnlySpan<byte> input, IInvocationBinder binder, out IList<HubMessage> messages);
+        bool TryParseMessages(ReadOnlySpan<byte> input, IInvocationBinder binder, IList<HubMessage> messages);
 
         void WriteMessage(HubMessage message, Stream output);
     }

--- a/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/JsonHubProtocol.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/JsonHubProtocol.cs
@@ -43,10 +43,8 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
 
         public ProtocolType Type => ProtocolType.Text;
 
-        public bool TryParseMessages(ReadOnlySpan<byte> input, IInvocationBinder binder, out IList<HubMessage> messages)
+        public bool TryParseMessages(ReadOnlySpan<byte> input, IInvocationBinder binder, IList<HubMessage> messages)
         {
-            messages = new List<HubMessage>();
-
             while (TextMessageParser.TryParseMessage(ref input, out var payload))
             {
                 // TODO: Need a span-native JSON parser!

--- a/src/Microsoft.AspNetCore.SignalR.Protocols.MsgPack/Internal/Protocol/MessagePackHubProtocol.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Protocols.MsgPack/Internal/Protocol/MessagePackHubProtocol.cs
@@ -35,10 +35,8 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
             SerializationContext = options.Value.SerializationContext;
         }
 
-        public bool TryParseMessages(ReadOnlySpan<byte> input, IInvocationBinder binder, out IList<HubMessage> messages)
+        public bool TryParseMessages(ReadOnlySpan<byte> input, IInvocationBinder binder, IList<HubMessage> messages)
         {
-            messages = new List<HubMessage>();
-
             while (BinaryMessageParser.TryParseMessage(ref input, out var payload))
             {
                 using (var memoryStream = new MemoryStream(payload.ToArray()))

--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/HttpConnection.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/HttpConnection.cs
@@ -3,12 +3,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Threading.Channels;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Sockets.Client.Http;
 using Microsoft.AspNetCore.Sockets.Client.Internal;
@@ -18,6 +16,7 @@ using Microsoft.AspNetCore.Sockets.Internal;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Newtonsoft.Json;
+using System.IO.Pipelines;
 
 namespace Microsoft.AspNetCore.Sockets.Client
 {
@@ -31,7 +30,7 @@ namespace Microsoft.AspNetCore.Sockets.Client
         private volatile ConnectionState _connectionState = ConnectionState.Disconnected;
         private readonly object _stateChangeLock = new object();
 
-        private volatile ChannelConnection<byte[], SendMessage> _transportChannel;
+        private volatile IDuplexPipe _transportChannel;
         private readonly HttpClient _httpClient;
         private readonly HttpOptions _httpOptions;
         private volatile ITransport _transport;
@@ -43,8 +42,8 @@ namespace Microsoft.AspNetCore.Sockets.Client
         private string _connectionId;
         private Exception _abortException;
         private readonly TimeSpan _eventQueueDrainTimeout = TimeSpan.FromSeconds(5);
-        private ChannelReader<byte[]> Input => _transportChannel.Input;
-        private ChannelWriter<SendMessage> Output => _transportChannel.Output;
+        private PipeReader Input => _transportChannel.Input;
+        private PipeWriter Output => _transportChannel.Output;
         private readonly List<ReceiveCallback> _callbacks = new List<ReceiveCallback>();
         private readonly TransportType _requestedTransportType = TransportType.All;
         private readonly ConnectionLogScope _logScope;
@@ -187,7 +186,7 @@ namespace Microsoft.AspNetCore.Sockets.Client
             {
                 _closeTcs = new TaskCompletionSource<object>();
 
-                _ = Input.Completion.ContinueWith(async t =>
+                Input.OnWriterCompleted(async (exception, state) =>
                 {
                     // Grab the exception and then clear it.
                     // See comment at AbortAsync for more discussion on the thread-safety
@@ -221,9 +220,9 @@ namespace Microsoft.AspNetCore.Sockets.Client
 
                     try
                     {
-                        if (t.IsFaulted)
+                        if (exception != null)
                         {
-                            Closed?.Invoke(t.Exception.InnerException);
+                            Closed?.Invoke(exception);
                         }
                         else
                         {
@@ -237,7 +236,8 @@ namespace Microsoft.AspNetCore.Sockets.Client
                         // Suppress (but log) the exception, this is user code
                         _logger.ErrorDuringClosedEvent(ex);
                     }
-                });
+
+                }, null);
 
                 _receiveLoopTask = ReceiveAsync();
             }
@@ -325,15 +325,13 @@ namespace Microsoft.AspNetCore.Sockets.Client
 
         private async Task StartTransport(Uri connectUrl)
         {
-            var applicationToTransport = Channel.CreateUnbounded<SendMessage>();
-            var transportToApplication = Channel.CreateUnbounded<byte[]>();
-            var applicationSide = ChannelConnection.Create(applicationToTransport, transportToApplication);
-            _transportChannel = ChannelConnection.Create(transportToApplication, applicationToTransport);
+            var pair = DuplexPipe.CreateConnectionPair(PipeOptions.Default, PipeOptions.Default);
+            _transportChannel = pair.Transport;
 
             // Start the transport, giving it one end of the pipeline
             try
             {
-                await _transport.StartAsync(connectUrl, applicationSide, GetTransferMode(), this);
+                await _transport.StartAsync(connectUrl, pair.Application, GetTransferMode(), this);
 
                 // actual transfer mode can differ from the one that was requested so set it on the feature
                 if (!_transport.Mode.HasValue)
@@ -379,56 +377,71 @@ namespace Microsoft.AspNetCore.Sockets.Client
             {
                 _logger.HttpReceiveStarted();
 
-                while (await Input.WaitToReadAsync())
+                while (true)
                 {
                     if (_connectionState != ConnectionState.Connected)
                     {
                         _logger.SkipRaisingReceiveEvent();
-                        // drain
-                        Input.TryRead(out _);
-                        continue;
+
+                        break;
                     }
 
-                    if (Input.TryRead(out var buffer))
+                    var result = await Input.ReadAsync();
+                    var buffer = result.Buffer;
+
+                    try
                     {
-                        _logger.ScheduleReceiveEvent();
-                        _ = _eventQueue.Enqueue(async () =>
+                        if (!buffer.IsEmpty)
                         {
-                            _logger.RaiseReceiveEvent();
+                            _logger.ScheduleReceiveEvent();
+                            var data = buffer.ToArray();
 
-                            // Copying the callbacks to avoid concurrency issues
-                            ReceiveCallback[] callbackCopies;
-                            lock (_callbacks)
+                            _ = _eventQueue.Enqueue(async () =>
                             {
-                                callbackCopies = new ReceiveCallback[_callbacks.Count];
-                                _callbacks.CopyTo(callbackCopies);
-                            }
+                                _logger.RaiseReceiveEvent();
 
-                            foreach (var callbackObject in callbackCopies)
-                            {
-                                try
+                                // Copying the callbacks to avoid concurrency issues
+                                ReceiveCallback[] callbackCopies;
+                                lock (_callbacks)
                                 {
-                                    await callbackObject.InvokeAsync(buffer);
+                                    callbackCopies = new ReceiveCallback[_callbacks.Count];
+                                    _callbacks.CopyTo(callbackCopies);
                                 }
-                                catch (Exception ex)
+
+                                foreach (var callbackObject in callbackCopies)
                                 {
-                                    _logger.ExceptionThrownFromCallback(nameof(OnReceived), ex);
+                                    try
+                                    {
+                                        await callbackObject.InvokeAsync(data);
+                                    }
+                                    catch (Exception ex)
+                                    {
+                                        _logger.ExceptionThrownFromCallback(nameof(OnReceived), ex);
+                                    }
                                 }
-                            }
-                        });
+                            });
+
+                        }
+                        else if (result.IsCompleted)
+                        {
+                            break;
+                        }
                     }
-                    else
+                    finally
                     {
-                        _logger.FailedReadingMessage();
+                        Input.AdvanceTo(buffer.End);
                     }
                 }
-
-                await Input.Completion;
             }
             catch (Exception ex)
             {
-                Output.TryComplete(ex);
+                Input.Complete(ex);
+
                 _logger.ErrorReceiving(ex);
+            }
+            finally
+            {
+                Input.Complete();
             }
 
             _logger.EndReceive();
@@ -450,23 +463,9 @@ namespace Microsoft.AspNetCore.Sockets.Client
                     "Cannot send messages when the connection is not in the Connected state.");
             }
 
-            // TaskCreationOptions.RunContinuationsAsynchronously ensures that continuations awaiting
-            // SendAsync (i.e. user's code) are not running on the same thread as the code that sets
-            // TaskCompletionSource result. This way we prevent from user's code blocking our channel
-            // send loop.
-            var sendTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
-            var message = new SendMessage(data, sendTcs);
-
             _logger.SendingMessage();
 
-            while (await Output.WaitToWriteAsync(cancellationToken))
-            {
-                if (Output.TryWrite(message))
-                {
-                    await sendTcs.Task;
-                    break;
-                }
-            }
+            await Output.WriteAsync(data);
         }
 
         // AbortAsync creates a few thread-safety races that we are OK with.
@@ -539,7 +538,7 @@ namespace Microsoft.AspNetCore.Sockets.Client
 
             if (_transportChannel != null)
             {
-                Output.TryComplete();
+                Output.Complete();
             }
 
             if (transport != null)

--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/HttpConnection.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/HttpConnection.cs
@@ -325,7 +325,8 @@ namespace Microsoft.AspNetCore.Sockets.Client
 
         private async Task StartTransport(Uri connectUrl)
         {
-            var pair = DuplexPipe.CreateConnectionPair(PipeOptions.Default, PipeOptions.Default);
+            var options = new PipeOptions(readerScheduler: PipeScheduler.ThreadPool);
+            var pair = DuplexPipe.CreateConnectionPair(options, options);
             _transportChannel = pair.Transport;
 
             // Start the transport, giving it one end of the pipeline
@@ -464,6 +465,8 @@ namespace Microsoft.AspNetCore.Sockets.Client
             }
 
             _logger.SendingMessage();
+
+            cancellationToken.ThrowIfCancellationRequested();
 
             await Output.WriteAsync(data);
         }

--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/HttpConnection.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/HttpConnection.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Pipelines;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -16,7 +17,6 @@ using Microsoft.AspNetCore.Sockets.Internal;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Newtonsoft.Json;
-using System.IO.Pipelines;
 
 namespace Microsoft.AspNetCore.Sockets.Client
 {

--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/ITransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/ITransport.cs
@@ -3,13 +3,13 @@
 
 using System;
 using System.Threading.Tasks;
-using System.Threading.Channels;
+using System.IO.Pipelines;
 
 namespace Microsoft.AspNetCore.Sockets.Client
 {
     public interface ITransport
     {
-        Task StartAsync(Uri url, Channel<byte[], SendMessage> application, TransferMode requestedTransferMode, IConnection connection);
+        Task StartAsync(Uri url, IDuplexPipe application, TransferMode requestedTransferMode, IConnection connection);
         Task StopAsync();
         TransferMode? Mode { get; }
     }

--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/ITransportFactory.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/ITransportFactory.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Net.Http;
-
 namespace Microsoft.AspNetCore.Sockets.Client
 {
     public interface ITransportFactory

--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/Internal/SocketClientLoggerExtensions.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/Internal/SocketClientLoggerExtensions.cs
@@ -47,8 +47,8 @@ namespace Microsoft.AspNetCore.Sockets.Client.Internal
         private static readonly Action<ILogger, int, Exception> _messageToApp =
             LoggerMessage.Define<int>(LogLevel.Debug, new EventId(12, nameof(MessageToApp)), "Passing message to application. Payload size: {count}.");
 
-        private static readonly Action<ILogger, int, Exception> _receivedFromApp =
-            LoggerMessage.Define<int>(LogLevel.Debug, new EventId(13, nameof(ReceivedFromApp)), "Received message from application. Payload size: {count}.");
+        private static readonly Action<ILogger, long, Exception> _receivedFromApp =
+            LoggerMessage.Define<long>(LogLevel.Debug, new EventId(13, nameof(ReceivedFromApp)), "Received message from application. Payload size: {count}.");
 
         private static readonly Action<ILogger, Exception> _sendMessageCanceled =
             LoggerMessage.Define(LogLevel.Information, new EventId(14, nameof(SendMessageCanceled)), "Sending a message canceled.");
@@ -221,7 +221,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Internal
             _sendStarted(logger, null);
         }
 
-        public static void ReceivedFromApp(this ILogger logger, int count)
+        public static void ReceivedFromApp(this ILogger logger, long count)
         {
             _receivedFromApp(logger, count, null);
         }

--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/Internal/SocketClientLoggerExtensions.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/Internal/SocketClientLoggerExtensions.cs
@@ -66,8 +66,8 @@ namespace Microsoft.AspNetCore.Sockets.Client.Internal
             LoggerMessage.Define(LogLevel.Debug, new EventId(18, nameof(CancelMessage)), "Canceled passing message to application.");
 
         // Category: ServerSentEventsTransport and LongPollingTransport
-        private static readonly Action<ILogger, int, Uri, Exception> _sendingMessages =
-            LoggerMessage.Define<int, Uri>(LogLevel.Debug, new EventId(10, nameof(SendingMessages)), "Sending {count} message(s) to the server using url: {url}.");
+        private static readonly Action<ILogger, long, Uri, Exception> _sendingMessages =
+            LoggerMessage.Define<long, Uri>(LogLevel.Debug, new EventId(10, nameof(SendingMessages)), "Sending {count} bytes to the server using url: {url}.");
 
         private static readonly Action<ILogger, Exception> _sentSuccessfully =
             LoggerMessage.Define(LogLevel.Debug, new EventId(11, nameof(SentSuccessfully)), "Message(s) sent successfully.");
@@ -261,7 +261,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Internal
             _cancelMessage(logger, null);
         }
 
-        public static void SendingMessages(this ILogger logger, int count, Uri url)
+        public static void SendingMessages(this ILogger logger, long count, Uri url)
         {
             _sendingMessages(logger, count, url, null);
         }

--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/SendUtils.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/SendUtils.cs
@@ -33,7 +33,7 @@ namespace Microsoft.AspNetCore.Sockets.Client
                         transportCts.Token.ThrowIfCancellationRequested();
                         if (!buffer.IsEmpty)
                         {
-                            // logger.SendingMessages(messages.Count, sendUrl);
+                            logger.SendingMessages(buffer.Length, sendUrl);
 
                             // Send them in a single post
                             var request = new HttpRequestMessage(HttpMethod.Post, sendUrl);

--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/SendUtils.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/SendUtils.cs
@@ -2,12 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.IO;
+using System.IO.Pipelines;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Threading.Channels;
 using Microsoft.AspNetCore.Sockets.Client.Http;
 using Microsoft.AspNetCore.Sockets.Client.Internal;
 using Microsoft.Extensions.Logging;
@@ -16,87 +14,61 @@ namespace Microsoft.AspNetCore.Sockets.Client
 {
     internal static class SendUtils
     {
-        public static async Task SendMessages(Uri sendUrl, Channel<byte[], SendMessage> application, HttpClient httpClient,
+        public static async Task SendMessages(Uri sendUrl, IDuplexPipe application, HttpClient httpClient,
             HttpOptions httpOptions, CancellationTokenSource transportCts, ILogger logger)
         {
             logger.SendStarted();
-            IList<SendMessage> messages = null;
+
             try
             {
-                while (await application.Reader.WaitToReadAsync(transportCts.Token))
+                while (true)
                 {
-                    // Grab as many messages as we can from the channel
-                    messages = new List<SendMessage>();
-                    while (!transportCts.IsCancellationRequested && application.Reader.TryRead(out SendMessage message))
+                    var result = await application.Input.ReadAsync(transportCts.Token);
+                    var buffer = result.Buffer;
+
+                    try
                     {
-                        messages.Add(message);
-                    }
+                        // Grab as many messages as we can from the channel
 
-                    transportCts.Token.ThrowIfCancellationRequested();
-                    if (messages.Count > 0)
-                    {
-                        logger.SendingMessages(messages.Count, sendUrl);
-
-                        // Send them in a single post
-                        var request = new HttpRequestMessage(HttpMethod.Post, sendUrl);
-                        PrepareHttpRequest(request, httpOptions);
-
-                        // TODO: We can probably use a pipeline here or some kind of pooled memory.
-                        // But where do we get the pool from? ArrayBufferPool.Instance?
-                        var memoryStream = new MemoryStream();
-
-                        foreach (var message in messages)
+                        transportCts.Token.ThrowIfCancellationRequested();
+                        if (!buffer.IsEmpty)
                         {
-                            if (message.Payload != null)
-                            {
-                                memoryStream.Write(message.Payload, 0, message.Payload.Length);
-                            }
+                            // logger.SendingMessages(messages.Count, sendUrl);
+
+                            // Send them in a single post
+                            var request = new HttpRequestMessage(HttpMethod.Post, sendUrl);
+                            PrepareHttpRequest(request, httpOptions);
+
+                            // TODO: Use a custom stream implementation over the ReadOnlyBuffer<byte>
+                            request.Content = new ByteArrayContent(buffer.ToArray());
+
+                            var response = await httpClient.SendAsync(request, transportCts.Token);
+                            response.EnsureSuccessStatusCode();
+
+                            logger.SentSuccessfully();
                         }
-
-                        memoryStream.Position = 0;
-
-                        // Set the, now filled, stream as the content
-                        request.Content = new StreamContent(memoryStream);
-
-                        var response = await httpClient.SendAsync(request, transportCts.Token);
-                        response.EnsureSuccessStatusCode();
-
-                        logger.SentSuccessfully();
-                        foreach (var message in messages)
+                        else if (result.IsCompleted)
                         {
-                            message.SendResult?.TrySetResult(null);
+                            break;
+                        }
+                        else
+                        {
+                            logger.NoMessages();
                         }
                     }
-                    else
+                    finally
                     {
-                        logger.NoMessages();
+                        application.Input.AdvanceTo(buffer.End);
                     }
                 }
             }
             catch (OperationCanceledException)
             {
-                // transport is being closed
-                if (messages != null)
-                {
-                    foreach (var message in messages)
-                    {
-                        // This will no-op for any messages that were already marked as completed.
-                        message.SendResult?.TrySetCanceled();
-                    }
-                }
                 logger.SendCanceled();
             }
             catch (Exception ex)
             {
                 logger.ErrorSending(sendUrl, ex);
-                if (messages != null)
-                {
-                    foreach (var message in messages)
-                    {
-                        // This will no-op for any messages that were already marked as completed.
-                        message.SendResult?.TrySetException(ex);
-                    }
-                }
                 throw;
             }
             finally

--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/ServerSentEventsTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/ServerSentEventsTransport.cs
@@ -2,13 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Buffers;
 using System.IO.Pipelines;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Threading.Channels;
 using Microsoft.AspNetCore.Sockets.Client.Http;
 using Microsoft.AspNetCore.Sockets.Client.Internal;
 using Microsoft.AspNetCore.Sockets.Internal.Formatters;
@@ -19,14 +17,13 @@ namespace Microsoft.AspNetCore.Sockets.Client
 {
     public class ServerSentEventsTransport : ITransport
     {
-        private static readonly MemoryPool _memoryPool = new MemoryPool();
         private readonly HttpClient _httpClient;
         private readonly HttpOptions _httpOptions;
         private readonly ILogger _logger;
         private readonly CancellationTokenSource _transportCts = new CancellationTokenSource();
         private readonly ServerSentEventsMessageParser _parser = new ServerSentEventsMessageParser();
 
-        private Channel<byte[], SendMessage> _application;
+        private IDuplexPipe _application;
 
         public Task Running { get; private set; } = Task.CompletedTask;
 
@@ -48,7 +45,7 @@ namespace Microsoft.AspNetCore.Sockets.Client
             _logger = (loggerFactory ?? NullLoggerFactory.Instance).CreateLogger<ServerSentEventsTransport>();
         }
 
-        public Task StartAsync(Uri url, Channel<byte[], SendMessage> application, TransferMode requestedTransferMode, IConnection connection)
+        public Task StartAsync(Uri url, IDuplexPipe application, TransferMode requestedTransferMode, IConnection connection)
         {
             if (requestedTransferMode != TransferMode.Binary && requestedTransferMode != TransferMode.Text)
             {
@@ -66,15 +63,16 @@ namespace Microsoft.AspNetCore.Sockets.Client
             Running = Task.WhenAll(sendTask, receiveTask).ContinueWith(t =>
             {
                 _logger.TransportStopped(t.Exception?.InnerException);
+                _application.Output.Complete(t.Exception?.InnerException);
+                _application.Input.Complete();
 
-                _application.Writer.TryComplete(t.IsFaulted ? t.Exception.InnerException : null);
                 return t;
             }).Unwrap();
 
             return Task.CompletedTask;
         }
 
-        private async Task OpenConnection(Channel<byte[], SendMessage> application, Uri url, CancellationToken cancellationToken)
+        private async Task OpenConnection(IDuplexPipe application, Uri url, CancellationToken cancellationToken)
         {
             _logger.StartReceive();
 
@@ -83,59 +81,60 @@ namespace Microsoft.AspNetCore.Sockets.Client
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/event-stream"));
             var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
 
-            var stream = await response.Content.ReadAsStreamAsync();
-            var pipelineReader = StreamPipeConnection.CreateReader(new PipeOptions(_memoryPool), stream);
-            var readCancellationRegistration = cancellationToken.Register(
-                reader => ((PipeReader)reader).CancelPendingRead(), pipelineReader);
-            try
+            using (var stream = await response.Content.ReadAsStreamAsync())
             {
-                while (true)
+                var pipelineReader = StreamPipeConnection.CreateReader(PipeOptions.Default, stream);
+                var readCancellationRegistration = cancellationToken.Register(
+                    reader => ((PipeReader)reader).CancelPendingRead(), pipelineReader);
+                try
                 {
-                    var result = await pipelineReader.ReadAsync();
-                    var input = result.Buffer;
-                    if (result.IsCancelled || (input.IsEmpty && result.IsCompleted))
+                    while (true)
                     {
-                        _logger.EventStreamEnded();
-                        break;
-                    }
-
-                    var consumed = input.Start;
-                    var examined = input.End;
-
-                    try
-                    {
-                        var parseResult = _parser.ParseMessage(input, out consumed, out examined, out var buffer);
-
-                        switch (parseResult)
+                        var result = await pipelineReader.ReadAsync();
+                        var input = result.Buffer;
+                        if (result.IsCancelled || (input.IsEmpty && result.IsCompleted))
                         {
-                            case ServerSentEventsMessageParser.ParseResult.Completed:
-                                _application.Writer.TryWrite(buffer);
-                                _parser.Reset();
-                                break;
-                            case ServerSentEventsMessageParser.ParseResult.Incomplete:
-                                if (result.IsCompleted)
-                                {
-                                    throw new FormatException("Incomplete message.");
-                                }
-                                break;
+                            _logger.EventStreamEnded();
+                            break;
+                        }
+
+                        var consumed = input.Start;
+                        var examined = input.End;
+
+                        try
+                        {
+                            var parseResult = _parser.ParseMessage(input, out consumed, out examined, out var buffer);
+
+                            switch (parseResult)
+                            {
+                                case ServerSentEventsMessageParser.ParseResult.Completed:
+                                    await _application.Output.WriteAsync(buffer);
+                                    _parser.Reset();
+                                    break;
+                                case ServerSentEventsMessageParser.ParseResult.Incomplete:
+                                    if (result.IsCompleted)
+                                    {
+                                        throw new FormatException("Incomplete message.");
+                                    }
+                                    break;
+                            }
+                        }
+                        finally
+                        {
+                            pipelineReader.AdvanceTo(consumed, examined);
                         }
                     }
-                    finally
-                    {
-                        pipelineReader.AdvanceTo(consumed, examined);
-                    }
                 }
-            }
-            catch (OperationCanceledException)
-            {
-                _logger.ReceiveCanceled();
-            }
-            finally
-            {
-                readCancellationRegistration.Dispose();
-                _transportCts.Cancel();
-                stream.Dispose();
-                _logger.ReceiveStopped();
+                catch (OperationCanceledException)
+                {
+                    _logger.ReceiveCanceled();
+                }
+                finally
+                {
+                    readCancellationRegistration.Dispose();
+                    _transportCts.Cancel();
+                    _logger.ReceiveStopped();
+                }
             }
         }
 
@@ -143,7 +142,6 @@ namespace Microsoft.AspNetCore.Sockets.Client
         {
             _logger.TransportStopping();
             _transportCts.Cancel();
-            _application.Writer.TryComplete();
 
             try
             {

--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/ServerSentEventsTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/ServerSentEventsTransport.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO.Pipelines;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Sockets.Client.Http;
@@ -98,7 +99,7 @@ namespace Microsoft.AspNetCore.Sockets.Client
                             break;
                         }
 
-                        _logger.LogDebug("Received {count} bytes", input.Length);
+                        _logger.LogDebug("Received {count} bytes: {payload}", input.Length, Encoding.UTF8.GetString(input.ToArray()));
 
                         var consumed = input.Start;
                         var examined = input.End;
@@ -110,7 +111,7 @@ namespace Microsoft.AspNetCore.Sockets.Client
                             switch (parseResult)
                             {
                                 case ServerSentEventsMessageParser.ParseResult.Completed:
-                                    _logger.LogDebug("Received {count} bytes from SSE payload", buffer.Length);
+                                    _logger.LogDebug("Received {count} bytes from SSE payload: {payload}", buffer.Length, Encoding.UTF8.GetString(buffer));
                                     await _application.Output.WriteAsync(buffer);
                                     _parser.Reset();
                                     break;

--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/ServerSentEventsTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/ServerSentEventsTransport.cs
@@ -98,6 +98,8 @@ namespace Microsoft.AspNetCore.Sockets.Client
                             break;
                         }
 
+                        _logger.LogDebug("Received {count} bytes", input.Length);
+
                         var consumed = input.Start;
                         var examined = input.End;
 
@@ -108,6 +110,7 @@ namespace Microsoft.AspNetCore.Sockets.Client
                             switch (parseResult)
                             {
                                 case ServerSentEventsMessageParser.ParseResult.Completed:
+                                    _logger.LogDebug("Received {count} bytes from SSE payload", buffer.Length);
                                     await _application.Output.WriteAsync(buffer);
                                     _parser.Reset();
                                     break;

--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/ServerSentEventsTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/ServerSentEventsTransport.cs
@@ -99,8 +99,6 @@ namespace Microsoft.AspNetCore.Sockets.Client
                             break;
                         }
 
-                        _logger.LogDebug("Received {count} bytes: {payload}", input.Length, Encoding.UTF8.GetString(input.ToArray()));
-
                         var consumed = input.Start;
                         var examined = input.End;
 
@@ -111,7 +109,6 @@ namespace Microsoft.AspNetCore.Sockets.Client
                             switch (parseResult)
                             {
                                 case ServerSentEventsMessageParser.ParseResult.Completed:
-                                    _logger.LogDebug("Received {count} bytes from SSE payload: {payload}", buffer.Length, Encoding.UTF8.GetString(buffer));
                                     await _application.Output.WriteAsync(buffer);
                                     _parser.Reset();
                                     break;

--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/WebSocketsTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/WebSocketsTransport.cs
@@ -2,11 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
+using System.IO.Pipelines;
 using System.Net.WebSockets;
 using System.Threading;
-using System.Threading.Channels;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Sockets.Client.Http;
 using Microsoft.AspNetCore.Sockets.Client.Internal;
@@ -18,7 +16,7 @@ namespace Microsoft.AspNetCore.Sockets.Client
     public class WebSocketsTransport : ITransport
     {
         private readonly ClientWebSocket _webSocket;
-        private Channel<byte[], SendMessage> _application;
+        private IDuplexPipe _application;
         private readonly CancellationTokenSource _transportCts = new CancellationTokenSource();
         private readonly CancellationTokenSource _receiveCts = new CancellationTokenSource();
         private readonly ILogger _logger;
@@ -54,7 +52,7 @@ namespace Microsoft.AspNetCore.Sockets.Client
             _logger = (loggerFactory ?? NullLoggerFactory.Instance).CreateLogger<WebSocketsTransport>();
         }
 
-        public async Task StartAsync(Uri url, Channel<byte[], SendMessage> application, TransferMode requestedTransferMode, IConnection connection)
+        public async Task StartAsync(Uri url, IDuplexPipe application, TransferMode requestedTransferMode, IConnection connection)
         {
             if (url == null)
             {
@@ -77,8 +75,8 @@ namespace Microsoft.AspNetCore.Sockets.Client
             _logger.StartTransport(Mode.Value);
 
             await Connect(url);
-            var sendTask = SendMessages(url);
-            var receiveTask = ReceiveMessages(url);
+            var sendTask = SendMessages();
+            var receiveTask = ReceiveMessages();
 
             // TODO: Handle TCP connection errors
             // https://github.com/SignalR/SignalR/blob/1fba14fa3437e24c204dfaf8a18db3fce8acad3c/src/Microsoft.AspNet.SignalR.Core/Owin/WebSockets/WebSocketHandler.cs#L248-L251
@@ -86,84 +84,43 @@ namespace Microsoft.AspNetCore.Sockets.Client
             {
                 _webSocket.Dispose();
                 _logger.TransportStopped(t.Exception?.InnerException);
-                _application.Writer.TryComplete(t.IsFaulted ? t.Exception.InnerException : null);
+
+                _application.Output.Complete(t.Exception?.InnerException);
+                _application.Input.Complete();
+
                 return t;
             }).Unwrap();
         }
 
-        private async Task ReceiveMessages(Uri pollUrl)
+        private async Task ReceiveMessages()
         {
             _logger.StartReceive();
 
             try
             {
-                while (!_receiveCts.Token.IsCancellationRequested)
+                while (true)
                 {
-                    const int bufferSize = 4096;
-                    var totalBytes = 0;
-                    var incomingMessage = new List<ArraySegment<byte>>();
-                    WebSocketReceiveResult receiveResult;
-                    do
+                    var memory = _application.Output.GetMemory();
+
+                    // REVIEW: Use new Memory<byte> websocket APIs on .NET Core 2.1
+                    memory.TryGetArray(out var arraySegment);
+
+                    // Exceptions are handled above where the send and receive tasks are being run.
+                    var receiveResult = await _webSocket.ReceiveAsync(arraySegment, _receiveCts.Token);
+                    if (receiveResult.MessageType == WebSocketMessageType.Close)
                     {
-                        var buffer = new ArraySegment<byte>(new byte[bufferSize]);
+                        _logger.WebSocketClosed(receiveResult.CloseStatus);
 
-                        //Exceptions are handled above where the send and receive tasks are being run.
-                        receiveResult = await _webSocket.ReceiveAsync(buffer, _receiveCts.Token);
-                        if (receiveResult.MessageType == WebSocketMessageType.Close)
-                        {
-                            _logger.WebSocketClosed(receiveResult.CloseStatus);
-
-                            _application.Writer.Complete(
-                                receiveResult.CloseStatus == WebSocketCloseStatus.NormalClosure
-                                ? null
-                                : new InvalidOperationException(
-                                    $"Websocket closed with error: {receiveResult.CloseStatus}."));
-                            return;
-                        }
-
-                        _logger.MessageReceived(receiveResult.MessageType, receiveResult.Count, receiveResult.EndOfMessage);
-
-                        var truncBuffer = new ArraySegment<byte>(buffer.Array, 0, receiveResult.Count);
-                        incomingMessage.Add(truncBuffer);
-                        totalBytes += receiveResult.Count;
-                    } while (!receiveResult.EndOfMessage);
-
-                    //Making sure the message type is either text or binary
-                    Debug.Assert((receiveResult.MessageType == WebSocketMessageType.Binary || receiveResult.MessageType == WebSocketMessageType.Text), "Unexpected message type");
-
-                    var messageBuffer = new byte[totalBytes];
-                    if (incomingMessage.Count > 1)
-                    {
-                        var offset = 0;
-                        for (var i = 0; i < incomingMessage.Count; i++)
-                        {
-                            Buffer.BlockCopy(incomingMessage[i].Array, 0, messageBuffer, offset, incomingMessage[i].Count);
-                            offset += incomingMessage[i].Count;
-                        }
-                    }
-                    else
-                    {
-                        Buffer.BlockCopy(incomingMessage[0].Array, incomingMessage[0].Offset, messageBuffer, 0, incomingMessage[0].Count);
+                        return;
                     }
 
-                    try
+                    _logger.MessageReceived(receiveResult.MessageType, receiveResult.Count, receiveResult.EndOfMessage);
+
+                    _application.Output.Advance(receiveResult.Count);
+
+                    if (receiveResult.EndOfMessage)
                     {
-                        if (!_transportCts.Token.IsCancellationRequested)
-                        {
-                            _logger.MessageToApp(messageBuffer.Length);
-                            while (await _application.Writer.WaitToWriteAsync(_transportCts.Token))
-                            {
-                                if (_application.Writer.TryWrite(messageBuffer))
-                                {
-                                    incomingMessage.Clear();
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                    catch (OperationCanceledException)
-                    {
-                        _logger.CancelMessage();
+                        await _application.Output.FlushAsync(_transportCts.Token);
                     }
                 }
             }
@@ -173,12 +130,13 @@ namespace Microsoft.AspNetCore.Sockets.Client
             }
             finally
             {
+                // We're done writing
                 _logger.ReceiveStopped();
                 _transportCts.Cancel();
             }
         }
 
-        private async Task SendMessages(Uri sendUrl)
+        private async Task SendMessages()
         {
             _logger.SendStarted();
 
@@ -189,32 +147,38 @@ namespace Microsoft.AspNetCore.Sockets.Client
 
             try
             {
-                while (await _application.Reader.WaitToReadAsync(_transportCts.Token))
+                while (true)
                 {
-                    while (_application.Reader.TryRead(out SendMessage message))
+                    var result = await _application.Input.ReadAsync(_transportCts.Token);
+                    var buffer = result.Buffer;
+                    try
                     {
-                        try
+                        if (!buffer.IsEmpty)
                         {
-                            _logger.ReceivedFromApp(message.Payload.Length);
+                            _logger.ReceivedFromApp(buffer.Length);
 
-                            await _webSocket.SendAsync(new ArraySegment<byte>(message.Payload), webSocketMessageType, true, _transportCts.Token);
-
-                            message.SendResult.SetResult(null);
+                            await _webSocket.SendAsync(new ArraySegment<byte>(buffer.ToArray()), webSocketMessageType, true, _transportCts.Token);
                         }
-                        catch (OperationCanceledException)
+                        else if (result.IsCompleted)
                         {
-                            _logger.SendMessageCanceled();
-                            message.SendResult.SetCanceled();
-                            await CloseWebSocket();
                             break;
                         }
-                        catch (Exception ex)
-                        {
-                            _logger.ErrorSendingMessage(ex);
-                            message.SendResult.SetException(ex);
-                            await CloseWebSocket();
-                            throw;
-                        }
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        _logger.SendMessageCanceled();
+                        await CloseWebSocket();
+                        break;
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.ErrorSendingMessage(ex);
+                        await CloseWebSocket();
+                        throw;
+                    }
+                    finally
+                    {
+                        _application.Input.AdvanceTo(buffer.End);
                     }
                 }
             }

--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/WebSocketsTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/WebSocketsTransport.cs
@@ -111,6 +111,11 @@ namespace Microsoft.AspNetCore.Sockets.Client
                     {
                         _logger.WebSocketClosed(receiveResult.CloseStatus);
 
+                        if (receiveResult.CloseStatus != WebSocketCloseStatus.NormalClosure)
+                        {
+                            throw new InvalidOperationException($"Websocket closed with error: {receiveResult.CloseStatus}.");
+                        }
+
                         return;
                     }
 

--- a/test/Common/TaskExtensions.cs
+++ b/test/Common/TaskExtensions.cs
@@ -20,11 +20,13 @@ namespace Microsoft.AspNetCore.SignalR.Tests.Common
 
         public static async Task OrTimeout(this Task task, TimeSpan timeout, [CallerMemberName] string memberName = null, [CallerFilePath] string filePath = null, [CallerLineNumber] int? lineNumber = null)
         {
-            var completed = await Task.WhenAny(task, Task.Delay(Debugger.IsAttached ? Timeout.InfiniteTimeSpan : timeout));
+            var cts = new CancellationTokenSource();
+            var completed = await Task.WhenAny(task, Task.Delay(Debugger.IsAttached ? Timeout.InfiniteTimeSpan : timeout, cts.Token));
             if (completed != task)
             {
                 throw new TimeoutException(GetMessage(memberName, filePath, lineNumber));
             }
+            cts.Cancel();
 
             await task;
         }
@@ -36,11 +38,13 @@ namespace Microsoft.AspNetCore.SignalR.Tests.Common
 
         public static async Task<T> OrTimeout<T>(this Task<T> task, TimeSpan timeout, [CallerMemberName] string memberName = null, [CallerFilePath] string filePath = null, [CallerLineNumber] int? lineNumber = null)
         {
-            var completed = await Task.WhenAny(task, Task.Delay(Debugger.IsAttached ? Timeout.InfiniteTimeSpan : timeout));
+            var cts = new CancellationTokenSource();
+            var completed = await Task.WhenAny(task, Task.Delay(Debugger.IsAttached ? Timeout.InfiniteTimeSpan : timeout, cts.Token));
             if (completed != task)
             {
                 throw new TimeoutException(GetMessage(memberName, filePath, lineNumber));
             }
+            cts.Cancel();
 
             return await task;
         }

--- a/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/HubConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/HubConnectionTests.cs
@@ -232,7 +232,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
                     var tcs = new TaskCompletionSource<string>();
                     connection.On<string>("Echo", tcs.SetResult);
 
-                    await connection.InvokeAsync("CallEcho", originalMessage).OrTimeout();
+                    await connection.InvokeAsync("CallEcho", originalMessage).OrTimeout(TimeSpan.FromSeconds(20));
 
                     Assert.Equal(originalMessage, await tcs.Task.OrTimeout());
                 }
@@ -252,7 +252,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
         [MemberData(nameof(HubProtocolsAndTransportsAndHubPaths))]
         public async Task InvokeNonExistantClientMethodFromServer(IHubProtocol protocol, TransportType transportType, string path)
         {
-            using (StartLog(out var loggerFactory, $"{nameof(InvokeNonExistantClientMethodFromServer)}_{protocol.Name}_{transportType}_{path.TrimStart('/')}"))
+            using (StartLog(out var loggerFactory, LogLevel.Trace, $"{nameof(InvokeNonExistantClientMethodFromServer)}_{protocol.Name}_{transportType}_{path.TrimStart('/')}"))
             {
                 var httpConnection = new HttpConnection(new Uri(_serverFixture.Url + path), transportType, loggerFactory);
                 var connection = new HubConnection(httpConnection, protocol, loggerFactory);
@@ -272,7 +272,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
                 try
                 {
                     await connection.StartAsync().OrTimeout();
-                    await connection.InvokeAsync("CallHandlerThatDoesntExist").OrTimeout();
+                    await connection.InvokeAsync("CallHandlerThatDoesntExist").OrTimeout(TimeSpan.FromSeconds(20));
                     await connection.DisposeAsync().OrTimeout();
                     await closeTcs.Task.OrTimeout();
                 }

--- a/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/HubConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/HubConnectionTests.cs
@@ -219,7 +219,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
         [MemberData(nameof(HubProtocolsAndTransportsAndHubPaths))]
         public async Task CanInvokeClientMethodFromServer(IHubProtocol protocol, TransportType transportType, string path)
         {
-            using (StartLog(out var loggerFactory, $"{nameof(CanInvokeClientMethodFromServer)}_{protocol.Name}_{transportType}_{path.TrimStart('/')}"))
+            using (StartLog(out var loggerFactory, LogLevel.Trace, $"{nameof(CanInvokeClientMethodFromServer)}_{protocol.Name}_{transportType}_{path.TrimStart('/')}"))
             {
                 const string originalMessage = "SignalR";
 

--- a/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/HubConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/HubConnectionTests.cs
@@ -292,7 +292,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
         [MemberData(nameof(HubProtocolsAndTransportsAndHubPaths))]
         public async Task CanStreamClientMethodFromServer(IHubProtocol protocol, TransportType transportType, string path)
         {
-            using (StartLog(out var loggerFactory, $"{nameof(CanStreamClientMethodFromServer)}_{protocol.Name}_{transportType}_{path.TrimStart('/')}"))
+            using (StartLog(out var loggerFactory, LogLevel.Trace, $"{nameof(CanStreamClientMethodFromServer)}_{protocol.Name}_{transportType}_{path.TrimStart('/')}"))
             {
                 var httpConnection = new HttpConnection(new Uri(_serverFixture.Url + path), transportType, loggerFactory);
                 var connection = new HubConnection(httpConnection, protocol, loggerFactory);

--- a/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/HubConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/HubConnectionTests.cs
@@ -232,7 +232,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
                     var tcs = new TaskCompletionSource<string>();
                     connection.On<string>("Echo", tcs.SetResult);
 
-                    await connection.InvokeAsync("CallEcho", originalMessage).OrTimeout(TimeSpan.FromSeconds(20));
+                    await connection.InvokeAsync("CallEcho", originalMessage).OrTimeout();
 
                     Assert.Equal(originalMessage, await tcs.Task.OrTimeout());
                 }
@@ -272,7 +272,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
                 try
                 {
                     await connection.StartAsync().OrTimeout();
-                    await connection.InvokeAsync("CallHandlerThatDoesntExist").OrTimeout(TimeSpan.FromSeconds(20));
+                    await connection.InvokeAsync("CallHandlerThatDoesntExist").OrTimeout();
                     await connection.DisposeAsync().OrTimeout();
                     await closeTcs.Task.OrTimeout();
                 }

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.ConnectionLifecycle.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.ConnectionLifecycle.cs
@@ -227,7 +227,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                         async (connection, closed) =>
                     {
                         await connection.StartAsync().OrTimeout();
-                        await Assert.ThrowsAsync<HttpRequestException>(() => connection.SendAsync(new byte[] { 0x42 }).OrTimeout());
+                        await connection.SendAsync(new byte[] { 0x42 }).OrTimeout();
 
                         longPollResult.TrySetResult(ResponseUtils.CreateResponse(HttpStatusCode.NoContent));
 
@@ -318,7 +318,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                 async (connection, closed) =>
                 {
                     await connection.StartAsync().OrTimeout();
-                    testTransport.Application.Writer.TryComplete(expected);
+                    testTransport.Application.Output.Complete(expected);
                     var actual = await Assert.ThrowsAsync<Exception>(() => closed.OrTimeout());
                     Assert.Same(expected, actual);
 

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.OnReceived.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.OnReceived.cs
@@ -66,7 +66,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                         }, receiveTcs);
 
                         await connection.StartAsync().OrTimeout();
-                        Assert.Equal("42", await receiveTcs.Task.OrTimeout());
+                        Assert.Contains("42", await receiveTcs.Task.OrTimeout());
                         Assert.True(receivedRaised);
                     });
             }
@@ -98,7 +98,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                         }, receiveTcs);
 
                         await connection.StartAsync().OrTimeout();
-                        Assert.Equal("42", await receiveTcs.Task.OrTimeout());
+                        Assert.Contains("42", await receiveTcs.Task.OrTimeout());
                         Assert.True(receivedRaised);
                     });
             }

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.OnReceived.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.OnReceived.cs
@@ -35,7 +35,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                         }, receiveTcs);
 
                         await connection.StartAsync().OrTimeout();
-                        Assert.Equal("42", await receiveTcs.Task.OrTimeout());
+                        Assert.Contains("42", await receiveTcs.Task.OrTimeout());
                     });
             }
 

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.cs
@@ -251,10 +251,8 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
 
             public ProtocolType Type => ProtocolType.Binary;
 
-            public bool TryParseMessages(ReadOnlySpan<byte> input, IInvocationBinder binder, out IList<HubMessage> messages)
+            public bool TryParseMessages(ReadOnlySpan<byte> input, IInvocationBinder binder, IList<HubMessage> messages)
             {
-                messages = new List<HubMessage>();
-
                 ParseCalls += 1;
                 if (_error != null)
                 {

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/TestTransport.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/TestTransport.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO.Pipelines;
 using System.Threading.Channels;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Sockets;
@@ -12,7 +13,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
         private readonly Func<Task> _startHandler;
 
         public TransferMode? Mode { get; }
-        public Channel<byte[], SendMessage> Application { get; private set; }
+        public IDuplexPipe Application { get; private set; }
 
         public TestTransport(Func<Task> onTransportStop = null, Func<Task> onTransportStart = null, TransferMode transferMode = TransferMode.Text)
         {
@@ -21,7 +22,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
             Mode = transferMode;
         }
 
-        public Task StartAsync(Uri url, Channel<byte[], SendMessage> application, TransferMode requestedTransferMode, IConnection connection)
+        public Task StartAsync(Uri url, IDuplexPipe application, TransferMode requestedTransferMode, IConnection connection)
         {
             Application = application;
             return _startHandler();
@@ -30,7 +31,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
         public async Task StopAsync()
         {
             await _stopHandler();
-            Application.Writer.TryComplete();
+            Application.Output.Complete();
         }
     }
 }

--- a/test/Microsoft.AspNetCore.SignalR.Common.Tests/Internal/Encoders/Base64EncoderTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Common.Tests/Internal/Encoders/Base64EncoderTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Text;
 using Xunit;
@@ -22,8 +23,10 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Encoders
         [MemberData(nameof(Payloads))]
         public void VerifyEncode(string payload, string encoded)
         {
-            var encodedMessage = Encoding.UTF8.GetBytes(encoded);
-            var decodedMessage = Encoding.UTF8.GetString(new Base64Encoder().Decode(encodedMessage).ToArray());
+            ReadOnlySpan<byte> encodedMessage = Encoding.UTF8.GetBytes(encoded);
+            var encoder = new Base64Encoder();
+            encoder.TryDecode(ref encodedMessage, out var data);
+            var decodedMessage = Encoding.UTF8.GetString(data.ToArray());
             Assert.Equal(payload, decodedMessage);
         }
 

--- a/test/Microsoft.AspNetCore.SignalR.Common.Tests/Internal/Encoders/Base64EncoderTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Common.Tests/Internal/Encoders/Base64EncoderTests.cs
@@ -30,6 +30,24 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Encoders
             Assert.Equal(payload, decodedMessage);
         }
 
+        [Fact]
+        public void CanParseMultipleMessages()
+        {
+            ReadOnlySpan<byte> data = Encoding.UTF8.GetBytes("28:QQpSDUMNCjtERUYxMjM0NTY3ODkw;4:QUJD;4:QUJD;");
+            var encoder = new Base64Encoder();
+            Assert.True(encoder.TryDecode(ref data, out var payload1));
+            Assert.True(encoder.TryDecode(ref data, out var payload2));
+            Assert.True(encoder.TryDecode(ref data, out var payload3));
+            Assert.False(encoder.TryDecode(ref data, out var payload4));
+            Assert.Equal(0, data.Length);
+            var payload1Value = Encoding.UTF8.GetString(payload1.ToArray());
+            var payload2Value = Encoding.UTF8.GetString(payload2.ToArray());
+            var payload3Value = Encoding.UTF8.GetString(payload3.ToArray());
+            Assert.Equal("A\nR\rC\r\n;DEF1234567890", payload1Value);
+            Assert.Equal("ABC", payload2Value);
+            Assert.Equal("ABC", payload3Value);
+        }
+
         public static IEnumerable<object[]> Payloads =>
             new object[][]
             {

--- a/test/Microsoft.AspNetCore.SignalR.Common.Tests/Internal/Protocol/JsonHubProtocolTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Common.Tests/Internal/Protocol/JsonHubProtocolTests.cs
@@ -125,7 +125,8 @@ namespace Microsoft.AspNetCore.SignalR.Common.Tests.Internal.Protocol
 
             var binder = new TestBinder(expectedMessage);
             var protocol = new JsonHubProtocol(Options.Create(protocolOptions));
-            protocol.TryParseMessages(Encoding.UTF8.GetBytes(input), binder, out var messages);
+            var messages = new List<HubMessage>();
+            protocol.TryParseMessages(Encoding.UTF8.GetBytes(input), binder, messages);
 
             Assert.Equal(expectedMessage, messages[0], TestHubMessageEqualityComparer.Instance);
         }
@@ -174,7 +175,8 @@ namespace Microsoft.AspNetCore.SignalR.Common.Tests.Internal.Protocol
 
             var binder = new TestBinder(Array.Empty<Type>(), typeof(object));
             var protocol = new JsonHubProtocol();
-            var ex = Assert.Throws<InvalidDataException>(() => protocol.TryParseMessages(Encoding.UTF8.GetBytes(input), binder, out var messages));
+            var messages = new List<HubMessage>();
+            var ex = Assert.Throws<InvalidDataException>(() => protocol.TryParseMessages(Encoding.UTF8.GetBytes(input), binder, messages));
             Assert.Equal(expectedMessage, ex.Message);
         }
 
@@ -189,7 +191,8 @@ namespace Microsoft.AspNetCore.SignalR.Common.Tests.Internal.Protocol
 
             var binder = new TestBinder(paramTypes: new[] { typeof(int), typeof(string) }, returnType: typeof(bool));
             var protocol = new JsonHubProtocol();
-            protocol.TryParseMessages(Encoding.UTF8.GetBytes(input), binder, out var messages);
+            var messages = new List<HubMessage>();
+            protocol.TryParseMessages(Encoding.UTF8.GetBytes(input), binder, messages);
             var ex = Assert.Throws<InvalidDataException>(() => ((HubMethodInvocationMessage)messages[0]).Arguments);
             Assert.Equal(expectedMessage, ex.Message);
         }

--- a/test/Microsoft.AspNetCore.SignalR.Common.Tests/Internal/Protocol/MessagePackHubProtocolTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Common.Tests/Internal/Protocol/MessagePackHubProtocolTests.cs
@@ -349,9 +349,10 @@ namespace Microsoft.AspNetCore.SignalR.Common.Tests.Internal.Protocol
             // Parse the input fully now.
             bytes = Frame(bytes);
             var protocol = new MessagePackHubProtocol();
-            Assert.True(protocol.TryParseMessages(bytes, new TestBinder(testData.Message), out var messages));
+            var messages = new List<HubMessage>();
+            Assert.True(protocol.TryParseMessages(bytes, new TestBinder(testData.Message), messages));
 
-            Assert.Equal(1, messages.Count);
+            Assert.Single(messages);
             Assert.Equal(testData.Message, messages[0], TestHubMessageEqualityComparer.Instance);
         }
 
@@ -419,7 +420,8 @@ namespace Microsoft.AspNetCore.SignalR.Common.Tests.Internal.Protocol
         {
             var buffer = Frame(Pack(testData.Encoded));
             var binder = new TestBinder(new[] { typeof(string) }, typeof(string));
-            var exception = Assert.Throws<FormatException>(() => _hubProtocol.TryParseMessages(buffer, binder, out var messages));
+            var messages = new List<HubMessage>();
+            var exception = Assert.Throws<FormatException>(() => _hubProtocol.TryParseMessages(buffer, binder, messages));
 
             Assert.Equal(testData.ErrorMessage, exception.Message);
         }
@@ -447,7 +449,8 @@ namespace Microsoft.AspNetCore.SignalR.Common.Tests.Internal.Protocol
         {
             var buffer = Frame(Pack(testData.Encoded));
             var binder = new TestBinder(new[] { typeof(string) }, typeof(string));
-            _hubProtocol.TryParseMessages(buffer, binder, out var messages);
+            var messages = new List<HubMessage>();
+            _hubProtocol.TryParseMessages(buffer, binder, messages);
             var exception = Assert.Throws<FormatException>(() => ((HubMethodInvocationMessage)messages[0]).Arguments);
 
             Assert.Equal(testData.ErrorMessage, exception.Message);
@@ -458,7 +461,8 @@ namespace Microsoft.AspNetCore.SignalR.Common.Tests.Internal.Protocol
         public void ParserDoesNotConsumePartialData(byte[] payload, int expectedMessagesCount)
         {
             var binder = new TestBinder(new[] { typeof(string) }, typeof(string));
-            var result = _hubProtocol.TryParseMessages(payload, binder, out var messages);
+            var messages = new List<HubMessage>();
+            var result = _hubProtocol.TryParseMessages(payload, binder, messages);
             Assert.True(result || messages.Count == 0);
             Assert.Equal(expectedMessagesCount, messages.Count);
         }

--- a/test/Microsoft.AspNetCore.SignalR.Tests.Utils/PipeReaderExtensions.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests.Utils/PipeReaderExtensions.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace System.IO.Pipelines
+{
+    public static class PipeReaderExtensions
+    {
+        public static async Task<bool> WaitToReadAsync(this PipeReader pipeReader)
+        {
+            while (true)
+            {
+                var result = await pipeReader.ReadAsync();
+
+                try
+                {
+                    if (!result.Buffer.IsEmpty)
+                    {
+                        return true;
+                    }
+
+                    if (result.IsCompleted)
+                    {
+                        return false;
+                    }
+                }
+                finally
+                {
+                    // Consume nothing, just wait for everything
+                    pipeReader.AdvanceTo(result.Buffer.Start, result.Buffer.End);
+                }
+            }
+        }
+
+        public static async Task<byte[]> ReadSingleAsync(this PipeReader pipeReader)
+        {
+            while (true)
+            {
+                var result = await pipeReader.ReadAsync();
+
+                try
+                {
+                    return result.Buffer.ToArray();
+                }
+                finally
+                {
+                    pipeReader.AdvanceTo(result.Buffer.End);
+                }
+            }
+        }
+
+        public static async Task<byte[]> ReadAllAsync(this PipeReader pipeReader)
+        {
+            while (true)
+            {
+                var result = await pipeReader.ReadAsync();
+
+                try
+                {
+                    if (result.IsCompleted)
+                    {
+                        return result.Buffer.ToArray();
+                    }
+                }
+                finally
+                {
+                    // Consume nothing, just wait for everything
+                    pipeReader.AdvanceTo(result.Buffer.Start, result.Buffer.End);
+                }
+            }
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.SignalR.Tests/EndToEndTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/EndToEndTests.cs
@@ -260,7 +260,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
         [MemberData(nameof(MessageSizesData))]
         public async Task ConnectionCanSendAndReceiveDifferentMessageSizesWebSocketsTransport(string message)
         {
-            using (StartLog(out var loggerFactory, testName: $"ConnectionCanSendAndReceiveDifferentMessageSizesWebSocketsTransport_{message.Length}"))
+            using (StartLog(out var loggerFactory, LogLevel.Trace, testName: $"ConnectionCanSendAndReceiveDifferentMessageSizesWebSocketsTransport_{message.Length}"))
             {
                 var logger = loggerFactory.CreateLogger<EndToEndTests>();
 


### PR DESCRIPTION
- Reworked the Client to be based on pipelines instead of Channels
- SendAsync no longer fails if the http request itself fails but the connection is closed as a result.
- Updated tests
