### PR TITLE
fix the umd build of msgpack

### DIFF
--- a/client-ts/signalr-protocol-msgpack/rollup.config.js
+++ b/client-ts/signalr-protocol-msgpack/rollup.config.js
@@ -4,5 +4,6 @@
 import baseConfig from "../rollup-base"
 
 export default baseConfig(__dirname, {
-    msgpack5: "msgpack5"
+    msgpack5: "msgpack5",
+    "@aspnet/signalr": "signalR",
 });


### PR DESCRIPTION
This was breaking the SocketsSample. Unfortunately, the UMD build isn't what the functional tests test, so it wasn't caught by them.