### PR TITLE
fix #1542 by removing browser field

### DIFF
--- a/client-ts/signalr-protocol-msgpack/package.json
+++ b/client-ts/signalr-protocol-msgpack/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.0-preview2-t000",
   "description": "MsgPack Protocol support for ASP.NET Core SignalR",
   "main": "./dist/cjs/index.js",
-  "browser": "./dist/browser/signalr-protocol-msgpack.js",
   "module": "./dist/esm/index.js",
   "typings": "./dist/esm/index.d.ts",
   "umd_name": "signalR.protocols.msgpack",

--- a/client-ts/signalr/package.json
+++ b/client-ts/signalr/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.0-preview2-t000",
   "description": "ASP.NET Core SignalR Client",
   "main": "./dist/cjs/index.js",
-  "browser": "./dist/browser/signalr.js",
   "module": "./dist/esm/index.js",
   "typings": "./dist/esm/index.d.ts",
   "umd_name": "signalR",


### PR DESCRIPTION
WebPack is using it, but it's supposed to use the "Main" value.