### PR TITLE
Exclude utility project from test discovery

### DIFF
--- a/build/repo.props
+++ b/build/repo.props
@@ -9,6 +9,9 @@
     <ProjectsToPack Include="$(RepositoryRoot)client-ts\Microsoft.AspNetCore.SignalR.Client.TS\*.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ExcludeFromTest Include="$(RepositoryRoot)test\Microsoft.AspNetCore.SignalR.Tests.Utils\*.csproj" />
+  </ItemGroup>
   <PropertyGroup>
     <!-- These properties are use by the automation that updates dependencies.props -->
     <LineupPackageId>Internal.AspNetCore.Universe.Lineup</LineupPackageId>


### PR DESCRIPTION
This is the same thing we do [here](https://github.com/aspnet/Mvc/blob/dev/build/repo.props#L9) to prevent this message:
`No test is available in C:\b\w\ea5b9663d62c5e38\test\Microsoft.AspNetCore.SignalR.Tests.Utils\bin\Release\netcoreapp2.1\Microsoft.AspNetCore.SignalR.Tests.Utils.dll. Make sure that test discoverer & executors are registered and platform & framework version settings are appropriate and try again.`