### PR TITLE
Add SignalR marker service

### DIFF
--- a/src/Microsoft.AspNetCore.SignalR/SignalRAppBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.SignalR/SignalRAppBuilderExtensions.cs
@@ -14,7 +14,8 @@ namespace Microsoft.AspNetCore.Builder
             var marker = app.ApplicationServices.GetService(typeof(SignalRMarkerService));
             if (marker == null)
             {
-                throw new InvalidOperationException("The SignalR service needs to be registered");
+                throw new InvalidOperationException("Unable to find the SignalR service. Please add it by " +
+                    "calling 'IServiceCollection.AddSignalR()'");
             }
 
             app.UseSockets(routes =>

--- a/src/Microsoft.AspNetCore.SignalR/SignalRAppBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.SignalR/SignalRAppBuilderExtensions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.Builder
             if (marker == null)
             {
                 throw new InvalidOperationException("Unable to find the SignalR service. Please add it by " +
-                    "calling 'IServiceCollection.AddSignalR()'");
+                    "calling 'IServiceCollection.AddSignalR()'.");
             }
 
             app.UseSockets(routes =>

--- a/src/Microsoft.AspNetCore.SignalR/SignalRAppBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.SignalR/SignalRAppBuilderExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNetCore.Builder
 {
@@ -10,6 +11,12 @@ namespace Microsoft.AspNetCore.Builder
     {
         public static IApplicationBuilder UseSignalR(this IApplicationBuilder app, Action<HubRouteBuilder> configure)
         {
+            var marker = app.ApplicationServices.GetService(typeof(SignalRMarkerService));
+            if (marker == null)
+            {
+                throw new InvalidOperationException("The SignalR service needs to be registered");
+            }
+
             app.UseSockets(routes =>
             {
                 configure(new HubRouteBuilder(routes));

--- a/src/Microsoft.AspNetCore.SignalR/SignalRDependencyInjectionExtensions.cs
+++ b/src/Microsoft.AspNetCore.SignalR/SignalRDependencyInjectionExtensions.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Extensions.DependencyInjection
         public static ISignalRBuilder AddSignalR(this IServiceCollection services)
         {
             services.AddSockets();
+            services.AddSingleton<SignalRMarkerService>();
             services.AddSingleton<IConfigureOptions<HubOptions>, HubOptionsSetup>();
             return services.AddSignalRCore()
                 .AddJsonProtocol();

--- a/src/Microsoft.AspNetCore.SignalR/SignalRMarkerService.cs
+++ b/src/Microsoft.AspNetCore.SignalR/SignalRMarkerService.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.Extensions.DependencyInjection
 {
-    class SignalRMarkerService
+    internal class SignalRMarkerService
     {
     }
 }

--- a/src/Microsoft.AspNetCore.SignalR/SignalRMarkerService.cs
+++ b/src/Microsoft.AspNetCore.SignalR/SignalRMarkerService.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    class SignalRMarkerService
+    {
+    }
+}

--- a/test/Microsoft.AspNetCore.SignalR.Tests/MapSignalRTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/MapSignalRTests.cs
@@ -26,15 +26,22 @@ namespace Microsoft.AspNetCore.SignalR.Tests
         [Fact]
         public void NotAddingSignalRServiceThrows()
         {
-            var ex = Assert.Throws<InvalidOperationException>(() =>
+            Exception ex = null;
+            var t = new WebHostBuilder()
+            .UseKestrel()
+            .Configure(app =>
             {
-                using (var builder = BuildWebHostWithOutSignalR(options => options.MapHub<AuthHub>("/overloads")))
-                {
-                    builder.Start();
-                }
-            });
+                ex = Assert.Throws<InvalidOperationException>(() => {
+                    app.UseSignalR(options =>
+                    {
+                        options.MapHub<AuthHub>("/overloads");
+                    });
+                });
 
-            Assert.Equal("The SignalR service needs to be registered", ex.Message);
+                Assert.Equal("Unable to find the SignalR service. Please add it by calling 'IServiceCollection.AddSignalR()'.", ex.Message);
+            })
+            .Build();
+
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.SignalR.Tests/MapSignalRTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/MapSignalRTests.cs
@@ -24,6 +24,20 @@ namespace Microsoft.AspNetCore.SignalR.Tests
         }
 
         [Fact]
+        public void NotAddingSignalRServiceThrows()
+        {
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+            {
+                using (var builder = BuildWebHostWithOutSignalR(options => options.MapHub<AuthHub>("/overloads")))
+                {
+                    builder.Start();
+                }
+            });
+
+            Assert.Equal("The SignalR service needs to be registered", ex.Message);
+        }
+
+        [Fact]
         public void MapHubFindsAuthAttributeOnHub()
         {
             var authCount = 0;
@@ -101,6 +115,17 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                 {
                     services.AddSignalR();
                 })
+                .Configure(app =>
+                {
+                    app.UseSignalR(options => configure(options));
+                })
+                .Build();
+        }
+
+        private IWebHost BuildWebHostWithOutSignalR(Action<HubRouteBuilder> configure)
+        {
+            return new WebHostBuilder()
+                .UseKestrel()
                 .Configure(app =>
                 {
                     app.UseSignalR(options => configure(options));

--- a/test/Microsoft.AspNetCore.SignalR.Tests/MapSignalRTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/MapSignalRTests.cs
@@ -26,12 +26,11 @@ namespace Microsoft.AspNetCore.SignalR.Tests
         [Fact]
         public void NotAddingSignalRServiceThrows()
         {
-            Exception ex = null;
             var t = new WebHostBuilder()
             .UseKestrel()
             .Configure(app =>
             {
-                ex = Assert.Throws<InvalidOperationException>(() => {
+                var ex = Assert.Throws<InvalidOperationException>(() => {
                     app.UseSignalR(options =>
                     {
                         options.MapHub<AuthHub>("/overloads");
@@ -122,17 +121,6 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                 {
                     services.AddSignalR();
                 })
-                .Configure(app =>
-                {
-                    app.UseSignalR(options => configure(options));
-                })
-                .Build();
-        }
-
-        private IWebHost BuildWebHostWithOutSignalR(Action<HubRouteBuilder> configure)
-        {
-            return new WebHostBuilder()
-                .UseKestrel()
                 .Configure(app =>
                 {
                     app.UseSignalR(options => configure(options));


### PR DESCRIPTION
Branches got messed up. 
This includes the changes requested from the previous PR
Adding a SignalR marker service to endure that the service has been added.
Issue: #1562