### PR TITLE
Improved allocations and throughput for broadcast scenarios

### DIFF
--- a/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/BroadcastBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/BroadcastBenchmark.cs
@@ -40,9 +40,10 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
                 protocol = new MessagePackHubProtocol();
             }
 
+            var options = new PipeOptions();
             for (var i = 0; i < Connections; ++i)
             {
-                var pair = DuplexPipe.CreateConnectionPair(PipeOptions.Default, PipeOptions.Default);
+                var pair = DuplexPipe.CreateConnectionPair(options, options);
                 var connection = new DefaultConnectionContext(Guid.NewGuid().ToString(), pair.Application, pair.Transport);
                 var hubConnection = new HubConnectionContext(connection, Timeout.InfiniteTimeSpan, NullLoggerFactory.Instance);
                 hubConnection.Protocol = protocol;

--- a/src/Microsoft.AspNetCore.SignalR.Core/DefaultHubLifetimeManager.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/DefaultHubLifetimeManager.cs
@@ -69,18 +69,37 @@ namespace Microsoft.AspNetCore.SignalR
 
         public override Task SendAllAsync(string methodName, object[] args)
         {
-            return SendAllWhere(methodName, args, c => true);
-        }
+            List<Task> tasks = null;
+            var message = CreateInvocationMessage(methodName, args);
 
-        private Task SendAllWhere(string methodName, object[] args, Func<HubConnectionContext, bool> include)
-        {
-            var count = _connections.Count;
-            if (count == 0)
+            foreach (var connection in _connections)
+            {
+                var task = connection.WriteAsync(message);
+
+                if (!task.IsCompleted)
+                {
+                    if (tasks == null)
+                    {
+                        tasks = new List<Task>();
+                    }
+
+                    tasks.Add(task);
+                }
+            }
+
+            // No async
+            if (tasks == null)
             {
                 return Task.CompletedTask;
             }
 
-            var tasks = new List<Task>(count);
+            // Some connections are slow
+            return Task.WhenAll(tasks);
+        }
+
+        private Task SendAllWhere(string methodName, object[] args, Func<HubConnectionContext, bool> include)
+        {
+            List<Task> tasks = null;
             var message = CreateInvocationMessage(methodName, args);
 
             foreach (var connection in _connections)
@@ -90,9 +109,25 @@ namespace Microsoft.AspNetCore.SignalR
                     continue;
                 }
 
-                tasks.Add(SafeWriteAsync(connection, message));
+                var task = connection.WriteAsync(message);
+
+                if (!task.IsCompleted)
+                {
+                    if (tasks == null)
+                    {
+                        tasks = new List<Task>();
+                    }
+
+                    tasks.Add(task);
+                }
             }
 
+            if (tasks == null)
+            {
+                return Task.CompletedTask;
+            }
+
+            // Some connections are slow
             return Task.WhenAll(tasks);
         }
 
@@ -112,7 +147,7 @@ namespace Microsoft.AspNetCore.SignalR
 
             var message = CreateInvocationMessage(methodName, args);
 
-            return SafeWriteAsync(connection, message);
+            return connection.WriteAsync(message);
         }
 
         public override Task SendGroupAsync(string groupName, string methodName, object[] args)
@@ -126,7 +161,7 @@ namespace Microsoft.AspNetCore.SignalR
             if (group != null)
             {
                 var message = CreateInvocationMessage(methodName, args);
-                var tasks = group.Values.Select(c => SafeWriteAsync(c, message));
+                var tasks = group.Values.Select(c => c.WriteAsync(message));
                 return Task.WhenAll(tasks);
             }
 
@@ -149,7 +184,7 @@ namespace Microsoft.AspNetCore.SignalR
                 var group = _groups[groupName];
                 if (group != null)
                 {
-                    tasks.Add(Task.WhenAll(group.Values.Select(c =>  SafeWriteAsync(c, message))));
+                    tasks.Add(Task.WhenAll(group.Values.Select(c => c.WriteAsync(message))));
                 }
             }
 
@@ -168,7 +203,7 @@ namespace Microsoft.AspNetCore.SignalR
             {
                 var message = CreateInvocationMessage(methodName, args);
                 var tasks = group.Values.Where(connection => !excludedIds.Contains(connection.ConnectionId))
-                    .Select(c => SafeWriteAsync(c, message));
+                    .Select(c => c.WriteAsync(message));
                 return Task.WhenAll(tasks);
             }
 
@@ -221,31 +256,6 @@ namespace Microsoft.AspNetCore.SignalR
             {
                 return userIds.Contains(connection.UserIdentifier);
             });
-        }
-
-        // This method is to protect against connections throwing synchronously when writing to them and preventing other connections from being written to
-        private async Task SafeWriteAsync(HubConnectionContext connection, InvocationMessage message)
-        {
-            try
-            {
-                await connection.WriteAsync(message);
-            }
-            // This exception isn't interesting to users
-            catch (Exception ex)
-            {
-                Log.FailedWritingMessage(_logger, ex);
-            }
-        }
-
-        private static class Log
-        {
-            private static readonly Action<ILogger, Exception> _failedWritingMessage =
-                LoggerMessage.Define(LogLevel.Warning, new EventId(1, "FailedWritingMessage"), "Failed writing message.");
-
-            public static void FailedWritingMessage(ILogger logger, Exception exception)
-            {
-                _failedWritingMessage(logger, exception);
-            }
         }
     }
 }

--- a/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionContext.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionContext.cs
@@ -74,20 +74,71 @@ namespace Microsoft.AspNetCore.SignalR
 
         public int? LocalPort => Features.Get<IHttpConnectionFeature>()?.LocalPort;
 
-        public virtual async Task WriteAsync(HubMessage message)
+        public virtual Task WriteAsync(HubMessage message)
         {
-            await _writeLock.WaitAsync();
+            // We were unable to get the lock so take the slow async path of waiting for the semaphore
+            if (!_writeLock.Wait(0))
+            {
+                return WriteSlowAsync(message);
+            }
 
+            // This method should never throw synchronously
+            var task = WriteCore(message);
+
+            // The write didn't complete synchronously so await completion
+            if (!task.IsCompleted)
+            {
+                return CompleteWriteAsync(task);
+            }
+
+            // The write failed so observe the exception
+            if (task.IsFaulted)
+            {
+                try
+                {
+                    task.GetAwaiter().GetResult();
+                }
+                catch (Exception ex)
+                {
+                    Log.FailedWritingMessage(_logger, ex);
+                }
+            }
+
+            // Otherwise, release the lock
+            _writeLock.Release();
+
+            return Task.CompletedTask;
+        }
+
+        private ValueTask<FlushResult> WriteCore(HubMessage message)
+        {
             try
             {
-                // This will internally cache the buffer for each unique HubProtocol/DataEncoder combination
+                // This will internally cache the buffer for each unique HubProtocol
                 // So that we don't serialize the HubMessage for every single connection
                 var buffer = message.WriteMessage(Protocol);
+
                 _connectionContext.Transport.Output.Write(buffer);
 
-                Interlocked.Exchange(ref _lastSendTimestamp, Stopwatch.GetTimestamp());
+                return _connectionContext.Transport.Output.FlushAsync();
+            }
+            catch (Exception ex)
+            {
+                Log.FailedWritingMessage(_logger, ex);
 
-                await _connectionContext.Transport.Output.FlushAsync();
+                return new ValueTask<FlushResult>(new FlushResult(isCanceled: false, isCompleted: true));
+            }
+        }
+
+        private async Task CompleteWriteAsync(ValueTask<FlushResult> task)
+        {
+            try
+            {
+                await task;
+            }
+            catch (Exception ex)
+            {
+                Log.FailedWritingMessage(_logger, ex);
             }
             finally
             {
@@ -95,23 +146,51 @@ namespace Microsoft.AspNetCore.SignalR
             }
         }
 
-        private async Task TryWritePingAsync()
+        private async Task WriteSlowAsync(HubMessage message)
+        {
+            try
+            {
+                await _writeLock.WaitAsync();
+
+                await WriteCore(message);
+            }
+            catch (Exception ex)
+            {
+                Log.FailedWritingMessage(_logger, ex);
+            }
+            finally
+            {
+                _writeLock.Release();
+            }
+        }
+
+        private Task TryWritePingAsync()
         {
             // Don't wait for the lock, if it returns false that means someone wrote to the connection
             // and we don't need to send a ping anymore
-            if (!await _writeLock.WaitAsync(0))
+            if (!_writeLock.Wait(0))
             {
-                return;
+                return Task.CompletedTask;
             }
 
+            return TryWritePingSlowAsync();
+        }
+
+        private async Task TryWritePingSlowAsync()
+        {
             try
             {
                 Debug.Assert(_cachedPingMessage != null);
+
                 _connectionContext.Transport.Output.Write(_cachedPingMessage);
 
-                Interlocked.Exchange(ref _lastSendTimestamp, Stopwatch.GetTimestamp());
-
                 await _connectionContext.Transport.Output.FlushAsync();
+
+                Log.SentPing(_logger);
+            }
+            catch (Exception ex)
+            {
+                Log.FailedWritingMessage(_logger, ex);
             }
             finally
             {
@@ -259,16 +338,15 @@ namespace Microsoft.AspNetCore.SignalR
             // If it is, we send a ping frame, if not, we no-op on this tick. This means that in the worst case, the
             // true "ping rate" of the server could be (_hubOptions.KeepAliveInterval + HubEndPoint.KeepAliveTimerInterval),
             // because if the interval elapses right after the last tick of this timer, it won't be detected until the next tick.
-
             if (Stopwatch.GetTimestamp() - Interlocked.Read(ref _lastSendTimestamp) > _keepAliveDuration)
             {
                 // Haven't sent a message for the entire keep-alive duration, so send a ping.
                 // If the transport channel is full, this will fail, but that's OK because
                 // adding a Ping message when the transport is full is unnecessary since the
                 // transport is still in the process of sending frames.
-
                 _ = TryWritePingAsync();
-                Log.SentPing(_logger);
+
+                Interlocked.Exchange(ref _lastSendTimestamp, Stopwatch.GetTimestamp());
             }
         }
 
@@ -308,6 +386,9 @@ namespace Microsoft.AspNetCore.SignalR
             private static readonly Action<ILogger, Exception> _handshakeFailed =
                 LoggerMessage.Define(LogLevel.Error, new EventId(5, "HandshakeFailed"), "Failed connection handshake.");
 
+            private static readonly Action<ILogger, Exception> _failedWritingMessage =
+                LoggerMessage.Define(LogLevel.Trace, new EventId(6, "FailedWritingMessage"), "Failed writing message.");
+
             public static void HandshakeComplete(ILogger logger, string hubProtocol)
             {
                 _handshakeComplete(logger, hubProtocol, null);
@@ -331,6 +412,11 @@ namespace Microsoft.AspNetCore.SignalR
             public static void HandshakeFailed(ILogger logger, Exception exception)
             {
                 _handshakeFailed(logger, exception);
+            }
+
+            public static void FailedWritingMessage(ILogger logger, Exception exception)
+            {
+                _failedWritingMessage(logger, exception);
             }
         }
 

--- a/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionList.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionList.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 
 namespace Microsoft.AspNetCore.SignalR
 {
-    public class HubConnectionList : IReadOnlyCollection<HubConnectionContext>
+    public class HubConnectionList
     {
         private readonly ConcurrentDictionary<string, HubConnectionContext> _connections = new ConcurrentDictionary<string, HubConnectionContext>();
 
@@ -32,14 +32,29 @@ namespace Microsoft.AspNetCore.SignalR
             _connections.TryRemove(connection.ConnectionId, out _);
         }
 
-        public IEnumerator<HubConnectionContext> GetEnumerator()
+        public Enumerator GetEnumerator()
         {
-            return _connections.Values.GetEnumerator();
+            return new Enumerator(this);
         }
 
-        IEnumerator IEnumerable.GetEnumerator()
+        public struct Enumerator : IEnumerator<HubConnectionContext>
         {
-            return GetEnumerator();
+            private IEnumerator<KeyValuePair<string, HubConnectionContext>> _enumerator;
+
+            public Enumerator(HubConnectionList hubConnectionList)
+            {
+                _enumerator = hubConnectionList._connections.GetEnumerator();
+            }
+
+            public HubConnectionContext Current => _enumerator.Current.Value;
+
+            object IEnumerator.Current => Current;
+
+            public void Dispose() => _enumerator.Dispose();
+
+            public bool MoveNext() => _enumerator.MoveNext();
+
+            public void Reset() => _enumerator.Reset();
         }
     }
 }


### PR DESCRIPTION
- Don't allocate when enumerating connections
- Don't allocate tasks unless we truly go async
- Don't get the timestamp, just write the pings always (if there's no ongoing write)
- Track the time since last keep alive write instead of the last write (this needs some reviewing)

## Old

![image](https://user-images.githubusercontent.com/95136/37571804-d1745c1c-2abe-11e8-8e3a-904bc6b6d8bb.png)

```
       Method | Connections | Protocol |         Mean |       Error |        StdDev |      Op/s |   Gen 0 |  Gen 1 | Allocated |
------------- |------------ |--------- |-------------:|------------:|--------------:|----------:|--------:|-------:|----------:|
 SendAsyncAll |           1 |     json |     7.545 us |   0.4048 us |     1.1936 us | 132,532.1 |  0.3204 |      - |   6.62 KB |
 SendAsyncAll |           1 |  msgpack |     5.492 us |   0.2845 us |     0.8343 us | 182,092.0 |  0.0610 |      - |   1.53 KB |
 SendAsyncAll |          10 |     json |    24.614 us |   1.3042 us |     3.7421 us |  40,626.6 |  0.2747 |      - |   7.27 KB |
 SendAsyncAll |          10 |  msgpack |    17.706 us |   0.3166 us |     0.3769 us |  56,476.9 |  0.0916 |      - |   2.17 KB |
 SendAsyncAll |        1000 |     json | 3,620.429 us | 371.4354 us | 1,095.1858 us |     276.2 | 11.7188 | 3.9063 |  593.6 KB |
 SendAsyncAll |        1000 |  msgpack | 2,705.518 us | 103.2645 us |   291.2594 us |     369.6 | 15.6250 | 3.9063 | 516.87 KB |
```

## New

![image](https://user-images.githubusercontent.com/95136/37569110-e9963654-2a9a-11e8-94ca-0557912d8447.png)

```
        Method | Connections | Protocol |         Mean |       Error |      StdDev |       Median |      Op/s |   Gen 0 |  Gen 1 | Allocated |
------------- |------------ |--------- |-------------:|------------:|------------:|-------------:|----------:|--------:|-------:|----------:|
 SendAsyncAll |           1 |     json |     6.614 us |   0.5787 us |   1.7064 us |     6.025 us | 151,184.7 |  0.3052 |      - |   6.33 KB |
 SendAsyncAll |           1 |  msgpack |     3.705 us |   0.1580 us |   0.4585 us |     3.576 us | 269,920.6 |  0.0496 |      - |   1.24 KB |
 SendAsyncAll |          10 |     json |    16.866 us |   0.9062 us |   2.6292 us |    17.083 us |  59,291.6 |  0.2899 | 0.0153 |   6.73 KB |
 SendAsyncAll |          10 |  msgpack |    14.836 us |   0.5637 us |   1.6443 us |    14.572 us |  67,403.7 |  0.0458 |      - |   1.36 KB |
 SendAsyncAll |        1000 |     json | 2,291.156 us |  75.0624 us | 212.9395 us | 2,282.967 us |     436.5 | 11.7188 | 3.9063 | 404.08 KB |
 SendAsyncAll |        1000 |  msgpack | 2,310.744 us | 116.0950 us | 333.0982 us | 2,209.508 us |     432.8 |  7.8125 |      - | 262.68 KB |
```