### PR TITLE
Fix UMD module version of @aspnet/signalr-protocol-msgpack

### DIFF
--- a/client-ts/rollup-base.js
+++ b/client-ts/rollup-base.js
@@ -22,31 +22,13 @@ export default function(rootDir, moduleGlobals) {
             banner: "/* @license\r\n" +
                 " * Copyright (c) .NET Foundation. All rights reserved.\r\n" +
                 " * Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.\r\n" +
-                "*/",
+                " */",
             globals: moduleGlobals,
         },
-        external: function (m) {
-            let match = m.match(/node_modules/);
-            if (match) {
-                let moduleName = m.substring(match.index + "node_modules".length + 1);
-                let slashIndex = moduleName.indexOf('/');
-                if(slashIndex < 0) {
-                    slashIndex = moduleName.indexOf('\\');
-                }
-                moduleName = moduleName.substring(0, slashIndex);
 
-                if(polyfills.indexOf(moduleName) >= 0) {
-                    // This is a polyfill
-                    console.log(`Importing polyfill: ${m}`);
-                    return false;
-                }
-                else if(!allowed_externals.indexOf(moduleName)) {
-                    console.log(`WARNING: External module '${m}' in use.`);
-                }
-                return true;
-            }
-            return false;
-        },
+        // Mark everything in the dependencies list as external
+        external: Object.keys(pkg.dependencies || {}),
+
         plugins: [
             commonjs(),
             resolve({


### PR DESCRIPTION
The problem was that the `rollup` was injecting `require("../../node_modules/msgpack5/index.js")` into the UMD build. It looks like it **was** working when used as a browser `<script>` reference. It was only when used as an AMD module that it failed because of the broken `require`. There's a separate issue here which is that WebPack was choosing to use the `dist/browser` script instead of the `dist/cjs` script it's supposed to use. I'll file that issue for later, but as long as this change makes it work in `webpack` (which I will test before merging), then we can ship this and #1520 as `1.0.0-preview1-update1` of the respective packages.

TODO:
* [x] Verify this fixes webpack (and thus will Fix #1530)