### PR TITLE
Emit warnings after off is called

### DIFF
--- a/client-ts/signalr/src/HubConnection.ts
+++ b/client-ts/signalr/src/HubConnection.ts
@@ -267,6 +267,9 @@ export class HubConnection {
         const removeIdx = handlers.indexOf(method);
         if (removeIdx !== -1) {
             handlers.splice(removeIdx, 1);
+            if(handles.length === 0) {
+                handles.delete(methodName);
+            }
         }
     }
 

--- a/client-ts/signalr/src/HubConnection.ts
+++ b/client-ts/signalr/src/HubConnection.ts
@@ -267,7 +267,7 @@ export class HubConnection {
         const removeIdx = handlers.indexOf(method);
         if (removeIdx !== -1) {
             handlers.splice(removeIdx, 1);
-            if(handles.length === 0) {
+            if(handlers.length === 0) {
                 this.methods.delete(methodName);
             }
         }

--- a/client-ts/signalr/src/HubConnection.ts
+++ b/client-ts/signalr/src/HubConnection.ts
@@ -267,7 +267,7 @@ export class HubConnection {
         const removeIdx = handlers.indexOf(method);
         if (removeIdx !== -1) {
             handlers.splice(removeIdx, 1);
-            if(handlers.length === 0) {
+            if (handlers.length === 0) {
                 this.methods.delete(methodName);
             }
         }

--- a/client-ts/signalr/src/HubConnection.ts
+++ b/client-ts/signalr/src/HubConnection.ts
@@ -268,7 +268,7 @@ export class HubConnection {
         if (removeIdx !== -1) {
             handlers.splice(removeIdx, 1);
             if(handles.length === 0) {
-                handles.delete(methodName);
+                this.methods.delete(methodName);
             }
         }
     }


### PR DESCRIPTION
If a handler has been registered, and then gets unregistered, the key/methodname still exists in the map and signalr does not warn about a missing handler. Might be by design, but I like it this way.