### PR TITLE
add AddRedis overload that takes connection string

### DIFF
--- a/src/Microsoft.AspNetCore.SignalR.Redis/RedisDependencyInjectionExtensions.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Redis/RedisDependencyInjectionExtensions.cs
@@ -4,6 +4,7 @@
 using System;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.AspNetCore.SignalR.Redis;
+using StackExchange.Redis;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -12,6 +13,14 @@ namespace Microsoft.Extensions.DependencyInjection
         public static ISignalRBuilder AddRedis(this ISignalRBuilder builder)
         {
             return AddRedis(builder, o => { });
+        }
+
+        public static ISignalRBuilder AddRedis(this ISignalRBuilder builder, string redisConnectionString)
+        {
+            return AddRedis(builder, o =>
+            {
+                o.Options = ConfigurationOptions.Parse(redisConnectionString);
+            });
         }
 
         public static ISignalRBuilder AddRedis(this ISignalRBuilder builder, Action<RedisOptions> configure)

--- a/test/Microsoft.AspNetCore.SignalR.Redis.Tests/RedisDependencyInjectionExtensionsTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Redis.Tests/RedisDependencyInjectionExtensionsTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Net;

--- a/test/Microsoft.AspNetCore.SignalR.Redis.Tests/RedisDependencyInjectionExtensionsTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Redis.Tests/RedisDependencyInjectionExtensionsTests.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Text;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Microsoft.AspNetCore.SignalR.Redis.Tests
+{
+    public class RedisDependencyInjectionExtensionsTests
+    {
+        // No need to go too deep with these tests, or we're just testing StackExchange.Redis again :). It's the one doing the parsing.
+        [Theory]
+        [InlineData("testredis.example.com", "testredis.example.com", 0, null, false)]
+        [InlineData("testredis.example.com:6380,ssl=True", "testredis.example.com", 6380, null, true)]
+        [InlineData("testredis.example.com:6380,password=hunter2,ssl=True", "testredis.example.com", 6380, "hunter2", true)]
+        public void AddRedisWithConnectionStringProperlyParsesOptions(string connectionString, string host, int port, string password, bool useSsl)
+        {
+            var services = new ServiceCollection();
+            services.AddSignalR().AddRedis(connectionString);
+            var provider = services.BuildServiceProvider();
+
+            var options = provider.GetService<IOptions<RedisOptions>>();
+            Assert.NotNull(options.Value);
+            Assert.NotNull(options.Value.Options);
+            Assert.Equal(password, options.Value.Options.Password);
+            Assert.Collection(options.Value.Options.EndPoints,
+                ep =>
+                {
+                    var dnsep = Assert.IsType<DnsEndPoint>(ep);
+                    Assert.Equal(host, dnsep.Host);
+                    Assert.Equal(port, dnsep.Port);
+                });
+            Assert.Equal(useSsl, options.Value.Options.Ssl);
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.SignalR.Redis.Tests/RedisDependencyInjectionExtensionsTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Redis.Tests/RedisDependencyInjectionExtensionsTests.cs
@@ -29,11 +29,11 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
             Assert.NotNull(options.Value.Options);
             Assert.Equal(password, options.Value.Options.Password);
             Assert.Collection(options.Value.Options.EndPoints,
-                ep =>
+                endpoint =>
                 {
-                    var dnsep = Assert.IsType<DnsEndPoint>(ep);
-                    Assert.Equal(host, dnsep.Host);
-                    Assert.Equal(port, dnsep.Port);
+                    var dnsEndpoint = Assert.IsType<DnsEndPoint>(endpoint);
+                    Assert.Equal(host, dnsEndpoint.Host);
+                    Assert.Equal(port, dnsEndpoint.Port);
                 });
             Assert.Equal(useSsl, options.Value.Options.Ssl);
         }


### PR DESCRIPTION
This has been annoying me for a while, and I kept forgetting to file it so I just decided to spend the 10 mins fixing it :). It's a pain to add Azure Redis as a redis cache because it gives you this convenient connection string and we don't provide an easy way to just ~~paste it in~~ read it in from config.