### PR TITLE
Make HubConnection re-create the HttpConnection instead of restarting it

### DIFF
--- a/client-ts/FunctionalTests/package-lock.json
+++ b/client-ts/FunctionalTests/package-lock.json
@@ -7,13 +7,13 @@
     "@std/esm": {
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/@std/esm/-/esm-0.18.0.tgz",
-      "integrity": "sha512-oeHSSVp/WxC08ngpKgyYR4LcI0+EBwZiJcB58jvIqyJnOGxudSkxTgAQKsVfpNsMXfOoILgu9PWhuzIZ8GQEjw==",
+      "integrity": "sha1-4hK1Zcdl+Tsp7FIqSToZLOeuK6Y=",
       "dev": true
     },
     "@types/debug": {
       "version": "0.0.30",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-0.0.30.tgz",
-      "integrity": "sha512-orGL5LXERPYsLov6CWs3Fh6203+dXzJkR7OnddIr2514Hsecwc8xRpzCapshBbKFImCsvS/mk6+FWiN5LyZJAQ==",
+      "integrity": "sha1-3B5A9687nIFQE6eGDmJS9jUqhN8=",
       "dev": true
     },
     "@types/node": {
@@ -31,7 +31,7 @@
     "@types/strip-json-comments": {
       "version": "0.0.30",
       "resolved": "https://registry.npmjs.org/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz",
-      "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==",
+      "integrity": "sha1-mqMMBNshKpoGSdaub9UKzMQHSKE=",
       "dev": true
     },
     "ansi-styles": {
@@ -69,7 +69,7 @@
     "color-convert": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "integrity": "sha1-wSYRB66y8pTr/+ye2eytUppgl+0=",
       "dev": true,
       "requires": {
         "color-name": "1.1.3"
@@ -90,7 +90,7 @@
     "debug": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
       "dev": true,
       "requires": {
         "ms": "2.0.0"
@@ -300,13 +300,13 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM=",
       "dev": true
     },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
       "dev": true
     },
     "source-map-support": {
@@ -321,7 +321,7 @@
     "split": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "integrity": "sha1-YFvZvjA6pZ+zX5Ip++oN3snqB9k=",
       "dev": true,
       "requires": {
         "through": "2.3.8"
@@ -473,7 +473,7 @@
     "tap-teamcity": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/tap-teamcity/-/tap-teamcity-3.0.2.tgz",
-      "integrity": "sha512-FI26a4CGNx9LWx2vRh3fLNrel1GJm5smBVJl2tzabTwGrmX9d+KHWP2O9xdKgMtH5IOBpN6goy9Yh4P2NRaoQw==",
+      "integrity": "sha1-727fs5PvMX09DcOZHugkurlIw54=",
       "dev": true,
       "requires": {
         "@std/esm": "0.18.0",
@@ -603,7 +603,7 @@
     "ts-node": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-4.1.0.tgz",
-      "integrity": "sha512-xcZH12oVg9PShKhy3UHyDmuDLV3y7iKwX25aMVPt1SIXSuAfWkFiGPEkg+th8R4YKW/QCxDoW7lJdb15lx6QWg==",
+      "integrity": "sha1-NtlSnHuQu5kzBsQIzQf3dD3iBxI=",
       "dev": true,
       "requires": {
         "arrify": "1.0.1",
@@ -621,7 +621,7 @@
     "tsconfig": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-7.0.0.tgz",
-      "integrity": "sha512-vZXmzPrL+EmC4T/4rVlT2jNVMWCi/O4DIiSj3UHg1OE5kCKbk4mfrXc6dZksLgRM/TZlKnousKH9bbTazUWRRw==",
+      "integrity": "sha1-hFOIdaTcIW5cSlQys6Tew9VOkbc=",
       "dev": true,
       "requires": {
         "@types/strip-bom": "3.0.0",

--- a/samples/ClientSample/RawSample.cs
+++ b/samples/ClientSample/RawSample.cs
@@ -42,7 +42,7 @@ namespace ClientSample
             try
             {
                 var closeTcs = new TaskCompletionSource<object>();
-                connection.Closed += e => closeTcs.SetResult(null);
+                connection.Closed += (c, e) => closeTcs.SetResult(null);
                 connection.OnReceived(data => Console.Out.WriteLineAsync($"{Encoding.UTF8.GetString(data)}"));
                 await connection.StartAsync(TransferFormat.Text);
 

--- a/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.cs
@@ -220,12 +220,12 @@ namespace Microsoft.AspNetCore.SignalR.Client
                     return;
                 }
 
-                _disposed = true;
-
                 if (_connection != null)
                 {
                     await DisposeConnectionAsync();
                 }
+
+                _disposed = true;
             }
             finally
             {
@@ -361,7 +361,7 @@ namespace Microsoft.AspNetCore.SignalR.Client
 
         private async Task InvokeStreamCore(string methodName, InvocationRequest irq, object[] args, CancellationToken cancellationToken)
         {
-AssertConnectionValid();
+            AssertConnectionValid();
 
             Log.PreparingStreamingInvocation(_logger, irq.InvocationId, methodName, irq.ResultType.FullName, args.Length);
 
@@ -709,7 +709,7 @@ AssertConnectionValid();
 
         private void AddInvocation(InvocationRequest irq)
         {
-AssertConnectionValid();
+            AssertConnectionValid();
 
             lock (_pendingCallsLock)
             {

--- a/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnectionBuilder.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnectionBuilder.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -43,12 +43,11 @@ namespace Microsoft.AspNetCore.SignalR.Client
             }
 
             IHubConnectionBuilder builder = this;
-            var connection = _connectionFactoryDelegate();
 
             var loggerFactory = builder.GetLoggerFactory();
             var hubProtocol = builder.GetHubProtocol();
 
-            return new HubConnection(connection, hubProtocol ?? new JsonHubProtocol(), loggerFactory);
+            return new HubConnection(_connectionFactoryDelegate, hubProtocol ?? new JsonHubProtocol(), loggerFactory);
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Microsoft.AspNetCore.SignalR.Client.Core/InvocationRequest.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client.Core/InvocationRequest.cs
@@ -121,7 +121,7 @@ namespace Microsoft.AspNetCore.SignalR.Client
 
             protected override void Cancel()
             {
-                _channel.Writer.TryComplete(new OperationCanceledException("Invocation terminated"));
+                _channel.Writer.TryComplete(new OperationCanceledException());
             }
         }
 

--- a/src/Microsoft.AspNetCore.SignalR.Client.Core/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client.Core/Properties/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Microsoft.AspNetCore.SignalR.Client.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100f33a29044fa9d740c9b3213a93e57c84b472c84e0b8a0e1ae48e67a9f8f6de9d5f7f3d52ac23e48ac51801f1dc950abe901da34d2a9e3baadb141a17c77ef3c565dd5ee5054b91cf63bb3c6ab83f72ab3aafe93d0fc3c2348b764fafb0b1c0733de51459aeab46580384bf9d74c4e28164b7cde247f891ba07891c9d872ad2bb")]

--- a/src/Microsoft.AspNetCore.Sockets.Abstractions/IConnection.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Abstractions/IConnection.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNetCore.Sockets.Client
 
         IDisposable OnReceived(Func<byte[], object, Task> callback, object state);
 
-        event Action<Exception> Closed;
+        event Action<IConnection, Exception> Closed;
 
         IFeatureCollection Features { get; }
     }

--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/HttpConnection.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/HttpConnection.cs
@@ -55,7 +55,7 @@ namespace Microsoft.AspNetCore.Sockets.Client
 
         public IFeatureCollection Features { get; } = new FeatureCollection();
 
-        public event Action<Exception> Closed;
+        public event Action<IConnection, Exception> Closed;
 
         public HttpConnection(Uri url)
             : this(url, TransportType.All)
@@ -323,13 +323,13 @@ namespace Microsoft.AspNetCore.Sockets.Client
                     {
                         if (exception != null)
                         {
-                            Closed?.Invoke(exception);
+                            Closed?.Invoke(this, exception);
                         }
                         else
                         {
                             // Call the closed event. If there was an abort exception, it will be flowed forward
                             // However, if there wasn't, this will just be null and we're good
-                            Closed?.Invoke(abortException);
+                            Closed?.Invoke(this, abortException);
                         }
                     }
                     catch (Exception ex)

--- a/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/HubConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/HubConnectionTests.cs
@@ -81,8 +81,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
             using (StartLog(out var loggerFactory, $"{nameof(CanSendAndReceiveMessage)}_{protocol.Name}_{transportType}_{path.TrimStart('/')}"))
             {
                 const string originalMessage = "SignalR";
-                var httpConnection = new HttpConnection(new Uri(_serverFixture.Url + path), transportType, loggerFactory);
-                var connection = new HubConnection(() => httpConnection, protocol, loggerFactory);
+                var connection = new HubConnection(GetHttpConnectionFactory(loggerFactory, path), protocol, loggerFactory);
                 try
                 {
                     await connection.StartAsync().OrTimeout();
@@ -110,8 +109,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
             using (StartLog(out var loggerFactory, LogLevel.Trace, $"{nameof(CanStopAndStartConnection)}_{protocol.Name}_{transportType}_{path.TrimStart('/')}"))
             {
                 const string originalMessage = "SignalR";
-                var httpConnection = new HttpConnection(new Uri(_serverFixture.Url + path), transportType, loggerFactory);
-                var connection = new HubConnection(() => httpConnection, protocol, loggerFactory);
+                var connection = new HubConnection(GetHttpConnectionFactory(loggerFactory, path), protocol, loggerFactory);
                 try
                 {
                     await connection.StartAsync().OrTimeout();
@@ -141,8 +139,8 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
             {
                 var logger = loggerFactory.CreateLogger<HubConnectionTests>();
                 const string originalMessage = "SignalR";
-                var httpConnection = new HttpConnection(new Uri(_serverFixture.Url + "/default"), loggerFactory);
-                var connection = new HubConnection(() => httpConnection, new JsonHubProtocol(), loggerFactory);
+
+                var connection = new HubConnection(GetHttpConnectionFactory(loggerFactory, "/default"), new JsonHubProtocol(), loggerFactory);
                 var restartTcs = new TaskCompletionSource<object>();
                 connection.Closed += async e =>
                 {
@@ -185,6 +183,11 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
             }
         }
 
+        private Func<IConnection> GetHttpConnectionFactory(ILoggerFactory loggerFactory, string path)
+        {
+            return () => new HttpConnection(new Uri(_serverFixture.Url + path), loggerFactory);
+        }
+
         [Theory]
         [MemberData(nameof(HubProtocolsAndTransportsAndHubPaths))]
         public async Task MethodsAreCaseInsensitive(IHubProtocol protocol, TransportType transportType, string path)
@@ -193,8 +196,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
             {
                 const string originalMessage = "SignalR";
                 var uriString = "http://test/" + path;
-                var httpConnection = new HttpConnection(new Uri(_serverFixture.Url + path), transportType, loggerFactory);
-                var connection = new HubConnection(() => httpConnection, protocol, loggerFactory);
+                var connection = new HubConnection(GetHttpConnectionFactory(loggerFactory, path), protocol, loggerFactory);
                 try
                 {
                     await connection.StartAsync().OrTimeout();
@@ -223,8 +225,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
             {
                 const string originalMessage = "SignalR";
 
-                var httpConnection = new HttpConnection(new Uri(_serverFixture.Url + path), transportType, loggerFactory);
-                var connection = new HubConnection(() => httpConnection, protocol, loggerFactory);
+                var connection = new HubConnection(GetHttpConnectionFactory(loggerFactory, path), protocol, loggerFactory);
                 try
                 {
                     await connection.StartAsync().OrTimeout();
@@ -254,8 +255,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
         {
             using (StartLog(out var loggerFactory, LogLevel.Trace, $"{nameof(InvokeNonExistantClientMethodFromServer)}_{protocol.Name}_{transportType}_{path.TrimStart('/')}"))
             {
-                var httpConnection = new HttpConnection(new Uri(_serverFixture.Url + path), transportType, loggerFactory);
-                var connection = new HubConnection(() => httpConnection, protocol, loggerFactory);
+                var connection = new HubConnection(GetHttpConnectionFactory(loggerFactory, path), protocol, loggerFactory);
                 var closeTcs = new TaskCompletionSource<object>();
                 connection.Closed += e =>
                 {
@@ -294,8 +294,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
         {
             using (StartLog(out var loggerFactory, LogLevel.Trace, $"{nameof(CanStreamClientMethodFromServer)}_{protocol.Name}_{transportType}_{path.TrimStart('/')}"))
             {
-                var httpConnection = new HttpConnection(new Uri(_serverFixture.Url + path), transportType, loggerFactory);
-                var connection = new HubConnection(() => httpConnection, protocol, loggerFactory);
+                var connection = new HubConnection(GetHttpConnectionFactory(loggerFactory, path), protocol, loggerFactory);
                 try
                 {
                     await connection.StartAsync().OrTimeout();
@@ -323,8 +322,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
         {
             using (StartLog(out var loggerFactory, $"{nameof(CanCloseStreamMethodEarly)}_{protocol.Name}_{transportType}_{path.TrimStart('/')}"))
             {
-                var httpConnection = new HttpConnection(new Uri(_serverFixture.Url + path), transportType, loggerFactory);
-                var connection = new HubConnection(() => httpConnection, protocol, loggerFactory);
+                var connection = new HubConnection(GetHttpConnectionFactory(loggerFactory, path), protocol, loggerFactory);
                 try
                 {
                     await connection.StartAsync().OrTimeout();
@@ -363,8 +361,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
         {
             using (StartLog(out var loggerFactory, $"{nameof(StreamDoesNotStartIfTokenAlreadyCanceled)}_{protocol.Name}_{transportType}_{path.TrimStart('/')}"))
             {
-                var httpConnection = new HttpConnection(new Uri(_serverFixture.Url + path), transportType, loggerFactory);
-                var connection = new HubConnection(() => httpConnection, protocol, loggerFactory);
+                var connection = new HubConnection(GetHttpConnectionFactory(loggerFactory, path), protocol, loggerFactory);
                 try
                 {
                     await connection.StartAsync().OrTimeout();
@@ -394,8 +391,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
         {
             using (StartLog(out var loggerFactory, $"{nameof(ExceptionFromStreamingSentToClient)}_{protocol.Name}_{transportType}_{path.TrimStart('/')}"))
             {
-                var httpConnection = new HttpConnection(new Uri(_serverFixture.Url + path), transportType, loggerFactory);
-                var connection = new HubConnection(() => httpConnection, protocol, loggerFactory);
+                var connection = new HubConnection(GetHttpConnectionFactory(loggerFactory, path), protocol, loggerFactory);
                 try
                 {
                     await connection.StartAsync().OrTimeout();
@@ -422,8 +418,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
         {
             using (StartLog(out var loggerFactory, $"{nameof(ServerThrowsHubExceptionIfHubMethodCannotBeResolved)}_{hubProtocol.Name}_{transportType}_{hubPath.TrimStart('/')}"))
             {
-                var httpConnection = new HttpConnection(new Uri(_serverFixture.Url + hubPath), transportType, loggerFactory);
-                var connection = new HubConnection(() => httpConnection, hubProtocol, loggerFactory);
+                var connection = new HubConnection(GetHttpConnectionFactory(loggerFactory, hubPath), hubProtocol, loggerFactory);
                 try
                 {
                     await connection.StartAsync().OrTimeout();
@@ -449,8 +444,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
         {
             using (StartLog(out var loggerFactory, $"{nameof(ServerThrowsHubExceptionOnHubMethodArgumentCountMismatch)}_{hubProtocol.Name}_{transportType}_{hubPath.TrimStart('/')}"))
             {
-                var httpConnection = new HttpConnection(new Uri(_serverFixture.Url + hubPath), transportType, loggerFactory);
-                var connection = new HubConnection(() => httpConnection, hubProtocol, loggerFactory);
+                var connection = new HubConnection(GetHttpConnectionFactory(loggerFactory, hubPath), hubProtocol, loggerFactory);
                 try
                 {
                     await connection.StartAsync().OrTimeout();
@@ -476,8 +470,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
         {
             using (StartLog(out var loggerFactory, $"{nameof(ServerThrowsHubExceptionOnHubMethodArgumentTypeMismatch)}_{hubProtocol.Name}_{transportType}_{hubPath.TrimStart('/')}"))
             {
-                var httpConnection = new HttpConnection(new Uri(_serverFixture.Url + hubPath), transportType, loggerFactory);
-                var connection = new HubConnection(() => httpConnection, hubProtocol, loggerFactory);
+                var connection = new HubConnection(GetHttpConnectionFactory(loggerFactory, hubPath), hubProtocol, loggerFactory);
                 try
                 {
                     await connection.StartAsync().OrTimeout();
@@ -503,8 +496,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
         {
             using (StartLog(out var loggerFactory, $"{nameof(ServerThrowsHubExceptionIfStreamingHubMethodCannotBeResolved)}_{hubProtocol.Name}_{transportType}_{hubPath.TrimStart('/')}"))
             {
-                var httpConnection = new HttpConnection(new Uri(_serverFixture.Url + hubPath), transportType, loggerFactory);
-                var connection = new HubConnection(() => httpConnection, hubProtocol, loggerFactory);
+                var connection = new HubConnection(GetHttpConnectionFactory(loggerFactory, hubPath), hubProtocol, loggerFactory);
                 try
                 {
                     await connection.StartAsync().OrTimeout();
@@ -532,8 +524,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
             using (StartLog(out var loggerFactory, $"{nameof(ServerThrowsHubExceptionOnStreamingHubMethodArgumentCountMismatch)}_{hubProtocol.Name}_{transportType}_{hubPath.TrimStart('/')}"))
             {
                 loggerFactory.AddConsole(LogLevel.Trace);
-                var httpConnection = new HttpConnection(new Uri(_serverFixture.Url + hubPath), transportType, loggerFactory);
-                var connection = new HubConnection(() => httpConnection, hubProtocol, loggerFactory);
+                var connection = new HubConnection(GetHttpConnectionFactory(loggerFactory, hubPath), hubProtocol, loggerFactory);
                 try
                 {
                     await connection.StartAsync().OrTimeout();
@@ -560,8 +551,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
         {
             using (StartLog(out var loggerFactory, $"{nameof(ServerThrowsHubExceptionOnStreamingHubMethodArgumentTypeMismatch)}_{hubProtocol.Name}_{transportType}_{hubPath.TrimStart('/')}"))
             {
-                var httpConnection = new HttpConnection(new Uri(_serverFixture.Url + hubPath), transportType, loggerFactory);
-                var connection = new HubConnection(() => httpConnection, hubProtocol, loggerFactory);
+                var connection = new HubConnection(GetHttpConnectionFactory(loggerFactory, hubPath), hubProtocol, loggerFactory);
                 try
                 {
                     await connection.StartAsync().OrTimeout();
@@ -588,8 +578,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
         {
             using (StartLog(out var loggerFactory, $"{nameof(ServerThrowsHubExceptionIfNonStreamMethodInvokedWithStreamAsync)}_{hubProtocol.Name}_{transportType}_{hubPath.TrimStart('/')}"))
             {
-                var httpConnection = new HttpConnection(new Uri(_serverFixture.Url + hubPath), transportType, loggerFactory);
-                var connection = new HubConnection(() => httpConnection, hubProtocol, loggerFactory);
+                var connection = new HubConnection(GetHttpConnectionFactory(loggerFactory, hubPath), hubProtocol, loggerFactory);
                 try
                 {
                     await connection.StartAsync().OrTimeout();
@@ -615,8 +604,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
         {
             using (StartLog(out var loggerFactory, $"{nameof(ServerThrowsHubExceptionIfStreamMethodInvokedWithInvoke)}_{hubProtocol.Name}_{transportType}_{hubPath.TrimStart('/')}"))
             {
-                var httpConnection = new HttpConnection(new Uri(_serverFixture.Url + hubPath), transportType, loggerFactory);
-                var connection = new HubConnection(() => httpConnection, hubProtocol, loggerFactory);
+                var connection = new HubConnection(GetHttpConnectionFactory(loggerFactory, hubPath), hubProtocol, loggerFactory);
                 try
                 {
                     await connection.StartAsync().OrTimeout();
@@ -642,8 +630,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
         {
             using (StartLog(out var loggerFactory, $"{nameof(ServerThrowsHubExceptionIfBuildingAsyncEnumeratorIsNotPossible)}_{hubProtocol.Name}_{transportType}_{hubPath.TrimStart('/')}"))
             {
-                var httpConnection = new HttpConnection(new Uri(_serverFixture.Url + hubPath), transportType, loggerFactory);
-                var connection = new HubConnection(() => httpConnection, hubProtocol, loggerFactory);
+                var connection = new HubConnection(GetHttpConnectionFactory(loggerFactory, hubPath), hubProtocol, loggerFactory);
                 try
                 {
                     await connection.StartAsync().OrTimeout();

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.Helpers.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.Helpers.cs
@@ -48,7 +48,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
             try
             {
                 var closedTcs = new TaskCompletionSource<object>();
-                connection.Closed += ex =>
+                connection.Closed += (sender, ex) =>
                 {
                     if (ex != null)
                     {
@@ -68,77 +68,6 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                 await connection.DisposeAsync().OrTimeout();
             }
         }
-
-        // Possibly useful as a general-purpose async testing helper?
-        private class SyncPoint
-        {
-            private TaskCompletionSource<object> _atSyncPoint = new TaskCompletionSource<object>();
-            private TaskCompletionSource<object> _continueFromSyncPoint = new TaskCompletionSource<object>();
-
-            /// <summary>
-            /// Waits for the code-under-test to reach <see cref="WaitToContinue"/>.
-            /// </summary>
-            /// <returns></returns>
-            public Task WaitForSyncPoint() => _atSyncPoint.Task;
-
-            /// <summary>
-            /// Releases the code-under-test to continue past where it waited for <see cref="WaitToContinue"/>.
-            /// </summary>
-            public void Continue() => _continueFromSyncPoint.TrySetResult(null);
-
-            /// <summary>
-            /// Used by the code-under-test to wait for the test code to sync up.
-            /// </summary>
-            /// <remarks>
-            /// This code will unblock <see cref="WaitForSyncPoint"/> and then block waiting for <see cref="Continue"/> to be called.
-            /// </remarks>
-            /// <returns></returns>
-            public Task WaitToContinue()
-            {
-                _atSyncPoint.TrySetResult(null);
-                return _continueFromSyncPoint.Task;
-            }
-
-            public static Func<Task> Create(out SyncPoint syncPoint)
-            {
-                var handler = Create(1, out var syncPoints);
-                syncPoint = syncPoints[0];
-                return handler;
-            }
-
-            /// <summary>
-            /// Creates a re-entrant function that waits for sync points in sequence.
-            /// </summary>
-            /// <param name="count">The number of sync points to expect</param>
-            /// <param name="syncPoints">The <see cref="SyncPoint"/> objects that can be used to coordinate the sync point</param>
-            /// <returns></returns>
-            public static Func<Task> Create(int count, out SyncPoint[] syncPoints)
-            {
-                // Need to use a local so the closure can capture it. You can't use out vars in a closure.
-                var localSyncPoints = new SyncPoint[count];
-                for (var i = 0; i < count; i += 1)
-                {
-                    localSyncPoints[i] = new SyncPoint();
-                }
-
-                syncPoints = localSyncPoints;
-
-                var counter = 0;
-                return () =>
-                {
-                    if (counter >= localSyncPoints.Length)
-                    {
-                        return Task.CompletedTask;
-                    }
-                    else
-                    {
-                        var syncPoint = localSyncPoints[counter];
-
-                        counter += 1;
-                        return syncPoint.WaitToContinue();
-                    }
-                };
-            }
-        }
     }
 }
+

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionExtensionsTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionExtensionsTests.cs
@@ -96,7 +96,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
         private async Task InvokeOn(Action<HubConnection, TaskCompletionSource<object[]>> onAction, object[] args)
         {
             var connection = new TestConnection();
-            var hubConnection = new HubConnection(connection, new JsonHubProtocol(), new LoggerFactory());
+            var hubConnection = new HubConnection(() => connection, new JsonHubProtocol(), new LoggerFactory());
             var handlerTcs = new TaskCompletionSource<object[]>();
             try
             {
@@ -126,7 +126,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
         public async Task ConnectionNotClosedOnCallbackArgumentCountMismatch()
         {
             var connection = new TestConnection();
-            var hubConnection = new HubConnection(connection, new JsonHubProtocol(), new LoggerFactory());
+            var hubConnection = new HubConnection(() => connection, new JsonHubProtocol(), new LoggerFactory());
             var receiveTcs = new TaskCompletionSource<int>();
 
             try
@@ -166,7 +166,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
         public async Task ConnectionNotClosedOnCallbackArgumentTypeMismatch()
         {
             var connection = new TestConnection();
-            var hubConnection = new HubConnection(connection, new JsonHubProtocol(), new LoggerFactory());
+            var hubConnection = new HubConnection(() => connection, new JsonHubProtocol(), new LoggerFactory());
             var receiveTcs = new TaskCompletionSource<int>();
 
             try

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionProtocolTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionProtocolTests.cs
@@ -139,7 +139,6 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
             finally
             {
                 await hubConnection.DisposeAsync().OrTimeout();
-                await connection.DisposeAsync().OrTimeout();
             }
         }
 

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionProtocolTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionProtocolTests.cs
@@ -94,7 +94,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
             TaskCompletionSource<Exception> closedTcs = new TaskCompletionSource<Exception>();
 
             var connection = new TestConnection();
-            var hubConnection = new HubConnection(connection, new JsonHubProtocol(), new LoggerFactory());
+            var hubConnection = new HubConnection(() => connection, new JsonHubProtocol(), new LoggerFactory());
             hubConnection.Closed += e => closedTcs.SetResult(e);
 
             try
@@ -121,7 +121,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
             TaskCompletionSource<Exception> closedTcs = new TaskCompletionSource<Exception>();
 
             var connection = new TestConnection();
-            var hubConnection = new HubConnection(connection, new JsonHubProtocol(), new LoggerFactory());
+            var hubConnection = new HubConnection(() => connection, new JsonHubProtocol(), new LoggerFactory());
             hubConnection.Closed += e => closedTcs.SetResult(e);
 
             try

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionProtocolTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionProtocolTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
         public async Task SendAsyncSendsANonBlockingInvocationMessage()
         {
             var connection = new TestConnection();
-            var hubConnection = new HubConnection(connection, new JsonHubProtocol(), new LoggerFactory());
+            var hubConnection = new HubConnection(() => connection, new JsonHubProtocol(), new LoggerFactory());
             try
             {
                 await hubConnection.StartAsync();
@@ -48,7 +48,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
         public async Task ClientSendsHandshakeMessageWhenStartingConnection()
         {
             var connection = new TestConnection();
-            var hubConnection = new HubConnection(connection, new JsonHubProtocol(), new LoggerFactory());
+            var hubConnection = new HubConnection(() => connection, new JsonHubProtocol(), new LoggerFactory());
             try
             {
                 await hubConnection.StartAsync();
@@ -68,7 +68,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
         public async Task InvokeSendsAnInvocationMessage()
         {
             var connection = new TestConnection();
-            var hubConnection = new HubConnection(connection, new JsonHubProtocol(), new LoggerFactory());
+            var hubConnection = new HubConnection(() => connection, new JsonHubProtocol(), new LoggerFactory());
             try
             {
                 await hubConnection.StartAsync();
@@ -147,7 +147,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
         public async Task StreamSendsAnInvocationMessage()
         {
             var connection = new TestConnection();
-            var hubConnection = new HubConnection(connection, new JsonHubProtocol(), new LoggerFactory());
+            var hubConnection = new HubConnection(() => connection, new JsonHubProtocol(), new LoggerFactory());
             try
             {
                 await hubConnection.StartAsync();
@@ -175,7 +175,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
         public async Task InvokeCompletedWhenCompletionMessageReceived()
         {
             var connection = new TestConnection();
-            var hubConnection = new HubConnection(connection, new JsonHubProtocol(), new LoggerFactory());
+            var hubConnection = new HubConnection(() => connection, new JsonHubProtocol(), new LoggerFactory());
             try
             {
                 await hubConnection.StartAsync();
@@ -199,7 +199,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
         public async Task StreamCompletesWhenCompletionMessageIsReceived()
         {
             var connection = new TestConnection();
-            var hubConnection = new HubConnection(connection, new JsonHubProtocol(), new LoggerFactory());
+            var hubConnection = new HubConnection(() => connection, new JsonHubProtocol(), new LoggerFactory());
             try
             {
                 await hubConnection.StartAsync();
@@ -223,7 +223,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
         public async Task InvokeYieldsResultWhenCompletionMessageReceived()
         {
             var connection = new TestConnection();
-            var hubConnection = new HubConnection(connection, new JsonHubProtocol(), new LoggerFactory());
+            var hubConnection = new HubConnection(() => connection, new JsonHubProtocol(), new LoggerFactory());
             try
             {
                 await hubConnection.StartAsync();
@@ -247,7 +247,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
         public async Task InvokeFailsWithExceptionWhenCompletionWithErrorReceived()
         {
             var connection = new TestConnection();
-            var hubConnection = new HubConnection(connection, new JsonHubProtocol(), new LoggerFactory());
+            var hubConnection = new HubConnection(() => connection, new JsonHubProtocol(), new LoggerFactory());
             try
             {
                 await hubConnection.StartAsync();
@@ -272,7 +272,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
         public async Task StreamFailsIfCompletionMessageHasPayload()
         {
             var connection = new TestConnection();
-            var hubConnection = new HubConnection(connection, new JsonHubProtocol(), new LoggerFactory());
+            var hubConnection = new HubConnection(() => connection, new JsonHubProtocol(), new LoggerFactory());
             try
             {
                 await hubConnection.StartAsync();
@@ -297,7 +297,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
         public async Task StreamFailsWithExceptionWhenCompletionWithErrorReceived()
         {
             var connection = new TestConnection();
-            var hubConnection = new HubConnection(connection, new JsonHubProtocol(), new LoggerFactory());
+            var hubConnection = new HubConnection(() => connection, new JsonHubProtocol(), new LoggerFactory());
             try
             {
                 await hubConnection.StartAsync();
@@ -322,7 +322,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
         public async Task InvokeFailsWithErrorWhenStreamingItemReceived()
         {
             var connection = new TestConnection();
-            var hubConnection = new HubConnection(connection, new JsonHubProtocol(), new LoggerFactory());
+            var hubConnection = new HubConnection(() => connection, new JsonHubProtocol(), new LoggerFactory());
             try
             {
                 await hubConnection.StartAsync();
@@ -347,7 +347,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
         public async Task StreamYieldsItemsAsTheyArrive()
         {
             var connection = new TestConnection();
-            var hubConnection = new HubConnection(connection, new JsonHubProtocol(), new LoggerFactory());
+            var hubConnection = new HubConnection(() => connection, new JsonHubProtocol(), new LoggerFactory());
             try
             {
                 await hubConnection.StartAsync();
@@ -376,7 +376,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
         public async Task HandlerRegisteredWithOnIsFiredWhenInvocationReceived()
         {
             var connection = new TestConnection();
-            var hubConnection = new HubConnection(connection, new JsonHubProtocol(), new LoggerFactory());
+            var hubConnection = new HubConnection(() => connection, new JsonHubProtocol(), new LoggerFactory());
             var handlerCalled = new TaskCompletionSource<object[]>();
             try
             {
@@ -402,7 +402,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
         public async Task AcceptsPingMessages()
         {
             var connection = new TestConnection();
-            var hubConnection = new HubConnection(connection,
+            var hubConnection = new HubConnection(() => connection,
                 new JsonHubProtocol(), new LoggerFactory());
 
             try

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.ConnectionLifecycle.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.ConnectionLifecycle.cs
@@ -1,0 +1,308 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.SignalR.Internal.Protocol;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Microsoft.AspNetCore.SignalR.Client.Tests
+{
+    public class HubConnectionTestsConnectionLifecycle
+    {
+        // This tactic (using names and a dictionary) allows non-serializable data (like a Func) to be used in a theory AND get it to show in the new hierarchical view in Test Explorer as separate tests you can run individually.
+        private static IDictionary<string, Func<HubConnection, Task>> MethodsThatRequireActiveConnection = new Dictionary<string, Func<HubConnection, Task>>()
+        {
+            { nameof(HubConnection.InvokeAsync), (connection) => connection.InvokeAsync("Foo") },
+            { nameof(HubConnection.SendAsync), (connection) => connection.SendAsync("Foo") },
+            { nameof(HubConnection.StreamAsChannelAsync), (connection) => connection.StreamAsChannelAsync<object>("Foo") },
+        };
+
+        public static IEnumerable<object[]> MethodsNamesThatRequireActiveConnection => MethodsThatRequireActiveConnection.Keys.Select(k => new object[] { k });
+
+        [Fact]
+        public async Task StartAsyncStartsTheUnderlyingConnection()
+        {
+            var testConnection = new TestConnection();
+            await AsyncUsing(new HubConnection(() => testConnection, new JsonHubProtocol()), async connection =>
+            {
+                await connection.StartAsync();
+                Assert.True(testConnection.Started.IsCompleted);
+            });
+        }
+
+        [Fact]
+        public async Task StartAsyncFailsIfAlreadyStarting()
+        {
+            // Set up StartAsync to wait on the syncPoint when starting
+            var testConnection = new TestConnection(onStart: SyncPoint.Create(out var syncPoint));
+            await AsyncUsing(new HubConnection(() => testConnection, new JsonHubProtocol()), async connection =>
+            {
+                var firstStart = connection.StartAsync().OrTimeout();
+                Assert.False(firstStart.IsCompleted);
+
+                // Wait for us to be in IConnection.StartAsync
+                await syncPoint.WaitForSyncPoint();
+
+                // Try starting again
+                var secondStart = connection.StartAsync().OrTimeout();
+                Assert.False(secondStart.IsCompleted);
+
+                // Release the sync point
+                syncPoint.Continue();
+
+                // First start should finish fine
+                await firstStart;
+
+                // Second start should have thrown
+                var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => secondStart);
+                Assert.Equal($"The '{nameof(HubConnection.StartAsync)}' method cannot be called if the connection has already been started.", ex.Message);
+            });
+        }
+
+        [Theory]
+        [MemberData(nameof(MethodsNamesThatRequireActiveConnection))]
+        public async Task MethodsThatRequireStartedConnectionFailIfConnectionNotYetStarted(string name)
+        {
+            var method = MethodsThatRequireActiveConnection[name];
+
+            var testConnection = new TestConnection();
+            await AsyncUsing(new HubConnection(() => testConnection, new JsonHubProtocol()), async connection =>
+            {
+                var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => method(connection));
+                Assert.Equal($"The '{name}' method cannot be called if the connection is not active", ex.Message);
+            });
+        }
+
+        [Theory]
+        [MemberData(nameof(MethodsNamesThatRequireActiveConnection))]
+        public async Task MethodsThatRequireStartedConnectionWaitForStartIfConnectionIsCurrentlyStarting(string name)
+        {
+            var method = MethodsThatRequireActiveConnection[name];
+
+            // Set up StartAsync to wait on the syncPoint when starting
+            var testConnection = new TestConnection(onStart: SyncPoint.Create(out var syncPoint));
+            await AsyncUsing(new HubConnection(() => testConnection, new JsonHubProtocol()), async connection =>
+            {
+                // Start, and wait for the sync point to be hit
+                var startTask = connection.StartAsync().OrTimeout();
+                Assert.False(startTask.IsCompleted);
+                await syncPoint.WaitForSyncPoint();
+
+                // Run the method, but it will be waiting for the lock
+                var targetTask = method(connection).OrTimeout();
+
+                // Release the SyncPoint
+                syncPoint.Continue();
+
+                // Wait for start to finish
+                await startTask;
+
+                // We need some special logic to ensure InvokeAsync completes.
+                if (string.Equals(name, nameof(HubConnection.InvokeAsync)))
+                {
+                    await ForceLastInvocationToComplete(testConnection);
+                }
+
+                // Wait for the method to complete.
+                await targetTask;
+            });
+        }
+
+        [Fact]
+        public async Task StopAsyncStopsConnection()
+        {
+            var testConnection = new TestConnection();
+            await AsyncUsing(new HubConnection(() => testConnection, new JsonHubProtocol()), async connection =>
+            {
+                await connection.StartAsync().OrTimeout();
+                Assert.True(testConnection.Started.IsCompleted);
+
+                await connection.StopAsync().OrTimeout();
+                Assert.True(testConnection.Disposed.IsCompleted);
+            });
+        }
+
+        [Fact]
+        public async Task StopAsyncNoOpsIfConnectionNotYetStarted()
+        {
+            var testConnection = new TestConnection();
+            await AsyncUsing(new HubConnection(() => testConnection, new JsonHubProtocol()), async connection =>
+            {
+                await connection.StopAsync().OrTimeout();
+                Assert.False(testConnection.Disposed.IsCompleted);
+            });
+        }
+
+        [Fact]
+        public async Task StopAsyncNoOpsIfConnectionAlreadyStopped()
+        {
+            var testConnection = new TestConnection();
+            await AsyncUsing(new HubConnection(() => testConnection, new JsonHubProtocol()), async connection =>
+            {
+                await connection.StartAsync().OrTimeout();
+                Assert.True(testConnection.Started.IsCompleted);
+
+                await connection.StopAsync().OrTimeout();
+                Assert.True(testConnection.Disposed.IsCompleted);
+
+                await connection.StopAsync().OrTimeout();
+            });
+        }
+
+        [Fact]
+        public async Task ClosedEventTriggersConnectionToStop()
+        {
+            var testConnection = new TestConnection();
+            var closed = new TaskCompletionSource<object>();
+            await AsyncUsing(new HubConnection(() => testConnection, new JsonHubProtocol()), async connection =>
+            {
+                connection.Closed += (e) => closed.TrySetResult(null);
+                await connection.StartAsync().OrTimeout();
+                Assert.True(testConnection.Started.IsCompleted);
+
+                // This will trigger the closed event
+                testConnection.ReceivedMessages.TryComplete();
+                await closed.Task.OrTimeout();
+
+                // We should be stopped now
+                var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => connection.SendAsync("Foo").OrTimeout());
+                Assert.Equal($"The '{nameof(HubConnection.SendAsync)}' method cannot be called if the connection is not active", ex.Message);
+            });
+        }
+
+        [Fact]
+        public async Task ClosedEventWhileShuttingDownIsNoOp()
+        {
+            var testConnection = new TestConnection(onDispose: SyncPoint.Create(out var syncPoint));
+            var testConnectionClosed = new TaskCompletionSource<object>();
+            var connectionClosed = new TaskCompletionSource<object>();
+            await AsyncUsing(new HubConnection(() => testConnection, new JsonHubProtocol()), async connection =>
+            {
+                // We're hooking the TestConnection Closed event here because the HubConnection one will be blocked on the lock
+                testConnection.Closed += (c, e) => testConnectionClosed.TrySetResult(null);
+                connection.Closed += (e) => connectionClosed.TrySetResult(null);
+
+                await connection.StartAsync().OrTimeout();
+                Assert.True(testConnection.Started.IsCompleted);
+
+                // Start shutting down, but hold at the sync point
+                var stopTask = connection.StopAsync().OrTimeout();
+                Assert.False(stopTask.IsCompleted);
+                await syncPoint.WaitForSyncPoint();
+
+                // Now trigger the closed event and wait for the underlying connection to close
+                testConnection.ReceivedMessages.TryComplete();
+                await testConnectionClosed.Task.OrTimeout();
+
+                // Now, complete the StopAsync
+                syncPoint.Continue();
+                await stopTask;
+
+                // The HubConnection should now be closed.
+                await connectionClosed.Task.OrTimeout();
+
+                // We should be stopped now
+                var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => connection.SendAsync("Foo").OrTimeout());
+                Assert.Equal($"The '{nameof(HubConnection.SendAsync)}' method cannot be called if the connection is not active", ex.Message);
+
+                Assert.Equal(1, testConnection.DisposeCount);
+            });
+        }
+
+        [Fact]
+        public async Task StopAsyncDuringUnderlyingConnectionCloseWaitsAndNoOps()
+        {
+            var testConnection = new TestConnection(onDispose: SyncPoint.Create(out var syncPoint));
+            var connectionClosed = new TaskCompletionSource<object>();
+            await AsyncUsing(new HubConnection(() => testConnection, new JsonHubProtocol()), async connection =>
+            {
+                connection.Closed += (e) => connectionClosed.TrySetResult(null);
+
+                await connection.StartAsync().OrTimeout();
+                Assert.True(testConnection.Started.IsCompleted);
+
+                // Trigger the closed event and wait for the underlying connection to close
+                testConnection.ReceivedMessages.TryComplete();
+
+                // Wait for the HubConnection to start disposing the underlying connection (in response to the Closed event firing)
+                await syncPoint.WaitForSyncPoint();
+
+                // Start stopping manually
+                var stopTask = connection.StopAsync().OrTimeout();
+                Assert.False(stopTask.IsCompleted);
+
+                // Now, complete the StopAsync and wait for TestConnection to be fully disposed
+                syncPoint.Continue();
+                await testConnection.Disposed.OrTimeout();
+
+                // Wait for the stop task to complete and the closed event to fire
+                await stopTask;
+                await connectionClosed.Task.OrTimeout();
+
+                // We should be stopped now
+                var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => connection.SendAsync("Foo").OrTimeout());
+                Assert.Equal($"The '{nameof(HubConnection.SendAsync)}' method cannot be called if the connection is not active", ex.Message);
+            });
+        }
+
+        [Theory]
+        [MemberData(nameof(MethodsNamesThatRequireActiveConnection))]
+        public async Task MethodsThatRequireActiveConnectionWaitForStopAndFailIfConnectionIsCurrentlyStopping(string name)
+        {
+            var method = MethodsThatRequireActiveConnection[name];
+
+            // Set up StartAsync to wait on the syncPoint when starting
+            var testConnection = new TestConnection(onDispose: SyncPoint.Create(out var syncPoint));
+            await AsyncUsing(new HubConnection(() => testConnection, new JsonHubProtocol()), async connection =>
+            {
+                await connection.StartAsync().OrTimeout();
+
+                // Stop, but wait at the sync point.
+                var disposeTask = connection.StopAsync().OrTimeout();
+                await syncPoint.WaitForSyncPoint();
+
+                // Now start invoking the method under test
+                var targetTask = method(connection).OrTimeout();
+                Assert.False(targetTask.IsCompleted);
+
+                // Release the sync point
+                syncPoint.Continue();
+
+                // Wait for the method to complete, with an expected error.
+                var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => targetTask);
+                Assert.Equal($"The '{name}' method cannot be called if the connection is not active", ex.Message);
+
+                await disposeTask;
+            });
+        }
+
+        private static async Task ForceLastInvocationToComplete(TestConnection testConnection)
+        {
+            // Dump the handshake message
+            _ = await testConnection.SentMessages.ReadAsync();
+
+            // We need to "complete" the invocation
+            var message = await testConnection.ReadSentTextMessageAsync();
+            var json = JObject.Parse(message.Substring(0, message.Length - 1)); // Gotta remove the record separator.
+            await testConnection.ReceiveJsonMessage(new
+            {
+                type = HubProtocolConstants.CompletionMessageType,
+                invocationId = json["invocationId"],
+            });
+        }
+
+        // A helper that we wouldn't want to use in product code, but is fine for testing until IAsyncDisposable arrives :)
+        private static async Task AsyncUsing(HubConnection connection, Func<HubConnection, Task> action)
+        {
+            try
+            {
+                await action(connection);
+            }
+            finally
+            {
+                await connection.DisposeAsync();
+            }
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.ConnectionLifecycle.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.ConnectionLifecycle.cs
@@ -8,300 +8,306 @@ using Xunit;
 
 namespace Microsoft.AspNetCore.SignalR.Client.Tests
 {
-    public class HubConnectionTestsConnectionLifecycle
+    public partial class HubConnectionTests
     {
-        // This tactic (using names and a dictionary) allows non-serializable data (like a Func) to be used in a theory AND get it to show in the new hierarchical view in Test Explorer as separate tests you can run individually.
-        private static IDictionary<string, Func<HubConnection, Task>> MethodsThatRequireActiveConnection = new Dictionary<string, Func<HubConnection, Task>>()
+        public class ConnectionLifecycle
         {
-            { nameof(HubConnection.InvokeAsync), (connection) => connection.InvokeAsync("Foo") },
-            { nameof(HubConnection.SendAsync), (connection) => connection.SendAsync("Foo") },
-            { nameof(HubConnection.StreamAsChannelAsync), (connection) => connection.StreamAsChannelAsync<object>("Foo") },
-        };
-
-        public static IEnumerable<object[]> MethodsNamesThatRequireActiveConnection => MethodsThatRequireActiveConnection.Keys.Select(k => new object[] { k });
-
-        [Fact]
-        public async Task StartAsyncStartsTheUnderlyingConnection()
-        {
-            var testConnection = new TestConnection();
-            await AsyncUsing(new HubConnection(() => testConnection, new JsonHubProtocol()), async connection =>
+            // This tactic (using names and a dictionary) allows non-serializable data (like a Func) to be used in a theory AND get it to show in the new hierarchical view in Test Explorer as separate tests you can run individually.
+            private static IDictionary<string, Func<HubConnection, Task>> MethodsThatRequireActiveConnection = new Dictionary<string, Func<HubConnection, Task>>()
             {
-                await connection.StartAsync();
-                Assert.True(testConnection.Started.IsCompleted);
-            });
-        }
+                { nameof(HubConnection.InvokeAsync), (connection) => connection.InvokeAsync("Foo") },
+                { nameof(HubConnection.SendAsync), (connection) => connection.SendAsync("Foo") },
+                { nameof(HubConnection.StreamAsChannelAsync), (connection) => connection.StreamAsChannelAsync<object>("Foo") },
+            };
 
-        [Fact]
-        public async Task StartAsyncFailsIfAlreadyStarting()
-        {
-            // Set up StartAsync to wait on the syncPoint when starting
-            var testConnection = new TestConnection(onStart: SyncPoint.Create(out var syncPoint));
-            await AsyncUsing(new HubConnection(() => testConnection, new JsonHubProtocol()), async connection =>
+            public static IEnumerable<object[]> MethodsNamesThatRequireActiveConnection => MethodsThatRequireActiveConnection.Keys.Select(k => new object[] { k });
+
+            [Fact]
+            public async Task StartAsyncStartsTheUnderlyingConnection()
             {
-                var firstStart = connection.StartAsync().OrTimeout();
-                Assert.False(firstStart.IsCompleted);
-
-                // Wait for us to be in IConnection.StartAsync
-                await syncPoint.WaitForSyncPoint();
-
-                // Try starting again
-                var secondStart = connection.StartAsync().OrTimeout();
-                Assert.False(secondStart.IsCompleted);
-
-                // Release the sync point
-                syncPoint.Continue();
-
-                // First start should finish fine
-                await firstStart;
-
-                // Second start should have thrown
-                var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => secondStart);
-                Assert.Equal($"The '{nameof(HubConnection.StartAsync)}' method cannot be called if the connection has already been started.", ex.Message);
-            });
-        }
-
-        [Theory]
-        [MemberData(nameof(MethodsNamesThatRequireActiveConnection))]
-        public async Task MethodsThatRequireStartedConnectionFailIfConnectionNotYetStarted(string name)
-        {
-            var method = MethodsThatRequireActiveConnection[name];
-
-            var testConnection = new TestConnection();
-            await AsyncUsing(new HubConnection(() => testConnection, new JsonHubProtocol()), async connection =>
-            {
-                var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => method(connection));
-                Assert.Equal($"The '{name}' method cannot be called if the connection is not active", ex.Message);
-            });
-        }
-
-        [Theory]
-        [MemberData(nameof(MethodsNamesThatRequireActiveConnection))]
-        public async Task MethodsThatRequireStartedConnectionWaitForStartIfConnectionIsCurrentlyStarting(string name)
-        {
-            var method = MethodsThatRequireActiveConnection[name];
-
-            // Set up StartAsync to wait on the syncPoint when starting
-            var testConnection = new TestConnection(onStart: SyncPoint.Create(out var syncPoint));
-            await AsyncUsing(new HubConnection(() => testConnection, new JsonHubProtocol()), async connection =>
-            {
-                // Start, and wait for the sync point to be hit
-                var startTask = connection.StartAsync().OrTimeout();
-                Assert.False(startTask.IsCompleted);
-                await syncPoint.WaitForSyncPoint();
-
-                // Run the method, but it will be waiting for the lock
-                var targetTask = method(connection).OrTimeout();
-
-                // Release the SyncPoint
-                syncPoint.Continue();
-
-                // Wait for start to finish
-                await startTask;
-
-                // We need some special logic to ensure InvokeAsync completes.
-                if (string.Equals(name, nameof(HubConnection.InvokeAsync)))
+                var testConnection = new TestConnection();
+                await AsyncUsing(new HubConnection(() => testConnection, new JsonHubProtocol()), async connection =>
                 {
-                    await ForceLastInvocationToComplete(testConnection);
-                }
-
-                // Wait for the method to complete.
-                await targetTask;
-            });
-        }
-
-        [Fact]
-        public async Task StopAsyncStopsConnection()
-        {
-            var testConnection = new TestConnection();
-            await AsyncUsing(new HubConnection(() => testConnection, new JsonHubProtocol()), async connection =>
-            {
-                await connection.StartAsync().OrTimeout();
-                Assert.True(testConnection.Started.IsCompleted);
-
-                await connection.StopAsync().OrTimeout();
-                Assert.True(testConnection.Disposed.IsCompleted);
-            });
-        }
-
-        [Fact]
-        public async Task StopAsyncNoOpsIfConnectionNotYetStarted()
-        {
-            var testConnection = new TestConnection();
-            await AsyncUsing(new HubConnection(() => testConnection, new JsonHubProtocol()), async connection =>
-            {
-                await connection.StopAsync().OrTimeout();
-                Assert.False(testConnection.Disposed.IsCompleted);
-            });
-        }
-
-        [Fact]
-        public async Task StopAsyncNoOpsIfConnectionAlreadyStopped()
-        {
-            var testConnection = new TestConnection();
-            await AsyncUsing(new HubConnection(() => testConnection, new JsonHubProtocol()), async connection =>
-            {
-                await connection.StartAsync().OrTimeout();
-                Assert.True(testConnection.Started.IsCompleted);
-
-                await connection.StopAsync().OrTimeout();
-                Assert.True(testConnection.Disposed.IsCompleted);
-
-                await connection.StopAsync().OrTimeout();
-            });
-        }
-
-        [Fact]
-        public async Task ClosedEventTriggersConnectionToStop()
-        {
-            var testConnection = new TestConnection();
-            var closed = new TaskCompletionSource<object>();
-            await AsyncUsing(new HubConnection(() => testConnection, new JsonHubProtocol()), async connection =>
-            {
-                connection.Closed += (e) => closed.TrySetResult(null);
-                await connection.StartAsync().OrTimeout();
-                Assert.True(testConnection.Started.IsCompleted);
-
-                // This will trigger the closed event
-                testConnection.ReceivedMessages.TryComplete();
-                await closed.Task.OrTimeout();
-
-                // We should be stopped now
-                var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => connection.SendAsync("Foo").OrTimeout());
-                Assert.Equal($"The '{nameof(HubConnection.SendAsync)}' method cannot be called if the connection is not active", ex.Message);
-            });
-        }
-
-        [Fact]
-        public async Task ClosedEventWhileShuttingDownIsNoOp()
-        {
-            var testConnection = new TestConnection(onDispose: SyncPoint.Create(out var syncPoint));
-            var testConnectionClosed = new TaskCompletionSource<object>();
-            var connectionClosed = new TaskCompletionSource<object>();
-            await AsyncUsing(new HubConnection(() => testConnection, new JsonHubProtocol()), async connection =>
-            {
-                // We're hooking the TestConnection Closed event here because the HubConnection one will be blocked on the lock
-                testConnection.Closed += (c, e) => testConnectionClosed.TrySetResult(null);
-                connection.Closed += (e) => connectionClosed.TrySetResult(null);
-
-                await connection.StartAsync().OrTimeout();
-                Assert.True(testConnection.Started.IsCompleted);
-
-                // Start shutting down, but hold at the sync point
-                var stopTask = connection.StopAsync().OrTimeout();
-                Assert.False(stopTask.IsCompleted);
-                await syncPoint.WaitForSyncPoint();
-
-                // Now trigger the closed event and wait for the underlying connection to close
-                testConnection.ReceivedMessages.TryComplete();
-                await testConnectionClosed.Task.OrTimeout();
-
-                // Now, complete the StopAsync
-                syncPoint.Continue();
-                await stopTask;
-
-                // The HubConnection should now be closed.
-                await connectionClosed.Task.OrTimeout();
-
-                // We should be stopped now
-                var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => connection.SendAsync("Foo").OrTimeout());
-                Assert.Equal($"The '{nameof(HubConnection.SendAsync)}' method cannot be called if the connection is not active", ex.Message);
-
-                Assert.Equal(1, testConnection.DisposeCount);
-            });
-        }
-
-        [Fact]
-        public async Task StopAsyncDuringUnderlyingConnectionCloseWaitsAndNoOps()
-        {
-            var testConnection = new TestConnection(onDispose: SyncPoint.Create(out var syncPoint));
-            var connectionClosed = new TaskCompletionSource<object>();
-            await AsyncUsing(new HubConnection(() => testConnection, new JsonHubProtocol()), async connection =>
-            {
-                connection.Closed += (e) => connectionClosed.TrySetResult(null);
-
-                await connection.StartAsync().OrTimeout();
-                Assert.True(testConnection.Started.IsCompleted);
-
-                // Trigger the closed event and wait for the underlying connection to close
-                testConnection.ReceivedMessages.TryComplete();
-
-                // Wait for the HubConnection to start disposing the underlying connection (in response to the Closed event firing)
-                await syncPoint.WaitForSyncPoint();
-
-                // Start stopping manually
-                var stopTask = connection.StopAsync().OrTimeout();
-                Assert.False(stopTask.IsCompleted);
-
-                // Now, complete the StopAsync and wait for TestConnection to be fully disposed
-                syncPoint.Continue();
-                await testConnection.Disposed.OrTimeout();
-
-                // Wait for the stop task to complete and the closed event to fire
-                await stopTask;
-                await connectionClosed.Task.OrTimeout();
-
-                // We should be stopped now
-                var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => connection.SendAsync("Foo").OrTimeout());
-                Assert.Equal($"The '{nameof(HubConnection.SendAsync)}' method cannot be called if the connection is not active", ex.Message);
-            });
-        }
-
-        [Theory]
-        [MemberData(nameof(MethodsNamesThatRequireActiveConnection))]
-        public async Task MethodsThatRequireActiveConnectionWaitForStopAndFailIfConnectionIsCurrentlyStopping(string name)
-        {
-            var method = MethodsThatRequireActiveConnection[name];
-
-            // Set up StartAsync to wait on the syncPoint when starting
-            var testConnection = new TestConnection(onDispose: SyncPoint.Create(out var syncPoint));
-            await AsyncUsing(new HubConnection(() => testConnection, new JsonHubProtocol()), async connection =>
-            {
-                await connection.StartAsync().OrTimeout();
-
-                // Stop, but wait at the sync point.
-                var disposeTask = connection.StopAsync().OrTimeout();
-                await syncPoint.WaitForSyncPoint();
-
-                // Now start invoking the method under test
-                var targetTask = method(connection).OrTimeout();
-                Assert.False(targetTask.IsCompleted);
-
-                // Release the sync point
-                syncPoint.Continue();
-
-                // Wait for the method to complete, with an expected error.
-                var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => targetTask);
-                Assert.Equal($"The '{name}' method cannot be called if the connection is not active", ex.Message);
-
-                await disposeTask;
-            });
-        }
-
-        private static async Task ForceLastInvocationToComplete(TestConnection testConnection)
-        {
-            // Dump the handshake message
-            _ = await testConnection.SentMessages.ReadAsync();
-
-            // We need to "complete" the invocation
-            var message = await testConnection.ReadSentTextMessageAsync();
-            var json = JObject.Parse(message.Substring(0, message.Length - 1)); // Gotta remove the record separator.
-            await testConnection.ReceiveJsonMessage(new
-            {
-                type = HubProtocolConstants.CompletionMessageType,
-                invocationId = json["invocationId"],
-            });
-        }
-
-        // A helper that we wouldn't want to use in product code, but is fine for testing until IAsyncDisposable arrives :)
-        private static async Task AsyncUsing(HubConnection connection, Func<HubConnection, Task> action)
-        {
-            try
-            {
-                await action(connection);
+                    await connection.StartAsync();
+                    Assert.True(testConnection.Started.IsCompleted);
+                });
             }
-            finally
+
+            [Fact]
+            public async Task StartAsyncFailsIfAlreadyStarting()
             {
-                await connection.DisposeAsync();
+                // Set up StartAsync to wait on the syncPoint when starting
+                var testConnection = new TestConnection(onStart: SyncPoint.Create(out var syncPoint));
+                await AsyncUsing(new HubConnection(() => testConnection, new JsonHubProtocol()), async connection =>
+                {
+                    var firstStart = connection.StartAsync().OrTimeout();
+                    Assert.False(firstStart.IsCompleted);
+
+                    // Wait for us to be in IConnection.StartAsync
+                    await syncPoint.WaitForSyncPoint();
+
+                    // Try starting again
+                    var secondStart = connection.StartAsync().OrTimeout();
+                    Assert.False(secondStart.IsCompleted);
+
+                    // Release the sync point
+                    syncPoint.Continue();
+
+                    // First start should finish fine
+                    await firstStart;
+
+                    // Second start should have thrown
+                    var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => secondStart);
+                    Assert.Equal($"The '{nameof(HubConnection.StartAsync)}' method cannot be called if the connection has already been started.", ex.Message);
+                });
+            }
+
+            [Theory]
+            [MemberData(nameof(MethodsNamesThatRequireActiveConnection))]
+            public async Task MethodsThatRequireStartedConnectionFailIfConnectionNotYetStarted(string name)
+            {
+                var method = MethodsThatRequireActiveConnection[name];
+
+                var testConnection = new TestConnection();
+                await AsyncUsing(new HubConnection(() => testConnection, new JsonHubProtocol()), async connection =>
+                {
+                    var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => method(connection));
+                    Assert.Equal($"The '{name}' method cannot be called if the connection is not active", ex.Message);
+                });
+            }
+
+            [Theory]
+            [MemberData(nameof(MethodsNamesThatRequireActiveConnection))]
+            public async Task MethodsThatRequireStartedConnectionWaitForStartIfConnectionIsCurrentlyStarting(string name)
+            {
+                var method = MethodsThatRequireActiveConnection[name];
+
+                // Set up StartAsync to wait on the syncPoint when starting
+                var testConnection = new TestConnection(onStart: SyncPoint.Create(out var syncPoint));
+                await AsyncUsing(new HubConnection(() => testConnection, new JsonHubProtocol()), async connection =>
+                {
+                    // Start, and wait for the sync point to be hit
+                    var startTask = connection.StartAsync().OrTimeout();
+                    Assert.False(startTask.IsCompleted);
+                    await syncPoint.WaitForSyncPoint();
+
+                    // Run the method, but it will be waiting for the lock
+                    var targetTask = method(connection).OrTimeout();
+
+                    // Release the SyncPoint
+                    syncPoint.Continue();
+
+                    // Wait for start to finish
+                    await startTask;
+
+                    // We need some special logic to ensure InvokeAsync completes.
+                    if (string.Equals(name, nameof(HubConnection.InvokeAsync)))
+                    {
+                        await ForceLastInvocationToComplete(testConnection);
+                    }
+
+                    // Wait for the method to complete.
+                    await targetTask;
+                });
+            }
+
+            [Fact]
+            public async Task StopAsyncStopsConnection()
+            {
+                var testConnection = new TestConnection();
+                await AsyncUsing(new HubConnection(() => testConnection, new JsonHubProtocol()), async connection =>
+                {
+                    await connection.StartAsync().OrTimeout();
+                    Assert.True(testConnection.Started.IsCompleted);
+
+                    await connection.StopAsync().OrTimeout();
+                    Assert.True(testConnection.Disposed.IsCompleted);
+                });
+            }
+
+            [Fact]
+            public async Task StopAsyncNoOpsIfConnectionNotYetStarted()
+            {
+                var testConnection = new TestConnection();
+                await AsyncUsing(new HubConnection(() => testConnection, new JsonHubProtocol()), async connection =>
+                {
+                    await connection.StopAsync().OrTimeout();
+                    Assert.False(testConnection.Disposed.IsCompleted);
+                });
+            }
+
+            [Fact]
+            public async Task StopAsyncNoOpsIfConnectionAlreadyStopped()
+            {
+                var testConnection = new TestConnection();
+                await AsyncUsing(new HubConnection(() => testConnection, new JsonHubProtocol()), async connection =>
+                {
+                    await connection.StartAsync().OrTimeout();
+                    Assert.True(testConnection.Started.IsCompleted);
+
+                    await connection.StopAsync().OrTimeout();
+                    Assert.True(testConnection.Disposed.IsCompleted);
+
+                    await connection.StopAsync().OrTimeout();
+                });
+            }
+
+            [Fact]
+            public async Task ClosedEventTriggersConnectionToStop()
+            {
+                var testConnection = new TestConnection();
+                var closed = new TaskCompletionSource<object>();
+                await AsyncUsing(new HubConnection(() => testConnection, new JsonHubProtocol()), async connection =>
+                {
+                    connection.Closed += (e) => closed.TrySetResult(null);
+                    await connection.StartAsync().OrTimeout();
+                    Assert.True(testConnection.Started.IsCompleted);
+
+                    // This will trigger the closed event
+                    testConnection.ReceivedMessages.TryComplete();
+                    await closed.Task.OrTimeout();
+
+                    // We should be stopped now
+                    var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => connection.SendAsync("Foo").OrTimeout());
+                    Assert.Equal($"The '{nameof(HubConnection.SendAsync)}' method cannot be called if the connection is not active", ex.Message);
+                });
+            }
+
+            [Fact]
+            public async Task ClosedEventWhileShuttingDownIsNoOp()
+            {
+                var testConnection = new TestConnection(onDispose: SyncPoint.Create(out var syncPoint));
+                var testConnectionClosed = new TaskCompletionSource<object>();
+                var connectionClosed = new TaskCompletionSource<object>();
+                await AsyncUsing(new HubConnection(() => testConnection, new JsonHubProtocol()), async connection =>
+                {
+                    // We're hooking the TestConnection Closed event here because the HubConnection one will be blocked on the lock
+                    testConnection.Closed += (c, e) => testConnectionClosed.TrySetResult(null);
+                    connection.Closed += (e) => connectionClosed.TrySetResult(null);
+
+                    await connection.StartAsync().OrTimeout();
+                    Assert.True(testConnection.Started.IsCompleted);
+
+                    // Start shutting down, but hold at the sync point
+                    var stopTask = connection.StopAsync().OrTimeout();
+                    Assert.False(stopTask.IsCompleted);
+                    await syncPoint.WaitForSyncPoint();
+
+                    // Now trigger the closed event and wait for the underlying connection to close
+                    testConnection.ReceivedMessages.TryComplete();
+                    await testConnectionClosed.Task.OrTimeout();
+
+                    // Now, complete the StopAsync
+                    syncPoint.Continue();
+                    await stopTask;
+
+                    // The HubConnection should now be closed.
+                    await connectionClosed.Task.OrTimeout();
+
+                    // We should be stopped now
+                    var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => connection.SendAsync("Foo").OrTimeout());
+                    Assert.Equal($"The '{nameof(HubConnection.SendAsync)}' method cannot be called if the connection is not active", ex.Message);
+
+                    Assert.Equal(1, testConnection.DisposeCount);
+                });
+            }
+
+            [Fact]
+            public async Task StopAsyncDuringUnderlyingConnectionCloseWaitsAndNoOps()
+            {
+                var testConnection = new TestConnection(onDispose: SyncPoint.Create(out var syncPoint));
+                var connectionClosed = new TaskCompletionSource<object>();
+                await AsyncUsing(new HubConnection(() => testConnection, new JsonHubProtocol()), async connection =>
+                {
+                    connection.Closed += (e) => connectionClosed.TrySetResult(null);
+
+                    await connection.StartAsync().OrTimeout();
+                    Assert.True(testConnection.Started.IsCompleted);
+
+                    // Trigger the closed event and wait for the underlying connection to close
+                    testConnection.ReceivedMessages.TryComplete();
+
+                    // Wait for the HubConnection to start disposing the underlying connection (in response to the Closed event firing)
+                    await syncPoint.WaitForSyncPoint();
+
+                    // Start stopping manually
+                    var stopTask = connection.StopAsync().OrTimeout();
+                    Assert.False(stopTask.IsCompleted);
+
+                    // Now, complete the StopAsync and wait for TestConnection to be fully disposed
+                    syncPoint.Continue();
+                    await testConnection.Disposed.OrTimeout();
+
+                    // Wait for the stop task to complete and the closed event to fire
+                    await stopTask;
+                    await connectionClosed.Task.OrTimeout();
+
+                    // We should be stopped now
+                    var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => connection.SendAsync("Foo").OrTimeout());
+                    Assert.Equal($"The '{nameof(HubConnection.SendAsync)}' method cannot be called if the connection is not active", ex.Message);
+                });
+            }
+
+            [Theory]
+            [MemberData(nameof(MethodsNamesThatRequireActiveConnection))]
+            public async Task MethodsThatRequireActiveConnectionWaitForStopAndFailIfConnectionIsCurrentlyStopping(string name)
+            {
+                var method = MethodsThatRequireActiveConnection[name];
+
+                // Set up StartAsync to wait on the syncPoint when starting
+                var testConnection = new TestConnection(onDispose: SyncPoint.Create(out var syncPoint));
+                await AsyncUsing(new HubConnection(() => testConnection, new JsonHubProtocol()), async connection =>
+                {
+                    await connection.StartAsync().OrTimeout();
+
+                    // Stop, but wait at the sync point.
+                    var disposeTask = connection.StopAsync().OrTimeout();
+                    await syncPoint.WaitForSyncPoint();
+
+                    // Now start invoking the method under test
+                    var targetTask = method(connection).OrTimeout();
+                    Assert.False(targetTask.IsCompleted);
+
+                    // Release the sync point
+                    syncPoint.Continue();
+
+                    // Wait for the method to complete, with an expected error.
+                    var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => targetTask);
+                    Assert.Equal($"The '{name}' method cannot be called if the connection is not active", ex.Message);
+
+                    await disposeTask;
+                });
+            }
+
+            private static async Task ForceLastInvocationToComplete(TestConnection testConnection)
+            {
+                // Dump the handshake message
+                _ = await testConnection.SentMessages.ReadAsync();
+
+                // Send a response
+                await testConnection.ReceiveJsonMessage(new { });
+
+                // We need to "complete" the invocation
+                var message = await testConnection.ReadSentTextMessageAsync();
+                var json = JObject.Parse(message.Substring(0, message.Length - 1)); // Gotta remove the record separator.
+                await testConnection.ReceiveJsonMessage(new
+                {
+                    type = HubProtocolConstants.CompletionMessageType,
+                    invocationId = json["invocationId"],
+                });
+            }
+
+            // A helper that we wouldn't want to use in product code, but is fine for testing until IAsyncDisposable arrives :)
+            private static async Task AsyncUsing(HubConnection connection, Func<HubConnection, Task> action)
+            {
+                try
+                {
+                    await action(connection);
+                }
+                finally
+                {
+                    await connection.DisposeAsync();
+                }
             }
         }
     }

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.cs
@@ -20,41 +20,15 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
     public class HubConnectionTests
     {
         [Fact]
-        public async Task StartAsyncCallsConnectionStart()
-        {
-            var connection = new Mock<IConnection>();
-            var protocol = new Mock<IHubProtocol>();
-            protocol.SetupGet(p => p.TransferFormat).Returns(TransferFormat.Text);
-            connection.SetupGet(p => p.Features).Returns(new FeatureCollection());
-            connection.Setup(m => m.StartAsync(TransferFormat.Text)).Returns(Task.CompletedTask).Verifiable();
-            var hubConnection = new HubConnection(connection.Object, protocol.Object, null);
-            await hubConnection.StartAsync();
-
-            connection.Verify(c => c.StartAsync(TransferFormat.Text), Times.Once());
-        }
-
-        [Fact]
-        public async Task DisposeAsyncCallsConnectionStart()
-        {
-            var connection = new Mock<IConnection>();
-            connection.Setup(m => m.Features).Returns(new FeatureCollection());
-            connection.Setup(m => m.StartAsync(TransferFormat.Text)).Verifiable();
-            var hubConnection = new HubConnection(connection.Object, Mock.Of<IHubProtocol>(), null);
-            await hubConnection.DisposeAsync();
-
-            connection.Verify(c => c.DisposeAsync(), Times.Once());
-        }
-
-        [Fact]
         public async Task InvokeThrowsIfSerializingMessageFails()
         {
             var exception = new InvalidOperationException();
             var mockProtocol = MockHubProtocol.Throw(exception);
-            var hubConnection = new HubConnection(new TestConnection(), mockProtocol, null);
+            var hubConnection = new HubConnection(() => new TestConnection(), mockProtocol, null);
             await hubConnection.StartAsync();
 
             var actualException =
-                await Assert.ThrowsAsync<InvalidOperationException>(async () => await hubConnection.InvokeAsync<int>("test"));
+                await Assert.ThrowsAsync<InvalidOperationException>(async () => await hubConnection.InvokeAsync<int>("test").OrTimeout());
             Assert.Same(exception, actualException);
         }
 
@@ -63,7 +37,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
         {
             var exception = new InvalidOperationException();
             var mockProtocol = MockHubProtocol.Throw(exception);
-            var hubConnection = new HubConnection(new TestConnection(), mockProtocol, null);
+            var hubConnection = new HubConnection(() => new TestConnection(), mockProtocol, null);
             await hubConnection.StartAsync();
 
             var actualException =
@@ -74,12 +48,12 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
         [Fact]
         public async Task ClosedEventRaisedWhenTheClientIsStopped()
         {
-            var hubConnection = new HubConnection(new TestConnection(), Mock.Of<IHubProtocol>(), null);
+            var hubConnection = new HubConnection(() => new TestConnection(), Mock.Of<IHubProtocol>(), null);
             var closedEventTcs = new TaskCompletionSource<Exception>();
             hubConnection.Closed += e => closedEventTcs.SetResult(e);
 
             await hubConnection.StartAsync().OrTimeout();
-            await hubConnection.DisposeAsync().OrTimeout();
+            await hubConnection.StopAsync().OrTimeout();
             Assert.Null(await closedEventTcs.Task);
         }
 
@@ -87,88 +61,115 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
         public async Task CannotCallInvokeOnNotStartedHubConnection()
         {
             var connection = new TestConnection();
-            var hubConnection = new HubConnection(connection, new JsonHubProtocol(), new LoggerFactory());
+            var hubConnection = new HubConnection(() => connection, new JsonHubProtocol(), new LoggerFactory());
 
             var exception = await Assert.ThrowsAsync<InvalidOperationException>(
                 () => hubConnection.InvokeAsync<int>("test"));
 
-            Assert.Equal("The 'InvokeAsync' method cannot be called before the connection has been started.", exception.Message);
+            Assert.Equal($"The '{nameof(HubConnection.InvokeAsync)}' method cannot be called if the connection is not active", exception.Message);
         }
 
         [Fact]
         public async Task CannotCallInvokeOnClosedHubConnection()
         {
             var connection = new TestConnection();
-            var hubConnection = new HubConnection(connection, new JsonHubProtocol(), new LoggerFactory());
+            var hubConnection = new HubConnection(() => connection, new JsonHubProtocol(), new LoggerFactory());
 
             await hubConnection.StartAsync();
-            await hubConnection.DisposeAsync();
+            await hubConnection.StopAsync();
             var exception = await Assert.ThrowsAsync<InvalidOperationException>(
                 () => hubConnection.InvokeAsync<int>("test"));
 
-            Assert.Equal("Connection has been terminated.", exception.Message);
+            Assert.Equal($"The '{nameof(HubConnection.InvokeAsync)}' method cannot be called if the connection is not active", exception.Message);
         }
 
         [Fact]
         public async Task CannotCallSendOnNotStartedHubConnection()
         {
             var connection = new TestConnection();
-            var hubConnection = new HubConnection(connection, new JsonHubProtocol(), new LoggerFactory());
+            var hubConnection = new HubConnection(() => connection, new JsonHubProtocol(), new LoggerFactory());
 
             var exception = await Assert.ThrowsAsync<InvalidOperationException>(
                 () => hubConnection.SendAsync("test"));
 
-            Assert.Equal("The 'SendAsync' method cannot be called before the connection has been started.", exception.Message);
+            Assert.Equal($"The '{nameof(HubConnection.SendAsync)}' method cannot be called if the connection is not active", exception.Message);
         }
 
         [Fact]
         public async Task CannotCallSendOnClosedHubConnection()
         {
             var connection = new TestConnection();
-            var hubConnection = new HubConnection(connection, new JsonHubProtocol(), new LoggerFactory());
+            var hubConnection = new HubConnection(() => connection, new JsonHubProtocol(), new LoggerFactory());
 
             await hubConnection.StartAsync();
-            await hubConnection.DisposeAsync();
+            await hubConnection.StopAsync();
             var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => hubConnection.SendAsync("test"));
 
-            Assert.Equal("Connection has been terminated.", exception.Message);
+            Assert.Equal($"The '{nameof(HubConnection.SendAsync)}' method cannot be called if the connection is not active", exception.Message);
         }
 
         [Fact]
         public async Task CannotCallStreamOnClosedHubConnection()
         {
             var connection = new TestConnection();
-            var hubConnection = new HubConnection(connection, new JsonHubProtocol(), new LoggerFactory());
+            var hubConnection = new HubConnection(() => connection, new JsonHubProtocol(), new LoggerFactory());
 
             await hubConnection.StartAsync();
-            await hubConnection.DisposeAsync();
+            await hubConnection.StopAsync();
             var exception = await Assert.ThrowsAsync<InvalidOperationException>(
                 () => hubConnection.StreamAsChannelAsync<int>("test"));
 
-            Assert.Equal("Connection has been terminated.", exception.Message);
+            Assert.Equal($"The '{nameof(HubConnection.StreamAsChannelAsync)}' method cannot be called if the connection is not active", exception.Message);
+        }
+
+        [Fact]
+        public async Task CannotCallSendOnDisposedHubConnection()
+        {
+            var connection = new TestConnection();
+            var hubConnection = new HubConnection(() => connection, new JsonHubProtocol(), new LoggerFactory());
+
+            await hubConnection.StartAsync();
+            await hubConnection.DisposeAsync();
+            var exception = await Assert.ThrowsAsync<ObjectDisposedException>(() => hubConnection.SendAsync("test"));
+
+            Assert.Equal(nameof(HubConnection), exception.ObjectName);
+        }
+
+        [Fact]
+        public async Task CannotCallStreamOnDisposedHubConnection()
+        {
+            var connection = new TestConnection();
+            var hubConnection = new HubConnection(() => connection, new JsonHubProtocol(), new LoggerFactory());
+
+            await hubConnection.StartAsync();
+            await hubConnection.DisposeAsync();
+            var exception = await Assert.ThrowsAsync<ObjectDisposedException>(
+                () => hubConnection.StreamAsChannelAsync<int>("test"));
+
+            Assert.Equal(nameof(HubConnection), exception.ObjectName);
         }
 
         [Fact]
         public async Task CannotCallStreamOnNotStartedHubConnection()
         {
             var connection = new TestConnection();
-            var hubConnection = new HubConnection(connection, new JsonHubProtocol(), new LoggerFactory());
+            var hubConnection = new HubConnection(() => connection, new JsonHubProtocol(), new LoggerFactory());
 
             var exception = await Assert.ThrowsAsync<InvalidOperationException>(
                 () => hubConnection.StreamAsChannelAsync<int>("test"));
 
-            Assert.Equal("The 'StreamAsChannelAsync' method cannot be called before the connection has been started.", exception.Message);
+            Assert.Equal($"The '{nameof(HubConnection.StreamAsChannelAsync)}' method cannot be called if the connection is not active", exception.Message);
         }
 
         [Fact]
         public async Task PendingInvocationsAreCancelledWhenConnectionClosesCleanly()
         {
             var connection = new TestConnection();
-            var hubConnection = new HubConnection(connection, new JsonHubProtocol(), new LoggerFactory());
+            var hubConnection = new HubConnection(() => connection, new JsonHubProtocol(), new LoggerFactory());
 
             await hubConnection.StartAsync();
             var invokeTask = hubConnection.InvokeAsync<int>("testMethod");
-            await hubConnection.DisposeAsync();
+            await hubConnection.StopAsync();
 
             await Assert.ThrowsAsync<TaskCanceledException>(async () => await invokeTask);
         }
@@ -182,7 +183,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                 .Setup(m => m.DisposeAsync())
                 .Returns(Task.FromResult<object>(null));
 
-            var hubConnection = new HubConnection(mockConnection.Object, Mock.Of<IHubProtocol>(), new LoggerFactory());
+            var hubConnection = new HubConnection(() => mockConnection.Object, Mock.Of<IHubProtocol>(), new LoggerFactory());
 
             await hubConnection.StartAsync();
             var invokeTask = hubConnection.InvokeAsync<int>("testMethod");
@@ -198,7 +199,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
         public async Task ConnectionTerminatedIfServerTimeoutIntervalElapsesWithNoMessages()
         {
             var connection = new TestConnection();
-            var hubConnection = new HubConnection(connection, new JsonHubProtocol(), new LoggerFactory());
+            var hubConnection = new HubConnection(() => connection, new JsonHubProtocol(), new LoggerFactory());
 
             hubConnection.ServerTimeout = TimeSpan.FromMilliseconds(100);
 
@@ -215,9 +216,9 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
         public async Task OnReceivedAfterTimerDisposedDoesNotThrow()
         {
             var connection = new TestConnection();
-            var hubConnection = new HubConnection(connection, new JsonHubProtocol(), new LoggerFactory());
+            var hubConnection = new HubConnection(() => connection, new JsonHubProtocol(), new LoggerFactory());
             await hubConnection.StartAsync().OrTimeout();
-            await hubConnection.DisposeAsync().OrTimeout();
+            await hubConnection.StopAsync().OrTimeout();
 
             // Fire callbacks, they shouldn't fail
             foreach (var registration in connection.Callbacks)

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.cs
@@ -17,7 +17,7 @@ using Xunit;
 
 namespace Microsoft.AspNetCore.SignalR.Client.Tests
 {
-    public class HubConnectionTests
+    public partial class HubConnectionTests
     {
         [Fact]
         public async Task InvokeThrowsIfSerializingMessageFails()
@@ -189,7 +189,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
             var invokeTask = hubConnection.InvokeAsync<int>("testMethod");
 
             var exception = new InvalidOperationException();
-            mockConnection.Raise(m => m.Closed += null, exception);
+            mockConnection.Raise(m => m.Closed += null, mockConnection.Object, exception);
 
             var actualException = await Assert.ThrowsAsync<InvalidOperationException>(async () => await invokeTask);
             Assert.Equal(exception, actualException);
@@ -213,7 +213,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
         }
 
         [Fact]
-        public async Task OnReceivedAfterTimerDisposedDoesNotThrow()
+        public async Task OnReceivedAfterConnectionDisposedDoesNotThrow()
         {
             var connection = new TestConnection();
             var hubConnection = new HubConnection(() => connection, new JsonHubProtocol(), new LoggerFactory());

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/SyncPoint.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/SyncPoint.cs
@@ -1,0 +1,76 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+// Possibly useful as a general-purpose async testing helper?
+public class SyncPoint
+        {
+            private TaskCompletionSource<object> _atSyncPoint = new TaskCompletionSource<object>();
+            private TaskCompletionSource<object> _continueFromSyncPoint = new TaskCompletionSource<object>();
+
+            /// <summary>
+            /// Waits for the code-under-test to reach <see cref="WaitToContinue"/>.
+            /// </summary>
+            /// <returns></returns>
+            public Task WaitForSyncPoint() => _atSyncPoint.Task;
+
+            /// <summary>
+            /// Releases the code-under-test to continue past where it waited for <see cref="WaitToContinue"/>.
+            /// </summary>
+            public void Continue() => _continueFromSyncPoint.TrySetResult(null);
+
+            /// <summary>
+            /// Used by the code-under-test to wait for the test code to sync up.
+            /// </summary>
+            /// <remarks>
+            /// This code will unblock <see cref="WaitForSyncPoint"/> and then block waiting for <see cref="Continue"/> to be called.
+            /// </remarks>
+            /// <returns></returns>
+            public Task WaitToContinue()
+            {
+                _atSyncPoint.TrySetResult(null);
+                return _continueFromSyncPoint.Task;
+            }
+
+            public static Func<Task> Create(out SyncPoint syncPoint)
+            {
+                var handler = Create(1, out var syncPoints);
+                syncPoint = syncPoints[0];
+                return handler;
+            }
+
+            /// <summary>
+            /// Creates a re-entrant function that waits for sync points in sequence.
+            /// </summary>
+            /// <param name="count">The number of sync points to expect</param>
+            /// <param name="syncPoints">The <see cref="SyncPoint"/> objects that can be used to coordinate the sync point</param>
+            /// <returns></returns>
+            public static Func<Task> Create(int count, out SyncPoint[] syncPoints)
+            {
+                // Need to use a local so the closure can capture it. You can't use out vars in a closure.
+                var localSyncPoints = new SyncPoint[count];
+                for (var i = 0; i < count; i += 1)
+                {
+                    localSyncPoints[i] = new SyncPoint();
+                }
+
+                syncPoints = localSyncPoints;
+
+                var counter = 0;
+                return () =>
+                {
+                    if (counter >= localSyncPoints.Length)
+                    {
+                        return Task.CompletedTask;
+                    }
+                    else
+                    {
+                        var syncPoint = localSyncPoints[counter];
+
+                        counter += 1;
+                        return syncPoint.WaitToContinue();
+                    }
+                };
+            }
+}

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/SyncPoint.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/SyncPoint.cs
@@ -1,76 +1,80 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Threading.Tasks;
-// Possibly useful as a general-purpose async testing helper?
-public class SyncPoint
+
+namespace Microsoft.AspNetCore.SignalR.Client.Tests
+{
+    // Possibly useful as a general-purpose async testing helper?
+    public class SyncPoint
+    {
+        private readonly TaskCompletionSource<object> _atSyncPoint = new TaskCompletionSource<object>();
+        private readonly TaskCompletionSource<object> _continueFromSyncPoint = new TaskCompletionSource<object>();
+
+        /// <summary>
+        /// Waits for the code-under-test to reach <see cref="WaitToContinue"/>.
+        /// </summary>
+        /// <returns></returns>
+        public Task WaitForSyncPoint() => _atSyncPoint.Task;
+
+        /// <summary>
+        /// Releases the code-under-test to continue past where it waited for <see cref="WaitToContinue"/>.
+        /// </summary>
+        public void Continue() => _continueFromSyncPoint.TrySetResult(null);
+
+        /// <summary>
+        /// Used by the code-under-test to wait for the test code to sync up.
+        /// </summary>
+        /// <remarks>
+        /// This code will unblock <see cref="WaitForSyncPoint"/> and then block waiting for <see cref="Continue"/> to be called.
+        /// </remarks>
+        /// <returns></returns>
+        public Task WaitToContinue()
         {
-            private TaskCompletionSource<object> _atSyncPoint = new TaskCompletionSource<object>();
-            private TaskCompletionSource<object> _continueFromSyncPoint = new TaskCompletionSource<object>();
+            _atSyncPoint.TrySetResult(null);
+            return _continueFromSyncPoint.Task;
+        }
 
-            /// <summary>
-            /// Waits for the code-under-test to reach <see cref="WaitToContinue"/>.
-            /// </summary>
-            /// <returns></returns>
-            public Task WaitForSyncPoint() => _atSyncPoint.Task;
+        public static Func<Task> Create(out SyncPoint syncPoint)
+        {
+            var handler = Create(1, out var syncPoints);
+            syncPoint = syncPoints[0];
+            return handler;
+        }
 
-            /// <summary>
-            /// Releases the code-under-test to continue past where it waited for <see cref="WaitToContinue"/>.
-            /// </summary>
-            public void Continue() => _continueFromSyncPoint.TrySetResult(null);
-
-            /// <summary>
-            /// Used by the code-under-test to wait for the test code to sync up.
-            /// </summary>
-            /// <remarks>
-            /// This code will unblock <see cref="WaitForSyncPoint"/> and then block waiting for <see cref="Continue"/> to be called.
-            /// </remarks>
-            /// <returns></returns>
-            public Task WaitToContinue()
+        /// <summary>
+        /// Creates a re-entrant function that waits for sync points in sequence.
+        /// </summary>
+        /// <param name="count">The number of sync points to expect</param>
+        /// <param name="syncPoints">The <see cref="SyncPoint"/> objects that can be used to coordinate the sync point</param>
+        /// <returns></returns>
+        public static Func<Task> Create(int count, out SyncPoint[] syncPoints)
+        {
+            // Need to use a local so the closure can capture it. You can't use out vars in a closure.
+            var localSyncPoints = new SyncPoint[count];
+            for (var i = 0; i < count; i += 1)
             {
-                _atSyncPoint.TrySetResult(null);
-                return _continueFromSyncPoint.Task;
+                localSyncPoints[i] = new SyncPoint();
             }
 
-            public static Func<Task> Create(out SyncPoint syncPoint)
-            {
-                var handler = Create(1, out var syncPoints);
-                syncPoint = syncPoints[0];
-                return handler;
-            }
+            syncPoints = localSyncPoints;
 
-            /// <summary>
-            /// Creates a re-entrant function that waits for sync points in sequence.
-            /// </summary>
-            /// <param name="count">The number of sync points to expect</param>
-            /// <param name="syncPoints">The <see cref="SyncPoint"/> objects that can be used to coordinate the sync point</param>
-            /// <returns></returns>
-            public static Func<Task> Create(int count, out SyncPoint[] syncPoints)
+            var counter = 0;
+            return () =>
             {
-                // Need to use a local so the closure can capture it. You can't use out vars in a closure.
-                var localSyncPoints = new SyncPoint[count];
-                for (var i = 0; i < count; i += 1)
+                if (counter >= localSyncPoints.Length)
                 {
-                    localSyncPoints[i] = new SyncPoint();
+                    return Task.CompletedTask;
                 }
-
-                syncPoints = localSyncPoints;
-
-                var counter = 0;
-                return () =>
+                else
                 {
-                    if (counter >= localSyncPoints.Length)
-                    {
-                        return Task.CompletedTask;
-                    }
-                    else
-                    {
-                        var syncPoint = localSyncPoints[counter];
+                    var syncPoint = localSyncPoints[counter];
 
-                        counter += 1;
-                        return syncPoint.WaitToContinue();
-                    }
-                };
-            }
+                    counter += 1;
+                    return syncPoint.WaitToContinue();
+                }
+            };
+        }
+    }
 }

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/TestConnection.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/TestConnection.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.Protocols;
 using Microsoft.AspNetCore.SignalR.Internal.Formatters;
 using Microsoft.AspNetCore.SignalR.Internal.Protocol;
 using Microsoft.AspNetCore.Sockets.Client;
+using Microsoft.AspNetCore.Sockets.Client.Internal;
 using Newtonsoft.Json;
 
 namespace Microsoft.AspNetCore.SignalR.Client.Tests
@@ -57,6 +58,8 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
 
         // TestConnection isn't restartable
         public Task StopAsync() => DisposeAsync();
+
+        private TaskQueue _taskQueue = new TaskQueue();
 
         private async Task DisposeCoreAsync(Exception ex = null)
         {
@@ -144,7 +147,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
 
                         foreach (var callback in callbackCopies)
                         {
-                            await callback.InvokeAsync(message);
+                            _ = _taskQueue.Enqueue(() => callback.InvokeAsync(message));
                         }
                     }
                 }

--- a/test/Microsoft.AspNetCore.SignalR.Tests/EndToEndTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/EndToEndTests.cs
@@ -180,7 +180,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                 try
                 {
                     var closeTcs = new TaskCompletionSource<object>();
-                    connection.Closed += e =>
+                    connection.Closed += (_, e) =>
                     {
                         if (e != null)
                         {


### PR DESCRIPTION
Part of #1475 

With this change, `HttpConnection` is left mostly unchanged (it is restartable), however `HubConnection` does not use that logic. Instead it dumps and recreates the `HttpConnection` each time. This is part of moving the restart logic to `HubConnection`.

A few behavioral changes:
* We used to silently complete streams that were cancelled, I changed that to throw OperationCancelledException (or `TaskCancelledException` in the Completion Task of the Channel))
* We used to have `HubConnection.StopAsync` wait until the `HttpConnection.Closed` event fired. Now, we dispose the `HttpConnection` and just null it out. We no longer care about it, so we can just ignore the `Closed` event when it fires. Note that **if** the `Closed` event fires before `StopAsync` (because the server disconnected), we still proceed to shut down. We do this by including the `IConnection` instance that triggered the close in the `Closed` event. This is mostly temporary until we pipelinify the client, at which point we'll have a Completion task to check and `ReadAsync` calls to wait on.

This is **not** complete and I expect to close it and continue iterating, but I want to get some code out to look at it. This component of the change is basically finished.