### PR TITLE
Detect Successful Start in LongPolling and SSE

### DIFF
--- a/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionContext.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionContext.cs
@@ -137,7 +137,10 @@ namespace Microsoft.AspNetCore.SignalR
             {
                 using (var cts = new CancellationTokenSource())
                 {
-                    cts.CancelAfter(timeout);
+                    if (!System.Diagnostics.Debugger.IsAttached)
+                    {
+                        cts.CancelAfter(timeout);
+                    }
 
                     while (true)
                     {

--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/LongPollingTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/LongPollingTransport.cs
@@ -52,7 +52,7 @@ namespace Microsoft.AspNetCore.Sockets.Client
             Log.StartTransport(_logger, transferFormat);
 
             // Start sending and polling (ask for binary if the server supports it)
-            var startTcs = new TaskCompletionSource<object>();
+            var startTcs = new TaskCompletionSource<object>(TaskContinuationOptions.RunContinuationsAsynchronously);
             _poller = Poll(url, startTcs, _transportCts.Token);
             _sender = SendUtils.SendMessages(url, _application, _httpClient, _httpOptions, _transportCts, _logger);
 

--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/LongPollingTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/LongPollingTransport.cs
@@ -24,7 +24,6 @@ namespace Microsoft.AspNetCore.Sockets.Client
         private Task _sender;
         private Task _poller;
         private HttpResponseMessage _response;
-
         private readonly CancellationTokenSource _transportCts = new CancellationTokenSource();
 
         public Task Running { get; private set; } = Task.CompletedTask;
@@ -123,11 +122,7 @@ namespace Microsoft.AspNetCore.Sockets.Client
                         Log.ReceivedMessages(_logger);
 
                         var stream = new PipeWriterStream(_application.Output);
-                        try
-                        {
-                            await _response.Content.CopyToAsync(stream);
-                        }
-                        catch { /*First request*/};
+                        await _response.Content.CopyToAsync(stream);
                         await _application.Output.FlushAsync();
                     }
                 }

--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/LongPollingTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/LongPollingTransport.cs
@@ -86,7 +86,7 @@ namespace Microsoft.AspNetCore.Sockets.Client
             }
         }
 
-        private async Task Poll(Uri pollUrl, TaskCompletionSource<object> startTcs,CancellationToken cancellationToken)
+        private async Task Poll(Uri pollUrl, TaskCompletionSource<object> startTcs, CancellationToken cancellationToken)
         {
             Log.StartReceive(_logger);
             try

--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/LongPollingTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/LongPollingTransport.cs
@@ -92,11 +92,11 @@ namespace Microsoft.AspNetCore.Sockets.Client
                 {
                     var request = new HttpRequestMessage(HttpMethod.Get, pollUrl);
                     SendUtils.PrepareHttpRequest(request, _httpOptions);
-                    HttpResponseMessage _response;
+                    HttpResponseMessage response;
 
                     try
                     {
-                        _response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+                        response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
                     }
                     catch (OperationCanceledException)
                     {
@@ -106,10 +106,10 @@ namespace Microsoft.AspNetCore.Sockets.Client
                         continue;
                     }
 
-                    _response.EnsureSuccessStatusCode();
+                    response.EnsureSuccessStatusCode();
                     startTcs.TrySetResult(null);
 
-                    if (_response.StatusCode == HttpStatusCode.NoContent || cancellationToken.IsCancellationRequested)
+                    if (response.StatusCode == HttpStatusCode.NoContent || cancellationToken.IsCancellationRequested)
                     {
                         Log.ClosingConnection(_logger);
 
@@ -121,9 +121,9 @@ namespace Microsoft.AspNetCore.Sockets.Client
                         Log.ReceivedMessages(_logger);
 
                         var stream = new PipeWriterStream(_application.Output);
-                        using (cancellationToken.Register(response => { ((HttpResponseMessage)response).Dispose(); }, _response))
+                        using (cancellationToken.Register(res => { ((HttpResponseMessage)res).Dispose(); }, response))
                         {
-                            await _response.Content.CopyToAsync(stream);
+                            await response.Content.CopyToAsync(stream);
                         }
                         await _application.Output.FlushAsync();
                     }

--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/ServerSentEventsTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/ServerSentEventsTransport.cs
@@ -77,10 +77,11 @@ namespace Microsoft.AspNetCore.Sockets.Client
             var request = new HttpRequestMessage(HttpMethod.Get, url);
             SendUtils.PrepareHttpRequest(request, _httpOptions);
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/event-stream"));
-            var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
 
+            HttpResponseMessage response;
             try
             {
+                response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
                 response.EnsureSuccessStatusCode();
                 tcs.TrySetResult(null);
             }

--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/ServerSentEventsTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/ServerSentEventsTransport.cs
@@ -50,7 +50,7 @@ namespace Microsoft.AspNetCore.Sockets.Client
                 throw new ArgumentException($"The '{transferFormat}' transfer format is not supported by this transport.", nameof(transferFormat));
             }
 
-            var startTcs = new TaskCompletionSource<object>();
+            var startTcs = new TaskCompletionSource<object>(TaskContinuationOptions.RunContinuationsAsynchronously);
             _application = application;
 
             Log.StartTransport(_logger, transferFormat);

--- a/src/Microsoft.AspNetCore.Sockets.Http/HttpConnectionDispatcher.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Http/HttpConnectionDispatcher.cs
@@ -222,11 +222,16 @@ namespace Microsoft.AspNetCore.Sockets
                     // Dispose these tokens when the request is over
                     context.Response.RegisterForDispose(timeoutSource);
                     context.Response.RegisterForDispose(tokenSource);
-
                     var longPolling = new LongPollingTransport(timeoutSource.Token, connection.Application.Input, connection.ConnectionId, _loggerFactory, isFirstRequest);
-
-                    // Start the transport
-                    connection.TransportTask = longPolling.ProcessRequestAsync(context, tokenSource.Token);
+                    if (isFirstRequest)
+                    {
+                        connection.TransportTask = longPolling.ProcessFirstRequestAsync(context, tokenSource.Token);
+                    }
+                    else
+                    {
+                        // Start the transport
+                        connection.TransportTask = longPolling.ProcessRequestAsync(context, tokenSource.Token);
+                    }
 
                     // Start the timeout after we return from creating the transport task
                     timeoutSource.CancelAfter(options.LongPolling.PollTimeout);

--- a/src/Microsoft.AspNetCore.Sockets.Http/HttpConnectionDispatcher.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Http/HttpConnectionDispatcher.cs
@@ -222,7 +222,7 @@ namespace Microsoft.AspNetCore.Sockets
                     // Dispose these tokens when the request is over
                     context.Response.RegisterForDispose(timeoutSource);
                     context.Response.RegisterForDispose(tokenSource);
-                    var longPolling = new LongPollingTransport(timeoutSource.Token, connection.Application.Input, connection.ConnectionId, _loggerFactory, isFirstRequest);
+                    var longPolling = new LongPollingTransport(timeoutSource.Token, connection.Application.Input, connection.ConnectionId, _loggerFactory);
                     if (isFirstRequest)
                     {
                         connection.TransportTask = longPolling.ProcessFirstRequestAsync(context, tokenSource.Token);

--- a/src/Microsoft.AspNetCore.Sockets.Http/HttpConnectionDispatcher.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Http/HttpConnectionDispatcher.cs
@@ -176,6 +176,7 @@ namespace Microsoft.AspNetCore.Sockets
                         return;
                     }
 
+                    var isFirstRequest = false;
                     if (connection.Status == DefaultConnectionContext.ConnectionStatus.Active)
                     {
                         var existing = connection.GetHttpContext();
@@ -199,6 +200,8 @@ namespace Microsoft.AspNetCore.Sockets
                     // Raise OnConnected for new connections only since polls happen all the time
                     if (connection.ApplicationTask == null)
                     {
+                        isFirstRequest = true;
+
                         Log.EstablishedConnection(_logger);
 
                         connection.Items[ConnectionMetadataNames.Transport] = TransportType.LongPolling;
@@ -220,7 +223,7 @@ namespace Microsoft.AspNetCore.Sockets
                     context.Response.RegisterForDispose(timeoutSource);
                     context.Response.RegisterForDispose(tokenSource);
 
-                    var longPolling = new LongPollingTransport(timeoutSource.Token, connection.Application.Input, connection.ConnectionId, _loggerFactory);
+                    var longPolling = new LongPollingTransport(timeoutSource.Token, connection.Application.Input, connection.ConnectionId, _loggerFactory, isFirstRequest);
 
                     // Start the transport
                     connection.TransportTask = longPolling.ProcessRequestAsync(context, tokenSource.Token);

--- a/src/Microsoft.AspNetCore.Sockets.Http/Internal/Transports/LongPollingTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Http/Internal/Transports/LongPollingTransport.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNetCore.Sockets.Internal.Transports
         private readonly CancellationToken _timeoutToken;
         private readonly string _connectionId;
 
-        public LongPollingTransport(CancellationToken timeoutToken, PipeReader application, string connectionId, ILoggerFactory loggerFactory, bool isFirstRequest = false)
+        public LongPollingTransport(CancellationToken timeoutToken, PipeReader application, string connectionId, ILoggerFactory loggerFactory)
         {
             _timeoutToken = timeoutToken;
             _application = application;

--- a/src/Microsoft.AspNetCore.Sockets.Http/Internal/Transports/LongPollingTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Http/Internal/Transports/LongPollingTransport.cs
@@ -46,6 +46,7 @@ namespace Microsoft.AspNetCore.Sockets.Internal.Transports
                 {
                     // We can't let the exception escape because we've already written headers, so
                     // ASP.NET Core will just terminate the HTTP connection, which is bad.
+                    // The next poll will trigger the catch block below and throw.
                 }
 
                 var buffer = result.Buffer;

--- a/src/Microsoft.AspNetCore.Sockets.Http/Internal/Transports/LongPollingTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Http/Internal/Transports/LongPollingTransport.cs
@@ -29,7 +29,7 @@ namespace Microsoft.AspNetCore.Sockets.Internal.Transports
         public async Task ProcessFirstRequestAsync(HttpContext context, CancellationToken token)
         {
             if (!token.IsCancellationRequested)
-            {
+            { 
                 try
                 {
                     await context.Response.Body.FlushAsync();
@@ -78,7 +78,6 @@ namespace Microsoft.AspNetCore.Sockets.Internal.Transports
         {
             try
             {
-
                 var result = await _application.ReadAsync(token);
                 var buffer = result.Buffer;
 

--- a/src/Microsoft.AspNetCore.Sockets.Http/Internal/Transports/LongPollingTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Http/Internal/Transports/LongPollingTransport.cs
@@ -37,7 +37,7 @@ namespace Microsoft.AspNetCore.Sockets.Internal.Transports
                 {
                     result = await _application.ReadAsync(token);
                 }
-                catch (Exception)
+                catch
                 {
                     // We can't let the exception escape because we've already written headers, so
                     // ASP.NET Core will just terminate the HTTP connection, which is bad.

--- a/src/Microsoft.AspNetCore.Sockets.Http/Internal/Transports/LongPollingTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Http/Internal/Transports/LongPollingTransport.cs
@@ -99,15 +99,12 @@ namespace Microsoft.AspNetCore.Sockets.Internal.Transports
                     context.Response.ContentType = "text/plain";
                     context.Response.StatusCode = StatusCodes.Status200OK;
                 }
-                else
+                else if (!_isFirstRequest)
                 {
                     // Case 3
-                    if (!_isFirstRequest)
-                    {
-                        Log.LongPolling204(_logger);
-                        context.Response.ContentType = "text/plain";
-                        context.Response.StatusCode = StatusCodes.Status204NoContent;
-                    }
+                    Log.LongPolling204(_logger);
+                    context.Response.ContentType = "text/plain";
+                    context.Response.StatusCode = StatusCodes.Status204NoContent;
                 }
             }
             catch (Exception ex)

--- a/src/Microsoft.AspNetCore.Sockets.Http/Internal/Transports/LongPollingTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Http/Internal/Transports/LongPollingTransport.cs
@@ -82,11 +82,6 @@ namespace Microsoft.AspNetCore.Sockets.Internal.Transports
                 // we still have to send a 200 because the headers have already been flushed.
                 if (buffer.IsEmpty && result.IsCompleted)
                 {
-                    // Complete the ReadAsync by indicating we haven't processed any data yet
-                    // (of course, there is no data because the buffer is empty, but we have to 
-                    // call AdvanceTo after every ReadAsync even if we don't have any data)
-                    _application.AdvanceTo(buffer.Start);
-
                     Log.LongPolling204(_logger);
                     context.Response.ContentType = "text/plain";
                     context.Response.StatusCode = StatusCodes.Status204NoContent;

--- a/src/Microsoft.AspNetCore.Sockets.Http/Internal/Transports/LongPollingTransport.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Http/Internal/Transports/LongPollingTransport.cs
@@ -85,7 +85,7 @@ namespace Microsoft.AspNetCore.Sockets.Internal.Transports
                     // Complete the ReadAsync by indicating we haven't processed any data yet
                     // (of course, there is no data because the buffer is empty, but we have to 
                     // call AdvanceTo after every ReadAsync even if we don't have any data)
-                    //_application.AdvanceTo(buffer.Start);
+                    _application.AdvanceTo(buffer.Start);
 
                     Log.LongPolling204(_logger);
                     context.Response.ContentType = "text/plain";

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.ConnectionLifecycle.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.ConnectionLifecycle.cs
@@ -237,17 +237,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
             {
                 using (StartLog(out var loggerFactory))
                 {
-                    var httpHandler = new TestHttpMessageHandler();
-
-                    var longPollResult = new TaskCompletionSource<HttpResponseMessage>();
-                    httpHandler.OnLongPoll(cancellationToken =>
-                    {
-                        cancellationToken.Register(() =>
-                        {
-                            longPollResult.TrySetResult(ResponseUtils.CreateResponse(HttpStatusCode.NoContent));
-                        });
-                        return longPollResult.Task;
-                    });
+                    var httpHandler = TestHttpMessageHandler.CreateDefault(handleSend:false);
 
                     httpHandler.OnSocketSend((data, _) =>
                     {

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.ConnectionLifecycle.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.ConnectionLifecycle.cs
@@ -363,7 +363,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
             [Fact]
             public async Task TransportIsStoppedWhenConnectionIsStopped()
             {
-                var testHttpHandler = new TestHttpMessageHandler();
+                var testHttpHandler = TestHttpMessageHandler.CreateDefault();
 
                 // Just keep returning data when polled
                 testHttpHandler.OnLongPoll(_ => ResponseUtils.CreateResponse(HttpStatusCode.OK));

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.ConnectionLifecycle.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.ConnectionLifecycle.cs
@@ -237,7 +237,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
             {
                 using (StartLog(out var loggerFactory))
                 {
-                    var httpHandler = TestHttpMessageHandler.CreateDefault(handleSend:false);
+                    var httpHandler = TestHttpMessageHandler.CreateDefault(handleSend: false);
 
                     httpHandler.OnSocketSend((data, _) =>
                     {

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.Negotiate.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.Negotiate.cs
@@ -60,7 +60,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                 var testHttpHandler = new TestHttpMessageHandler(autoNegotiate: false);
 
                 var negotiateUrlTcs = new TaskCompletionSource<string>();
-                testHttpHandler.OnLongPoll(cancellationToken => ResponseUtils.CreateResponse(HttpStatusCode.NoContent));
+                testHttpHandler.OnLongPoll(cancellationToken => ResponseUtils.CreateResponse(HttpStatusCode.OK));
                 testHttpHandler.OnNegotiate((request, cancellationToken) =>
                 {
                     negotiateUrlTcs.TrySetResult(request.RequestUri.ToString());

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.SendAsync.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.SendAsync.cs
@@ -21,12 +21,11 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
             {
                 var data = new byte[] { 1, 1, 2, 3, 5, 8 };
 
-                var testHttpHandler = new TestHttpMessageHandler();
+                var testHttpHandler = TestHttpMessageHandler.CreateDefault(handleSend: false);
 
                 var sendTcs = new TaskCompletionSource<byte[]>();
                 var longPollTcs = new TaskCompletionSource<HttpResponseMessage>();
 
-                testHttpHandler.OnLongPoll(cancellationToken => longPollTcs.Task);
 
                 testHttpHandler.OnSocketSend((buf, cancellationToken) =>
                 {
@@ -96,16 +95,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
             [Fact]
             public async Task ExceptionOnSendAsyncClosesWithError()
             {
-                var testHttpHandler = new TestHttpMessageHandler();
-
-                var longPollTcs = new TaskCompletionSource<HttpResponseMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
-
-                testHttpHandler.OnLongPoll(cancellationToken =>
-                {
-                    cancellationToken.Register(() => longPollTcs.TrySetResult(null));
-
-                    return longPollTcs.Task;
-                });
+                var testHttpHandler = TestHttpMessageHandler.CreateDefault(handleSend:false);
 
                 testHttpHandler.OnSocketSend((buf, cancellationToken) =>
                 {

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.SendAsync.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.SendAsync.cs
@@ -95,7 +95,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
             [Fact]
             public async Task ExceptionOnSendAsyncClosesWithError()
             {
-                var testHttpHandler = TestHttpMessageHandler.CreateDefault(handleSend:false);
+                var testHttpHandler = TestHttpMessageHandler.CreateDefault(handleSend: false);
 
                 testHttpHandler.OnSocketSend((buf, cancellationToken) =>
                 {

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.cs
@@ -132,7 +132,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
         [Fact]
         public async Task HttpOptionsSetOntoHttpClientHandler()
         {
-            var testHttpHandler = new TestHttpMessageHandler();
+            var testHttpHandler = TestHttpMessageHandler.CreateDefault();
 
             var negotiateUrlTcs = new TaskCompletionSource<string>();
             testHttpHandler.OnNegotiate((request, cancellationToken) =>

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/LongPollingTransportTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/LongPollingTransportTests.cs
@@ -149,7 +149,7 @@ namespace Microsoft.AspNetCore.Client.Tests
         }
 
         [Fact]
-        public async Task LongPollingTransportStopsWhenPollRequestFails()
+        public async Task LongPollingTransportFailsToStartWhenPollRequestFails()
         {
             var mockHttpHandler = new Mock<HttpMessageHandler>();
             mockHttpHandler.Protected()
@@ -166,17 +166,11 @@ namespace Microsoft.AspNetCore.Client.Tests
                 try
                 {
                     var pair = DuplexPipe.CreateConnectionPair(PipeOptions.Default, PipeOptions.Default);
-                    await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), pair.Application, TransferFormat.Binary, connection: new TestConnection());
 
                     var exception =
                         await Assert.ThrowsAsync<HttpRequestException>(async () =>
                         {
-                            async Task ReadAsync()
-                            {
-                                await pair.Transport.Input.ReadAsync();
-                            }
-
-                            await ReadAsync().OrTimeout();
+                            await longPollingTransport.StartAsync(new Uri("http://fakeuri.org"), pair.Application, TransferFormat.Binary, connection: new TestConnection()).OrTimeout();
                         });
                     Assert.Contains(" 500 ", exception.Message);
                 }

--- a/test/Microsoft.AspNetCore.Sockets.Tests/HttpConnectionDispatcherTests.cs
+++ b/test/Microsoft.AspNetCore.Sockets.Tests/HttpConnectionDispatcherTests.cs
@@ -513,7 +513,7 @@ namespace Microsoft.AspNetCore.Sockets.Tests
                 builder.UseEndPoint<ImmediatelyCompleteEndPoint>();
                 var app = builder.Build();
 
-                // We need two requests because te first just establishes the transport.
+                // We need two requests because the first just establishes the transport.
                 await dispatcher.ExecuteAsync(context, new HttpSocketOptions(), app);
 
                 Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);

--- a/test/Microsoft.AspNetCore.Sockets.Tests/HttpConnectionDispatcherTests.cs
+++ b/test/Microsoft.AspNetCore.Sockets.Tests/HttpConnectionDispatcherTests.cs
@@ -512,6 +512,8 @@ namespace Microsoft.AspNetCore.Sockets.Tests
                 var builder = new ConnectionBuilder(services.BuildServiceProvider());
                 builder.UseEndPoint<ImmediatelyCompleteEndPoint>();
                 var app = builder.Build();
+
+                // We need two requests because te first just establishes the transport.
                 await dispatcher.ExecuteAsync(context, new HttpSocketOptions(), app);
 
                 Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
@@ -786,10 +788,9 @@ namespace Microsoft.AspNetCore.Sockets.Tests
 
                 await connection.Application.Output.WriteAsync(buffer);
 
+                await task;
 
                 Assert.Equal(StatusCodes.Status204NoContent, context.Response.StatusCode);
-
-                await task;
 
                 bool exists = manager.TryGetConnection(connection.ConnectionId, out _);
                 Assert.False(exists);


### PR DESCRIPTION
So this is hacky and doesn't work yet but I wanted to get some feedback.
Currently storing a first request flag in the HttpContext which is probably 👎 

Basically wanted some help with the LongPolling transport code. Not setting the ContentLength or the Status code if flush has already been called.