### PR TITLE
Check for actual start in SSE

### DIFF
--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.ConnectionLifecycle.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.ConnectionLifecycle.cs
@@ -371,6 +371,57 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
             }
 
             [Fact]
+            public async Task SSEWontStartIfSuccessfulConnectionIsNotEstablished()
+            {
+                using (StartLog(out var loggerFactory))
+                {
+                    var httpHandler = new TestHttpMessageHandler();
+
+                    httpHandler.OnGet("/?id=00000000-0000-0000-0000-000000000000", (_, __) =>
+                    {
+                        return Task.FromResult(ResponseUtils.CreateResponse(HttpStatusCode.InternalServerError));
+                    });
+
+                    var sse = new ServerSentEventsTransport(new HttpClient(httpHandler));
+
+                    await WithConnectionAsync(
+                        CreateConnection(httpHandler, loggerFactory: loggerFactory, url: null, transport: sse),
+                        async (connection, closed) =>
+                        {
+                            await Assert.ThrowsAsync<InvalidOperationException>(
+                                () => connection.StartAsync(TransferFormat.Text).OrTimeout());
+                        });
+                }
+            }
+
+            [Fact]
+            public async Task SSEWaitsForResponseToStart()
+            {
+                using (StartLog(out var loggerFactory))
+                {
+                    var httpHandler = new TestHttpMessageHandler();
+
+                    var sseStartTcs = new TaskCompletionSource<object>();
+                    httpHandler.OnGet("/?id=00000000-0000-0000-0000-000000000000", (_, __) =>
+                    {
+                        sseStartTcs.TrySetResult(null);
+                        return Task.FromResult(ResponseUtils.CreateResponse(HttpStatusCode.Accepted));
+                    });
+
+                    var sse = new ServerSentEventsTransport(new HttpClient(httpHandler));
+
+                    await WithConnectionAsync(
+                        CreateConnection(httpHandler, loggerFactory: loggerFactory, url: null, transport: sse),
+                        async (connection, closed) =>
+                        {
+                            Assert.False(sseStartTcs.Task.IsCompleted);
+                            await connection.StartAsync(TransferFormat.Text).OrTimeout();
+                            Assert.True(sseStartTcs.Task.IsCompleted);
+                        });
+                }
+            }
+
+            [Fact]
             public async Task TransportIsStoppedWhenConnectionIsStopped()
             {
                 var testHttpHandler = new TestHttpMessageHandler();


### PR DESCRIPTION
Closed #1566  in favor of this.
We're just gonna leave LP alone since it's the last transport in the fallback loop and don't actually need to detect successful start up.
That means a lot less churn on the client and sever and in the tests.
You'll see that this change is much smaller.