### PR TITLE
clean up test output

### DIFF
--- a/client-ts/FunctionalTests/selenium/run-ci-tests.ts
+++ b/client-ts/FunctionalTests/selenium/run-ci-tests.ts
@@ -74,16 +74,13 @@ if (!existsSync(chromeBinary)) {
 }
 
 // Launch the tests
-const args = ["test", "--", "--chrome", chromeBinary];
+const args = ["test", "--", "--raw", "--chrome", chromeBinary];
 if (configuration) {
     args.push("--configuration");
     args.push(configuration);
 }
 if (verbose) {
     args.push("--verbose");
-}
-if (teamcity) {
-    args.push("--raw");
 }
 
 const testProcess = spawn("npm", args, { cwd: path.resolve(__dirname, "..") });


### PR DESCRIPTION
* More greppable, just search for `not ok`
* The TAP formatter libraries just aren't cutting it on the CI, so just use the raw output
* Disable verbose mode (which interleaves server log messages) by default because it is le noisy.