### PR TITLE
Small optimizations

### DIFF
--- a/src/Common/PipeWriterStream.cs
+++ b/src/Common/PipeWriterStream.cs
@@ -67,7 +67,7 @@ namespace System.IO.Pipelines
         {
             _pipeWriter.Write(source.Span);
             _length += source.Length;
-            return new ValueTask(Task.CompletedTask);
+            return default;
         }
 #endif
     }

--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/Internal/StreamExtensions.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/Internal/StreamExtensions.cs
@@ -12,7 +12,9 @@ namespace System.IO.Pipelines
         {
             try
             {
-                await stream.CopyToAsync(writer, cancellationToken);
+                // REVIEW: Should we use the default buffer size here?
+                // 81920 is the default bufferSize, there is no stream.CopyToAsync overload that takes only a cancellationToken
+                await stream.CopyToAsync(new PipelineWriterStream(writer), bufferSize: 81920, cancellationToken: cancellationToken);
             }
             catch (Exception ex)
             {
@@ -20,19 +22,6 @@ namespace System.IO.Pipelines
                 return;
             }
             writer.Complete();
-        }
-
-        /// <summary>
-        /// Copies the content of a <see cref="Stream"/> into a <see cref="PipeWriter"/>.
-        /// </summary>
-        /// <param name="stream"></param>
-        /// <param name="writer"></param>
-        /// <param name="cancellationToken"></param>
-        /// <returns></returns>
-        private static Task CopyToAsync(this Stream stream, PipeWriter writer, CancellationToken cancellationToken = default)
-        {
-            // 81920 is the default bufferSize, there is not stream.CopyToAsync overload that takes only a cancellationToken
-            return stream.CopyToAsync(new PipelineWriterStream(writer), bufferSize: 81920, cancellationToken: cancellationToken);
         }
 
         private class PipelineWriterStream : Stream

--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/SendUtils.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/SendUtils.cs
@@ -111,7 +111,7 @@ namespace Microsoft.AspNetCore.Sockets.Client
 
             protected override Task SerializeToStreamAsync(Stream stream, TransportContext context)
             {
-                return stream.WriteAsync(_buffer);
+                return stream.WriteAsync(_buffer).AsTask();
             }
 
             protected override bool TryComputeLength(out long length)


### PR DESCRIPTION
- Return ValueTask instead of Task from WriteAsync helpers
- Use TryGet instead of foreach to avoid enumerator (though it's just a stack allocation here)