### PR TITLE
Use Threadpool for pipe scheduler

### DIFF
--- a/src/Microsoft.AspNetCore.Sockets.Http/HttpConnectionDispatcher.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Http/HttpConnectionDispatcher.cs
@@ -517,8 +517,8 @@ namespace Microsoft.AspNetCore.Sockets
 
         private DefaultConnectionContext CreateConnectionInternal(HttpSocketOptions options)
         {
-            var transportPipeOptions = new PipeOptions(pauseWriterThreshold: options.TransportMaxBufferSize, resumeWriterThreshold: options.TransportMaxBufferSize / 2);
-            var appPipeOptions = new PipeOptions(pauseWriterThreshold: options.ApplicationMaxBufferSize, resumeWriterThreshold: options.ApplicationMaxBufferSize / 2);
+            var transportPipeOptions = new PipeOptions(pauseWriterThreshold: options.TransportMaxBufferSize, resumeWriterThreshold: options.TransportMaxBufferSize / 2, readerScheduler: PipeScheduler.ThreadPool);
+            var appPipeOptions = new PipeOptions(pauseWriterThreshold: options.ApplicationMaxBufferSize, resumeWriterThreshold: options.ApplicationMaxBufferSize / 2, readerScheduler: PipeScheduler.ThreadPool);
             return _manager.CreateConnection(transportPipeOptions, appPipeOptions);
         }
 


### PR DESCRIPTION
Reasoning: We used to write the `HubMessage` to a channel and there would be a thread reading from the channel and doing the serialization and communication with the transport. Now we write directly to the transports pipe and serialize inline instead of dispatching to a thread, this causes severe perf regressions when sending to multiple connections.

Adding the ThreadPool scheduler brings some of the perf back