### PR TITLE
[WIP] change our default casing for serialization to include dictionary keys

### DIFF
--- a/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/JsonHubProtocol.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/JsonHubProtocol.cs
@@ -377,7 +377,16 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
 
         internal static JsonSerializerSettings CreateDefaultSerializerSettings()
         {
-            return new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver() };
+            return new JsonSerializerSettings
+            {
+                ContractResolver = new DefaultContractResolver()
+                {
+                    NamingStrategy = new CamelCaseNamingStrategy()
+                    {
+                        ProcessDictionaryKeys = true
+                    }
+                }
+            };
         }
     }
 }


### PR DESCRIPTION
Fixes #1550

I didn't have a chance to write the tests before I had to leave for the evening but wanted to start a discussion on this :). Tests will be in RedisHubLifetimeManagerTests and will consist of calling SendAllAsync with a PascalCased object and ensuring it becomes camelCased.

It's not a totally benign change since it means that if I write the following:

```csharp
Clients.All.SendAsync("SomeMethod", new Dictionary<string, string>() {
  { "FooBar", "Baz" }
});
```

It will be serialized as:

```json
{
  "fooBar": "Baz"
}
```

That may not be desirable, since I gave you a dictionary with strings (indicating I knew what I wanted to serialize).

I think the fact that it's configurable makes up for that though. Other fixes for this are a little hairy. We could serialize using the payload serializer before putting the value in Redis, but we don't easily have access to that in the lifetime manager today since we don't know the protocols in use.