### PR TITLE
Use the array unpacker instead of the Stream unpacker

### DIFF
--- a/src/Microsoft.AspNetCore.SignalR.Protocols.MsgPack/Internal/Protocol/MessagePackHubProtocol.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Protocols.MsgPack/Internal/Protocol/MessagePackHubProtocol.cs
@@ -41,16 +41,13 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
         {
             while (BinaryMessageParser.TryParseMessage(ref input, out var payload))
             {
-                using (var memoryStream = new MemoryStream(payload.ToArray()))
-                {
-                    messages.Add(ParseMessage(memoryStream, binder));
-                }
+                messages.Add(ParseMessage(payload.ToArray(), binder));
             }
 
             return messages.Count > 0;
         }
 
-        private static HubMessage ParseMessage(Stream input, IInvocationBinder binder)
+        private static HubMessage ParseMessage(byte[] input, IInvocationBinder binder)
         {
             using (var unpacker = Unpacker.Create(input))
             {


### PR DESCRIPTION
- This reduces allocations and improves throughout of msgpack

## Before

```
             Method |          Input | HubProtocol |         Mean |       Error |       StdDev |        Op/s |   Gen 0 |  Gen 1 | Allocated |
------------------- |--------------- |------------ |-------------:|------------:|-------------:|------------:|--------:|-------:|----------:|
  ReadSingleMessage |   FewArguments |     MsgPack |   1,488.4 ns |    61.36 ns |     91.84 ns |   671,844.0 |  0.0906 |      - |    1104 B |
 WriteSingleMessage |   FewArguments |     MsgPack |   1,607.7 ns |   100.52 ns |    150.46 ns |   621,994.0 |  0.1007 |      - |    1224 B |
  ReadSingleMessage | LargeArguments |     MsgPack |  19,433.3 ns |   991.52 ns |  1,484.07 ns |    51,458.1 |  5.1056 | 0.5371 |   62440 B |
 WriteSingleMessage | LargeArguments |     MsgPack |  29,826.8 ns | 2,135.01 ns |  3,195.58 ns |    33,526.9 |  9.3384 | 0.9430 |  113944 B |
  ReadSingleMessage |  ManyArguments |     MsgPack |   3,524.8 ns |   295.32 ns |    442.01 ns |   283,704.2 |  0.1282 |      - |    1592 B |
 WriteSingleMessage |  ManyArguments |     MsgPack |   3,110.4 ns |   355.27 ns |    531.75 ns |   321,501.5 |  0.1217 |      - |    1496 B |
  ReadSingleMessage |    NoArguments |     MsgPack |     558.9 ns |    13.73 ns |     20.55 ns | 1,789,141.1 |  0.0581 |      - |     704 B |
 WriteSingleMessage |    NoArguments |     MsgPack |     711.8 ns |    27.08 ns |     40.54 ns | 1,404,982.0 |  0.0810 |      - |     976 B |
```

## After

```
              Method |          Input | HubProtocol |         Mean |       Error |       StdDev |        Op/s |   Gen 0 |  Gen 1 | Allocated |
------------------- |--------------- |------------ |-------------:|------------:|-------------:|------------:|--------:|-------:|----------:|
  ReadSingleMessage |   FewArguments |     MsgPack |   1,325.8 ns |    37.96 ns |     56.82 ns |   754,246.0 |  0.0799 |      - |     976 B |
 WriteSingleMessage |   FewArguments |     MsgPack |   1,369.3 ns |    17.66 ns |     26.43 ns |   730,286.1 |  0.1001 |      - |    1224 B |
  ReadSingleMessage | LargeArguments |     MsgPack |  17,850.9 ns |   915.41 ns |  1,370.15 ns |    56,019.5 |  5.0995 | 0.4272 |   62312 B |
 WriteSingleMessage | LargeArguments |     MsgPack |  35,684.4 ns | 7,376.32 ns | 11,040.53 ns |    28,023.4 |  9.3414 | 0.8698 |  113944 B |
  ReadSingleMessage |  ManyArguments |     MsgPack |   3,086.5 ns |   201.56 ns |    301.69 ns |   323,986.6 |  0.1186 |      - |    1464 B |
 WriteSingleMessage |  ManyArguments |     MsgPack |   2,747.5 ns |   122.03 ns |    182.65 ns |   363,965.2 |  0.1202 |      - |    1496 B |
  ReadSingleMessage |    NoArguments |     MsgPack |     471.5 ns |    31.70 ns |     47.45 ns | 2,120,818.5 |  0.0476 |      - |     576 B |
 WriteSingleMessage |    NoArguments |     MsgPack |     710.4 ns |    27.51 ns |     41.18 ns | 1,407,637.1 |  0.0811 |      - |     976 B |
```

PS @JamesNK this gave me an idea, I'd like a fast path in JSON.NET that took a char[] or Span<char> directly and assumed the entire payload was in there. See https://github.com/aspnet/SignalR/issues/1618