### PR TITLE
Update the TS Client Poll Timeout

### DIFF
--- a/client-ts/signalr/src/Transports.ts
+++ b/client-ts/signalr/src/Transports.ts
@@ -216,7 +216,7 @@ export class LongPollingTransport implements ITransport {
         const pollOptions: HttpRequest = {
             abortSignal: this.pollAbort.signal,
             headers: new Map<string, string>(),
-            timeout: 120000,
+            timeout: 90000,
         };
 
         if (transferMode === TransferMode.Binary) {


### PR DESCRIPTION
The timeout that we have in LongPollingOptions is 90s https://github.com/aspnet/SignalR/blob/e214d5cdfac12475f0d5c7a1b6a5e063a61870e1/src/Microsoft.AspNetCore.Sockets.Http/LongPollingOptions.cs#L9
This was based on CloudFlares 100 second timeout policy. 
Issue: https://github.com/aspnet/SignalR/issues/1357