### PR TITLE
Do over the websocket transport

### DIFF
--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/HttpOptions.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/HttpOptions.cs
@@ -13,6 +13,7 @@ namespace Microsoft.AspNetCore.Sockets.Client.Http
         public HttpMessageHandler HttpMessageHandler { get; set; }
         public IReadOnlyCollection<KeyValuePair<string, string>> Headers { get; set; }
         public Func<string> AccessTokenFactory { get; set; }
+        public TimeSpan CloseTimeout { get; set; } = TimeSpan.FromSeconds(5);
 
         /// <summary>
         /// Gets or sets a delegate that will be invoked with the <see cref="ClientWebSocketOptions"/> object used

--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/WebSocketsTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/WebSocketsTransport.cs
@@ -50,7 +50,6 @@ namespace Microsoft.AspNetCore.Sockets.Client
 
             httpOptions?.WebSocketOptions?.Invoke(_webSocket.Options);
 
-
             _closeTimeout = httpOptions?.CloseTimeout ?? TimeSpan.FromSeconds(5);
             _logger = (loggerFactory ?? NullLoggerFactory.Instance).CreateLogger<WebSocketsTransport>();
         }

--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/WebSocketsTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/WebSocketsTransport.cs
@@ -237,7 +237,7 @@ namespace Microsoft.AspNetCore.Sockets.Client
                     {
                         if (result.IsCancelled)
                         {
-                            return;
+                            break;
                         }
 
                         if (!buffer.IsEmpty)

--- a/src/Microsoft.AspNetCore.Sockets.Http/Internal/Transports/WebSocketsTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Http/Internal/Transports/WebSocketsTransport.cs
@@ -163,7 +163,7 @@ namespace Microsoft.AspNetCore.Sockets.Internal.Transports
                     {
                         var flushResult = await _application.Output.FlushAsync();
 
-                        // We cancelled in the middle of applying back pressure
+                        // We canceled in the middle of applying back pressure
                         // or if the consumer is done
                         if (flushResult.IsCancelled || flushResult.IsCompleted)
                         {
@@ -194,7 +194,7 @@ namespace Microsoft.AspNetCore.Sockets.Internal.Transports
             }
         }
 
-        private async Task StartSending(WebSocket ws)
+        private async Task StartSending(WebSocket socket)
         {
             Exception error = null;
 
@@ -224,9 +224,9 @@ namespace Microsoft.AspNetCore.Sockets.Internal.Transports
                                     ? WebSocketMessageType.Binary
                                     : WebSocketMessageType.Text);
 
-                                if (WebSocketCanSend(ws))
+                                if (WebSocketCanSend(socket))
                                 {
-                                    await ws.SendAsync(buffer, webSocketMessageType);
+                                    await socket.SendAsync(buffer, webSocketMessageType);
                                 }
                                 else
                                 {
@@ -260,10 +260,10 @@ namespace Microsoft.AspNetCore.Sockets.Internal.Transports
             finally
             {
                 // Send the close frame before calling into user code
-                if (WebSocketCanSend(ws))
+                if (WebSocketCanSend(socket))
                 {
                     // We're done sending, send the close frame to the client if the websocket is still open
-                    await ws.CloseOutputAsync(error != null ? WebSocketCloseStatus.InternalServerError : WebSocketCloseStatus.NormalClosure, "", CancellationToken.None);
+                    await socket.CloseOutputAsync(error != null ? WebSocketCloseStatus.InternalServerError : WebSocketCloseStatus.NormalClosure, "", CancellationToken.None);
                 }
 
                 _application.Input.Complete();

--- a/src/Microsoft.AspNetCore.Sockets.Http/Internal/Transports/WebSocketsTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Http/Internal/Transports/WebSocketsTransport.cs
@@ -68,39 +68,26 @@ namespace Microsoft.AspNetCore.Sockets.Internal.Transports
             var receiving = StartReceiving(socket);
             var sending = StartSending(socket);
 
-            // Wait for something to complete
+            // Wait for send or receive to complete
             var trigger = await Task.WhenAny(receiving, sending);
 
             if (trigger == receiving)
             {
                 _logger.WaitingForSend();
 
-                // If receiving finished first, it's because of a couple of reasons
-                // 1. We received a close frame, if that's the case, we should send one back
-                if (socket.State == WebSocketState.CloseReceived)
-                {
-                    await socket.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, "", CancellationToken.None);
-                }
-                else
-                {
-                    // 2. If close wasn't received that means we ended because of an exception. Here the websocket is still running
-                    // fine and we need to close it with an error
-                    await socket.CloseOutputAsync(WebSocketCloseStatus.InternalServerError, "", CancellationToken.None);
-                }
-
                 // We're waiting for the application to finish and there are 2 things it could be doing
                 // 1. Waiting for application data
                 // 2. Waiting for a websocket send to complete
+
+                // Cancel the application so that ReadAsync yields
+                _application.Input.CancelPendingRead();
 
                 var resultTask = await Task.WhenAny(sending, Task.Delay(_options.CloseTimeout));
 
                 if (resultTask != sending)
                 {
-                    _logger.CloseTimedOut();
-
                     // We timed out so now we're in ungraceful shutdown mode
-                    // Cancel the application so that ReadAsync yields
-                    _application.Input.CancelPendingRead();
+                    _logger.CloseTimedOut();
 
                     // Abort the websocket if we're stuck in a pending send to the client
                     socket.Abort();
@@ -110,26 +97,19 @@ namespace Microsoft.AspNetCore.Sockets.Internal.Transports
             {
                 _logger.WaitingForClose();
 
-                // The websocket receive loop is still running so we attempt to graceful close by sending the client
-                // a close frame
-                await socket.CloseOutputAsync(sending.IsFaulted ? WebSocketCloseStatus.InternalServerError : WebSocketCloseStatus.NormalClosure, "", CancellationToken.None);
-
                 // We're waiting on the websocket to close and there are 2 things it could be doing
                 // 1. Waiting for websocket data
                 // 2. Waiting on a flush to complete (backpressure being applied)
 
-                // Give the receiving task time to complete gracefully with a close message
                 var resultTask = await Task.WhenAny(receiving, Task.Delay(_options.CloseTimeout));
 
                 if (resultTask != receiving)
                 {
-                    _logger.CloseTimedOut();
+                    // Abort the websocket if we're stuck in a pending receive from the client
+                    socket.Abort();
 
                     // Cancel any pending flush so that we can quit
                     _application.Output.CancelPendingFlush();
-
-                    // We didn't complete so abort the websocket
-                    socket.Abort();
                 }
             }
         }
@@ -173,6 +153,10 @@ namespace Microsoft.AspNetCore.Sockets.Internal.Transports
                     }
                 }
             }
+            catch (OperationCanceledException)
+            {
+                // Ignore aborts, don't treat them like transport errors
+            }
             catch (Exception ex)
             {
                 _application.Output.Complete(ex);
@@ -190,6 +174,8 @@ namespace Microsoft.AspNetCore.Sockets.Internal.Transports
 
         private async Task StartSending(WebSocket ws)
         {
+            Exception error = null;
+
             try
             {
                 while (true)
@@ -244,10 +230,22 @@ namespace Microsoft.AspNetCore.Sockets.Internal.Transports
                     }
                 }
             }
+            catch (Exception ex)
+            {
+                error = ex;
+            }
             finally
             {
+                // Send the clpse frame before calling into user code
+                if (WebSocketCanSend(ws))
+                {
+                    // We're done sending, send the close frame to the client if the websocket is still open
+                    await ws.CloseOutputAsync(error != null ? WebSocketCloseStatus.InternalServerError : WebSocketCloseStatus.NormalClosure, "", CancellationToken.None);
+                }
+
                 _application.Input.Complete();
             }
+
         }
 
         private static bool WebSocketCanSend(WebSocket ws)

--- a/src/Microsoft.AspNetCore.Sockets.Http/Internal/Transports/WebSocketsTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Http/Internal/Transports/WebSocketsTransport.cs
@@ -211,7 +211,7 @@ namespace Microsoft.AspNetCore.Sockets.Internal.Transports
                     {
                         if (result.IsCancelled)
                         {
-                            return;
+                            break;
                         }
 
                         if (!buffer.IsEmpty)

--- a/test/Microsoft.AspNetCore.SignalR.Tests/WebSocketsTransportTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/WebSocketsTransportTests.cs
@@ -73,9 +73,6 @@ namespace Microsoft.AspNetCore.SignalR.Tests
 
                 await pair.Transport.Output.WriteAsync(new byte[] { 0x42 });
 
-                await pair.Transport.Input.WaitToReadAsync();
-                pair.Transport.Output.Complete();
-
                 // The echo endpoint closes the connection immediately after sending response which should stop the transport
                 await webSocketsTransport.Running.OrTimeout();
 

--- a/test/Microsoft.AspNetCore.SignalR.Tests/WebSocketsTransportTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/WebSocketsTransportTests.cs
@@ -73,6 +73,9 @@ namespace Microsoft.AspNetCore.SignalR.Tests
 
                 await pair.Transport.Output.WriteAsync(new byte[] { 0x42 });
 
+                await pair.Transport.Input.WaitToReadAsync();
+                pair.Transport.Output.Complete();
+
                 // The echo endpoint closes the connection immediately after sending response which should stop the transport
                 await webSocketsTransport.Running.OrTimeout();
 

--- a/test/Microsoft.AspNetCore.Sockets.Tests/TestWebSocketConnectionFeature.cs
+++ b/test/Microsoft.AspNetCore.Sockets.Tests/TestWebSocketConnectionFeature.cs
@@ -134,6 +134,9 @@ namespace Microsoft.AspNetCore.Sockets.Tests
                             break;
                     }
 
+                    // Complete the client side if there's an error
+                    _output.TryComplete();
+
                     throw;
                 }
 

--- a/test/Microsoft.AspNetCore.Sockets.Tests/WebSocketsTests.cs
+++ b/test/Microsoft.AspNetCore.Sockets.Tests/WebSocketsTests.cs
@@ -108,7 +108,7 @@ namespace Microsoft.AspNetCore.Sockets.Tests
         }
 
         [Fact]
-        public async Task TransportFailsWhenClientDisconnectsAbnormally()
+        public async Task TransportCommunicatesErrorToApplicationWhenClientDisconnectsAbnormally()
         {
             using (StartLog(out var loggerFactory, LogLevel.Debug))
             {
@@ -124,6 +124,10 @@ namespace Microsoft.AspNetCore.Sockets.Tests
                             // Wait until the transport completes so that we can end the application
                             var result = await connection.Transport.Input.ReadAsync();
                             connection.Transport.Input.AdvanceTo(result.Buffer.End);
+                        }
+                        catch (Exception ex)
+                        {
+                            Assert.IsType<WebSocketError>(ex);
                         }
                         finally
                         {

--- a/test/Microsoft.AspNetCore.Sockets.Tests/WebSocketsTests.cs
+++ b/test/Microsoft.AspNetCore.Sockets.Tests/WebSocketsTests.cs
@@ -119,12 +119,17 @@ namespace Microsoft.AspNetCore.Sockets.Tests
                 {
                     async Task CompleteApplicationAfterTransportCompletes()
                     {
-                        // Wait until the transport completes so that we can end the application
-                        var result = await connection.Transport.Input.ReadAsync();
-                        connection.Transport.Input.AdvanceTo(result.Buffer.End);
-
-                        // Complete the application so that the connection unwinds without aborting
-                        connection.Transport.Output.Complete();
+                        try
+                        {
+                            // Wait until the transport completes so that we can end the application
+                            var result = await connection.Transport.Input.ReadAsync();
+                            connection.Transport.Input.AdvanceTo(result.Buffer.End);
+                        }
+                        finally
+                        {
+                            // Complete the application so that the connection unwinds without aborting
+                            connection.Transport.Output.Complete();
+                        }
                     }
 
                     var connectionContext = new DefaultConnectionContext(string.Empty, null, null);
@@ -144,7 +149,7 @@ namespace Microsoft.AspNetCore.Sockets.Tests
                     feature.Client.SendAbort();
 
                     // Wait for the transport
-                    await Assert.ThrowsAsync<WebSocketException>(() => transport).OrTimeout();
+                    await transport.OrTimeout();
 
                     await client.OrTimeout();
                 }
@@ -178,8 +183,7 @@ namespace Microsoft.AspNetCore.Sockets.Tests
                     // Close from the client
                     await feature.Client.CloseAsync(WebSocketCloseStatus.NormalClosure, "", CancellationToken.None);
 
-                    var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => transport.OrTimeout());
-                    Assert.Equal("Catastrophic failure.", ex.Message);
+                    await transport.OrTimeout();
                 }
             }
         }
@@ -247,7 +251,7 @@ namespace Microsoft.AspNetCore.Sockets.Tests
                     // fail the client to server channel
                     connection.Transport.Output.Complete(new Exception());
 
-                    await Assert.ThrowsAsync<Exception>(() => transport).OrTimeout();
+                    await transport.OrTimeout();
 
                     Assert.Equal(WebSocketState.Aborted, serverSocket.State);
                 }


### PR DESCRIPTION
- Unify client and server logic (no code sharing yet)
- Removed use of cancellation tokens to communicate shutdown and instead used the pipe reader and socket abort.
- Added CloseTimeout to HttpOptions

I started looking at this because of a test failure with the following error in a test:

```
[00:05:19] [xUnit.net 00:00:13.0999990]         | TestLifetime Information: Finished test InvokeNonExistantClientMethodFromServer_messagepack_WebSockets_default in 0.0684804s
[00:05:19] [xUnit.net 00:00:13.1268739]     Microsoft.AspNetCore.SignalR.Client.FunctionalTests.HubConnectionTests.InvokeNonExistantClientMethodFromServer(protocol: MessagePackHubProtocol { Name = "messagepack", SerializationContext = 
[00:05:19] SerializationContext { Compatibi
[00:05:19] lityOptions = SerializationCompatibilityOptions { ... }, DefaultCollectionTypes = DefaultConcreteTypeRepository { ... }, DefaultDateTimeConversionMethod = Timestamp, DictionarySerlaizationOptions = DictionarySerlaizationOptions 
[00:05:19] { ... }, EnumSerializationMethod = ByName, ... }, Type = Binary }, transportType: WebSockets, path: "/dynamic") [FAIL]
[00:05:19] 
[00:05:19] [xUnit.net 00:00:13.1270787]       System.Net.WebSockets.WebSocketException : The 'System.Net.WebSockets.InternalClientWebSocket' instance cannot be used for communication because it has been transitioned into the 'Aborted' state.
[00:05:19] [xUnit.net 00:00:13.1271324]       ---- System.Threading.Tasks.TaskCanceledException : A task was canceled.
[00:05:19] [xUnit.net 00:00:13.1273979]       Stack Trace:
[00:05:19] [xUnit.net 00:00:13.1274872]            at System.Net.WebSockets.WebSocketBase.ThrowIfAborted(Boolean aborted, Exception innerException)
[00:05:19] [xUnit.net 00:00:13.1275419]            at System.Net.WebSockets.WebSocketBase.ThrowIfConvertibleException(String methodName, Exception exception, CancellationToken cancellationToken, Boolean aborted)
[00:05:19] [xUnit.net 00:00:13.1275898]            at System.Net.WebSockets.WebSocketBase.<ReceiveAsyncCore>d__45.MoveNext()
[00:05:19] [xUnit.net 00:00:13.1276267]         --- End of stack trace from previous location where exception was thrown ---
[00:05:19] [xUnit.net 00:00:13.1276699]            at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
[00:05:19] [xUnit.net 00:00:13.1277120]            at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
[00:05:19] [xUnit.net 00:00:13.1277631]         C:\projects\signalr\src\Microsoft.AspNetCore.Sockets.Client.Http\WebSocketsTransport.cs(114,0): at Microsoft.AspNetCore.Sockets.Client.WebSocketsTransport.<ReceiveMessages>d__16.MoveNext()
[00:05:19] [xUnit.net 00:00:13.1278121]         --- End of stack trace from previous location where exception was thrown ---
[00:05:19] [xUnit.net 00:00:13.1278556]            at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
[00:05:19] [xUnit.net 00:00:13.1278975]            at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
[00:05:19] [xUnit.net 00:00:13.1279461]         C:\projects\signalr\src\Microsoft.AspNetCore.Sockets.Client.Http\WebSocketsTransport.cs(231,0): at Microsoft.AspNetCore.Sockets.Client.WebSocketsTransport.<StopAsync>d__19.MoveNext()
[00:05:19] [xUnit.net 00:00:13.1279867]         --- End of stack trace from previous location where exception was thrown ---
[00:05:19] [xUnit.net 00:00:13.1280255]            at System.IO.Pipelines.PipeCompletion.ThrowFailed()
[00:05:19] [xUnit.net 00:00:13.1280637]            at System.IO.Pipelines.Pipe.GetResult(ReadResult& result)
[00:05:19] [xUnit.net 00:00:13.1281065]            at System.IO.Pipelines.Pipe.System.Threading.IAwaiter<System.IO.Pipelines.ReadResult>.GetResult()
[00:05:19] [xUnit.net 00:00:13.1281520]         C:\projects\signalr\src\Microsoft.AspNetCore.Sockets.Client.Http\HttpConnection.cs(390,0): at Microsoft.AspNetCore.Sockets.Client.HttpConnection.<ReceiveAsync>d__50.MoveNext()
[00:05:19] [xUnit.net 00:00:13.1281915]         --- End of stack trace from previous location where exception was thrown ---
[00:05:19] [xUnit.net 00:00:13.1282319]            at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
[00:05:19] [xUnit.net 00:00:13.1282800]            at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
[00:05:19] [xUnit.net 00:00:13.1283278]         C:\projects\signalr\test\Microsoft.AspNetCore.SignalR.Tests.Utils\TaskExtensions.cs(0,0): at System.Threading.Tasks.TaskExtensions.<OrTimeout>d__4`1.MoveNext()
[00:05:19] [xUnit.net 00:00:13.1283681]         --- End of stack trace from previous location where exception was thrown ---
[00:05:19] [xUnit.net 00:00:13.1284087]            at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
[00:05:19] [xUnit.net 00:00:13.1284523]            at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
[00:05:19] [xUnit.net 00:00:13.1284914]            at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd(Task task)
[00:05:19] [xUnit.net 00:00:13.1285406]         C:\projects\signalr\test\Microsoft.AspNetCore.SignalR.Client.FunctionalTests\HubConnectionTests.cs(282,0): at Microsoft.AspNetCore.SignalR.Client.FunctionalTests.HubConnectionTests.<InvokeNonExistantClientMethodFromServer>d__8.MoveNext()
```

I still haven't found a great way to share this code (maybe a shared file with stub methods for the logs).
