### PR TITLE
fix package-lock.json files

### DIFF
--- a/client-ts/signalr-protocol-msgpack/package-lock.json
+++ b/client-ts/signalr-protocol-msgpack/package-lock.json
@@ -1,18 +1,9 @@
 {
   "name": "@aspnet/signalr-protocol-msgpack",
-  "version": "1.0.0-preview1-t000",
+  "version": "1.0.0-preview2-t000",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@aspnet/signalr": {
-      "version": "file:../signalr",
-      "dependencies": {
-        "es6-promise": {
-          "version": "4.2.2",
-          "bundled": true
-        }
-      }
-    },
     "@types/bl": {
       "version": "0.8.31",
       "resolved": "https://registry.npmjs.org/@types/bl/-/bl-0.8.31.tgz",

--- a/client-ts/signalr/package-lock.json
+++ b/client-ts/signalr/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@aspnet/signalr",
-  "version": "1.0.0-preview1-t000",
+  "version": "1.0.0-preview2-t000",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
I'm just going to merge this right away because the build is **already** using these files (since they are regenerated during build). Just using a PR for recordkeeping-sake