### PR TITLE
Add timeout back to hanging test

### DIFF
--- a/test/Microsoft.AspNetCore.SignalR.Tests.Utils/TaskExtensions.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests.Utils/TaskExtensions.cs
@@ -8,7 +8,7 @@ namespace System.Threading.Tasks
 {
     public static class TaskExtensions
     {
-        private const int DefaultTimeout = 5000;
+        private const int DefaultTimeout = 1000 * 60;
 
         public static Task OrTimeout(this Task task, int milliseconds = DefaultTimeout, [CallerMemberName] string memberName = null, [CallerFilePath] string filePath = null, [CallerLineNumber] int? lineNumber = null)
         {

--- a/test/Microsoft.AspNetCore.SignalR.Tests/EndToEndTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/EndToEndTests.cs
@@ -290,8 +290,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                     logger.LogInformation("Sent message", bytes.Length);
 
                     logger.LogInformation("Receiving message");
-                    // No timeout here because it can take a while to receive all the bytes
-                    var receivedData = await receiveTcs.Task;
+                    var receivedData = await receiveTcs.Task.OrTimeout();
                     Assert.Equal(message, Encoding.UTF8.GetString(receivedData));
                     logger.LogInformation("Completed receive");
                 }


### PR DESCRIPTION
- Increase timeout to 60 seconds

This test is still never completing randomly