### PR TITLE
Fix #1301 by updating MsgPack-Cli

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -56,7 +56,7 @@
     <MicrosoftNETCoreApp21PackageVersion>2.1.0-preview2-26130-04</MicrosoftNETCoreApp21PackageVersion>
     <MicrosoftNETTestSdkPackageVersion>15.3.0</MicrosoftNETTestSdkPackageVersion>
     <MoqPackageVersion>4.7.49</MoqPackageVersion>
-    <MsgPackCliPackageVersion>0.9.0-beta2</MsgPackCliPackageVersion>
+    <MsgPackCliPackageVersion>1.0.0-rc</MsgPackCliPackageVersion>
     <NewtonsoftJsonPackageVersion>10.0.1</NewtonsoftJsonPackageVersion>
     <StackExchangeRedisStrongNamePackageVersion>1.2.4</StackExchangeRedisStrongNamePackageVersion>
     <SystemBuffersPackageVersion>4.5.0-preview2-26130-01</SystemBuffersPackageVersion>

--- a/client-ts/signalr-protocol-msgpack/package.json
+++ b/client-ts/signalr-protocol-msgpack/package.json
@@ -18,7 +18,7 @@
     "build:cjs": "node ../node_modules/typescript/bin/tsc --project ./tsconfig.json --module commonjs --outDir ./dist/cjs --target ES5",
     "build:browser": "node ../node_modules/rollup/bin/rollup -c",
     "build:uglify": "node ../node_modules/uglify-js/bin/uglifyjs --source-map \"url='signalr-protocol-msgpack.min.js.map',content='./dist/browser/signalr-protocol-msgpack.js.map'\" --comments -o ./dist/browser/signalr-protocol-msgpack.min.js ./dist/browser/signalr-protocol-msgpack.js",
-    "pretest": "node ../node_modules/rimraf/bin.js ./spec/obj && tsc --project ./spec/tsconfig.json",
+    "pretest": "node ../node_modules/rimraf/bin.js ./spec/obj && node ../node_modules/typescript/bin/tsc --project ./spec/tsconfig.json",
     "test": "node ../node_modules/jasmine/bin/jasmine.js ./spec/obj/signalr-protocol-msgpack/spec/**/*.spec.js"
   },
   "keywords": [

--- a/client-ts/signalr/package.json
+++ b/client-ts/signalr/package.json
@@ -18,7 +18,7 @@
     "build:cjs": "node ../node_modules/typescript/bin/tsc --project ./tsconfig.json --module commonjs --outDir ./dist/cjs --target ES5",
     "build:browser": "node ../node_modules/rollup/bin/rollup -c",
     "build:uglify": "node ../node_modules/uglify-js/bin/uglifyjs --source-map \"url='signalr.min.js.map',content='./dist/browser/signalr.js.map'\" --comments -o ./dist/browser/signalr.min.js ./dist/browser/signalr.js",
-    "pretest": "node ../node_modules/rimraf/bin.js ./spec/obj && tsc --project ./spec/tsconfig.json",
+    "pretest": "node ../node_modules/rimraf/bin.js ./spec/obj && node ../node_modules/typescript/bin/tsc --project ./spec/tsconfig.json",
     "test": "node ../node_modules/jasmine/bin/jasmine.js ./spec/obj/spec/**/*.spec.js"
   },
   "repository": {

--- a/client-ts/tsconfig-base.json
+++ b/client-ts/tsconfig-base.json
@@ -3,6 +3,7 @@
     "compilerOptions": {
         "module": "es2015",
         "target": "es2016",
+        "outDir": "./obj/js",
         "sourceMap": true,
         "moduleResolution": "node",
         "inlineSources": true,

--- a/samples/SocketsSample/SocketsSample.csproj
+++ b/samples/SocketsSample/SocketsSample.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Microsoft.AspNetCore.SignalR.MsgPack\Microsoft.AspNetCore.SignalR.MsgPack.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.AspNetCore.SignalR\Microsoft.AspNetCore.SignalR.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.AspNetCore.Sockets.Http\Microsoft.AspNetCore.Sockets.Http.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.AspNetCore.SignalR.Redis\Microsoft.AspNetCore.SignalR.Redis.csproj" />
@@ -29,7 +30,12 @@
       <SignalRJSClientFiles Include="$(MSBuildThisFileDirectory)..\..\client-ts\signalr\dist\browser\*" />
       <SignalRJSClientFiles Include="$(MSBuildThisFileDirectory)..\..\client-ts\signalr-protocol-msgpack\dist\browser\*" />
     </ItemGroup>
-    <Copy SourceFiles="@(SignalRJSClientFiles)" DestinationFolder="$(MSBuildThisFileDirectory)wwwroot\lib\signalr-client" />
+    <Copy SourceFiles="@(SignalRJSClientFiles)" DestinationFolder="$(MSBuildThisFileDirectory)wwwroot\lib\signalr" />
+
+    <ItemGroup>
+      <MsgPackClientFiles Include="$(MSBuildThisFileDirectory)..\..\client-ts\signalr-protocol-msgpack\node_modules\msgpack5\dist\*" />
+    </ItemGroup>
+    <Copy SourceFiles="@(MsgPackClientFiles)" DestinationFolder="$(MSBuildThisFileDirectory)wwwroot\lib\msgpack5" />
   </Target>
 
 </Project>

--- a/samples/SocketsSample/Startup.cs
+++ b/samples/SocketsSample/Startup.cs
@@ -5,9 +5,10 @@ using System;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
-using Newtonsoft.Json.Serialization;
+using MsgPack.Serialization;
 using SocketsSample.EndPoints;
 using SocketsSample.Hubs;
+using StackExchange.Redis;
 
 namespace SocketsSample
 {
@@ -23,6 +24,10 @@ namespace SocketsSample
             {
                 // Faster pings for testing
                 options.KeepAliveInterval = TimeSpan.FromSeconds(5);
+            })
+            .AddMessagePackProtocol(options =>
+            {
+                options.SerializationContext.DictionarySerlaizationOptions.KeyTransformer = DictionaryKeyTransformers.LowerCamel;
             });
             // .AddRedis();
 

--- a/samples/SocketsSample/wwwroot/hubs.html
+++ b/samples/SocketsSample/wwwroot/hubs.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html>
 
 <head>
@@ -7,11 +7,23 @@
 </head>
 
 <body>
-    <h1 id="head1"></h1>
+    <h1 id="head1">SignalR Hubs Sample</h1>
     <div>
-        <select id="formatType">
-            <option value="json">json</option>
-            <option value="line">line</option>
+        <select id="protocol">
+            <option value="json" selected>json</option>
+            <option value="msgpack">msgpack</option>
+        </select>
+
+        <select id="transport">
+            <option value="WebSockets" selected>WebSockets</option>
+            <option value="ServerSentEvents">ServerSentEvents</option>
+            <option value="LongPolling">LongPolling</option>
+        </select>
+
+        <select id="hubType">
+            <option value="default" selected>Hub</option>
+            <option value="dynamic">DynamicHub</option>
+            <option value="hubT">Hub&lt;T&gt;</option>
         </select>
 
         <input type="button" id="connect" value="Connect" />
@@ -62,7 +74,9 @@
 </body>
 
 </html>
-<script src="lib/signalr-client/signalr.js"></script>
+<script src="lib/signalr/signalr.js"></script>
+<script src="lib/msgpack5/msgpack5.js"></script>
+<script src="lib/signalr/signalr-protocol-msgpack.js"></script>
 <script src="utils.js"></script>
 <script>
     var isConnected = false;
@@ -88,12 +102,7 @@
         return document.getElementById(id).value;
     }
 
-    let transportType = signalR.TransportType[getParameterByName('transport')] || signalR.TransportType.WebSockets;
     let logger = new signalR.ConsoleLogger(signalR.LogLevel.Trace);
-    let hubRoute = getParameterByName('hubType') || "default";
-    console.log('Hub Route:' + hubRoute);
-
-    document.getElementById('head1').innerHTML = signalR.TransportType[transportType];
 
     let connectButton = document.getElementById('connect');
     let disconnectButton = document.getElementById('disconnect');
@@ -105,6 +114,9 @@
     let groupMsgButton = document.getElementById('groupmsg');
     let othersGroupMsgButton = document.getElementById('others-groupmsg');
     let sendButton = document.getElementById('send');
+    let protocolDropdown = document.getElementById('protocol');
+    let transportDropdown = document.getElementById('transport');
+    let hubTypeDropdown = document.getElementById('hubType');
 
     function updateButtonState(isConnected) {
         broadcastButton.disabled = !isConnected;
@@ -123,8 +135,14 @@
     var connection;
 
     click('connect', function (event) {
+        let transportType = signalR.TransportType[transportDropdown.value] || signalR.TransportType.WebSockets;
+        let hubRoute = hubTypeDropdown.value || "default";
+        let protocol = protocolDropdown.value === "msgpack" ?
+            new signalR.protocols.msgpack.MessagePackHubProtocol() :
+            new signalR.JsonHubProtocol();
+
         console.log('http://' + document.location.host + '/' + hubRoute);
-        connection = new signalR.HubConnection(hubRoute, { transport: transportType, logger: logger });
+        connection = new signalR.HubConnection(hubRoute, { transport: transportType, logger: logger, protocol: protocol });
         connection.on('Send', function (msg) {
             addLine('message-list', msg);
         });

--- a/samples/SocketsSample/wwwroot/index.html
+++ b/samples/SocketsSample/wwwroot/index.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html>
 <head>
     <meta charset="utf-8" />
@@ -14,21 +14,7 @@
     </ul>
     <h1>ASP.NET Core SignalR (Hubs)</h1>
     <ul>
-        <li><a href="hubs.html?transport=LongPolling">Long polling</a></li>
-        <li><a href="hubs.html?transport=ServerSentEvents">Server Sent Events</a></li>
-        <li><a href="hubs.html?transport=WebSockets">Web Sockets</a></li>
-    </ul>
-    <h1>ASP.NET Core SignalR (Dynamic Hubs)</h1>
-    <ul>
-        <li><a href="hubs.html?transport=LongPolling&hubType=dynamic">Long polling</a></li>
-        <li><a href="hubs.html?transport=ServerSentEvents&hubType=dynamic">Server Sent Events</a></li>
-        <li><a href="hubs.html?transport=WebSockets&hubType=dynamic">Web Sockets</a></li>
-    </ul>
-    <h1>ASP.NET Core SignalR (Hub&lt;T&gt;)</h1>
-    <ul>
-        <li><a href="hubs.html?transport=LongPolling&hubType=hubT">Long polling</a></li>
-        <li><a href="hubs.html?transport=ServerSentEvents&hubType=hubT">Server Sent Events</a></li>
-        <li><a href="hubs.html?transport=WebSockets&hubType=hubT">Web Sockets</a></li>
+        <li><a href="hubs.html">Hubs</a></li>
     </ul>
     <h1>ASP.NET Core SignalR (Streaming)</h1>
     <ul>

--- a/samples/SocketsSample/wwwroot/sockets.html
+++ b/samples/SocketsSample/wwwroot/sockets.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html>
 
 <head>
@@ -15,7 +15,7 @@
     </form>
 
     <ul id="messages"></ul>
-    <script src="lib/signalr-client/signalr.js"></script>
+    <script src="lib/signalr/signalr.js"></script>
     <script src="utils.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', function () {

--- a/samples/SocketsSample/wwwroot/streaming.html
+++ b/samples/SocketsSample/wwwroot/streaming.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html>
 
 <head>
@@ -25,7 +25,7 @@
     <ul id="resultsList"></ul>
 
     <ul id="messages"></ul>
-    <script src="lib/signalr-client/signalr.js"></script>
+    <script src="lib/signalr/signalr.js"></script>
     <script src="utils.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', function () {


### PR DESCRIPTION
Also added MsgPack support to SocketSample and cleaned it up a bit by using dropdowns instead of querystring values. The sample now sends an object too, in order to help debug serialization issues.