### PR TITLE
Use ActivatorUtlities.CreateFactory instead of CreateInstance

### DIFF
--- a/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/DefaultHubActivatorBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/DefaultHubActivatorBenchmark.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
+{
+    public class DefaultHubActivatorBenchmark
+    {
+        private DefaultHubActivator<MyHub> _activator;
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            var services = new ServiceCollection();
+
+            _activator = new DefaultHubActivator<MyHub>(services.BuildServiceProvider());
+        }
+
+        [Benchmark]
+        public int Create()
+        {
+            var hub = _activator.Create();
+            int result = hub.Addition();
+            return result;
+        }
+
+        public class MyHub : Hub
+        {
+            public int Addition()
+            {
+                return 1 + 1;
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.SignalR.Core/DefaultHubActivator.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/DefaultHubActivator.cs
@@ -9,8 +9,8 @@ namespace Microsoft.AspNetCore.SignalR
 {
     public class DefaultHubActivator<THub> : IHubActivator<THub> where THub: Hub
     {
-        // Object factory for all this Hub type
-        private static ObjectFactory _objectFactory = ActivatorUtilities.CreateFactory(typeof(THub), Type.EmptyTypes);
+        // Object factory for THub instances
+        private static Lazy<ObjectFactory> _objectFactory = new Lazy<ObjectFactory>(() => ActivatorUtilities.CreateFactory(typeof(THub), Type.EmptyTypes));
         private readonly IServiceProvider _serviceProvider;
         private bool? _created;
 
@@ -27,7 +27,7 @@ namespace Microsoft.AspNetCore.SignalR
             var hub = _serviceProvider.GetService<THub>();
             if (hub == null)
             {
-                hub = (THub)_objectFactory(_serviceProvider, Array.Empty<object>());
+                hub = (THub)_objectFactory.Value(_serviceProvider, Array.Empty<object>());
                 _created = true;
             }
 

--- a/src/Microsoft.AspNetCore.SignalR.Core/DefaultHubActivator.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/DefaultHubActivator.cs
@@ -9,6 +9,8 @@ namespace Microsoft.AspNetCore.SignalR
 {
     public class DefaultHubActivator<THub> : IHubActivator<THub> where THub: Hub
     {
+        // Object factory for all this Hub type
+        private static ObjectFactory _objectFactory = ActivatorUtilities.CreateFactory(typeof(THub), Type.EmptyTypes);
         private readonly IServiceProvider _serviceProvider;
         private bool? _created;
 
@@ -25,7 +27,7 @@ namespace Microsoft.AspNetCore.SignalR
             var hub = _serviceProvider.GetService<THub>();
             if (hub == null)
             {
-                hub = ActivatorUtilities.CreateInstance<THub>(_serviceProvider);
+                hub = (THub)_objectFactory(_serviceProvider, Array.Empty<object>());
                 _created = true;
             }
 

--- a/src/Microsoft.AspNetCore.SignalR.Core/DefaultHubActivator.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/DefaultHubActivator.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.SignalR
     public class DefaultHubActivator<THub> : IHubActivator<THub> where THub: Hub
     {
         // Object factory for THub instances
-        private static Lazy<ObjectFactory> _objectFactory = new Lazy<ObjectFactory>(() => ActivatorUtilities.CreateFactory(typeof(THub), Type.EmptyTypes));
+        private static readonly Lazy<ObjectFactory> _objectFactory = new Lazy<ObjectFactory>(() => ActivatorUtilities.CreateFactory(typeof(THub), Type.EmptyTypes));
         private readonly IServiceProvider _serviceProvider;
         private bool? _created;
 


### PR DESCRIPTION
- Turns out CreateFactory is much much faster
- Added a benchmark for hub activation

## Before

```
 Method |     Mean |    Error |   StdDev |        Op/s |  Gen 0 | Allocated |
------- |---------:|---------:|---------:|------------:|-------:|----------:|
 Create | 710.7 ns | 14.40 ns | 39.89 ns | 1,406,988.1 | 0.0153 |     224 B |
```

## After

```
  Method |     Mean |    Error |   StdDev |         Op/s |  Gen 0 | Allocated |
------- |---------:|---------:|---------:|-------------:|-------:|----------:|
 Create | 76.34 ns | 3.347 ns | 9.386 ns | 13,099,035.7 | 0.0037 |      48 B |
```

## Lazy

```
 Method |     Mean |    Error |   StdDev |   Median |         Op/s |  Gen 0 | Allocated |
------- |---------:|---------:|---------:|---------:|-------------:|-------:|----------:|
 Create | 65.39 ns | 1.480 ns | 4.102 ns | 63.73 ns | 15,292,741.1 | 0.0037 |      48 B |
```

Fixes #1570 