### PR TITLE
Fix #1580 by correcting README sample

### DIFF
--- a/client-ts/signalr-protocol-msgpack/README.md
+++ b/client-ts/signalr-protocol-msgpack/README.md
@@ -16,7 +16,7 @@ To use the client in a browser, copy `*.js` files from the `dist/browser` folder
 
 ```JavaScript
 let connection = new signalR.HubConnection('/chat', {
-    protocol: new signalR.protocol.msgpack.MessagePackHubProtocol()
+    protocol: new signalR.protocols.msgpack.MessagePackHubProtocol()
 });
 
 connection.on('send', data => {


### PR DESCRIPTION
Corrects the README sample in @aspnet/signalr-protocol-msgpack. The package is **intentionally** named `-protocol-` and the UMD module is also **intentionally** `.protocols.` (with an `s`). We may want to review that as it could be a source of confusion, but it has some prior art in NodeJS extensibility (specifically Babel uses some similar patterns: https://www.npmjs.com/package/babel-preset-env). We don't do the thing Babel does (yet) where we auto-`require` plugins though so it may not be necessary.

Regardless of that decision, the README should... y'know... have accurate instructions :)

Fixes #1580 