### PR TITLE
Don't copy the array for incoming msgpack reads

### DIFF
--- a/src/Microsoft.AspNetCore.SignalR.Protocols.MsgPack/Internal/Protocol/MessagePackHubProtocol.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Protocols.MsgPack/Internal/Protocol/MessagePackHubProtocol.cs
@@ -3,8 +3,10 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Runtime.ExceptionServices;
+using System.Runtime.InteropServices;
 using Microsoft.AspNetCore.Protocols;
 using Microsoft.AspNetCore.SignalR.Internal.Formatters;
 using Microsoft.AspNetCore.Sockets;
@@ -41,15 +43,17 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
         {
             while (BinaryMessageParser.TryParseMessage(ref input, out var payload))
             {
-                messages.Add(ParseMessage(payload.ToArray(), binder));
+                var isArray = MemoryMarshal.TryGetArray(payload, out var arraySegment);
+                Debug.Assert(isArray);
+                messages.Add(ParseMessage(arraySegment.Array, arraySegment.Offset, binder));
             }
 
             return messages.Count > 0;
         }
 
-        private static HubMessage ParseMessage(byte[] input, IInvocationBinder binder)
+        private static HubMessage ParseMessage(byte[] input, int startOffset, IInvocationBinder binder)
         {
-            using (var unpacker = Unpacker.Create(input))
+            using (var unpacker = Unpacker.Create(input, startOffset))
             {
                 _ = ReadArrayLength(unpacker, "elementCount");
 

--- a/src/Microsoft.AspNetCore.SignalR.Protocols.MsgPack/Internal/Protocol/MessagePackHubProtocol.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Protocols.MsgPack/Internal/Protocol/MessagePackHubProtocol.cs
@@ -44,6 +44,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
             while (BinaryMessageParser.TryParseMessage(ref input, out var payload))
             {
                 var isArray = MemoryMarshal.TryGetArray(payload, out var arraySegment);
+                // This will never be false unless we started using un-managed buffers
                 Debug.Assert(isArray);
                 messages.Add(ParseMessage(arraySegment.Array, arraySegment.Offset, binder));
             }


### PR DESCRIPTION
- Don't use ToArray on the already sliced msgpack data.
- Turns out msgpack is self describing enough to not require the count, it just needs the buffer and start offset.

The reason we don't need count is because we're reading a single message from the array passed in. We just need to know where it starts so we can start reading the right thing. We handle the outer framing of messages ourselves so we don't need the msgpack library to be incremental.

## Before

```
             Method |          Input | HubProtocol |         Mean |       Error |       StdDev |      Median |        Op/s |  Gen 0 |  Gen 1 | Allocated |
------------------- |--------------- |------------ |-------------:|------------:|-------------:|------------:|------------:|-------:|-------:|----------:|
  ReadSingleMessage |   FewArguments |     MsgPack |   2,013.4 ns |   142.19 ns |    410.25 ns |  1,871.1 ns |   496,660.8 | 0.0305 |      - |     976 B |
  ReadSingleMessage | LargeArguments |     MsgPack |  22,808.1 ns | 1,172.53 ns |  3,420.33 ns | 22,705.7 ns |    43,844.1 | 2.0752 | 0.0916 |   62312 B |
  ReadSingleMessage |  ManyArguments |     MsgPack |   4,260.0 ns |   288.69 ns |    832.94 ns |  3,997.4 ns |   234,743.5 | 0.0458 |      - |    1464 B |
  ReadSingleMessage |    NoArguments |     MsgPack |     599.6 ns |    27.51 ns |     80.25 ns |    587.8 ns | 1,667,830.4 | 0.0181 |      - |     576 B |
```

## After

```
             Method |          Input | HubProtocol |         Mean |       Error |       StdDev |       Median |        Op/s |  Gen 0 |  Gen 1 | Allocated |
------------------- |--------------- |------------ |-------------:|------------:|-------------:|-------------:|------------:|-------:|-------:|----------:|
  ReadSingleMessage |   FewArguments |     MsgPack |   1,577.2 ns |    30.81 ns |     37.83 ns |   1,570.8 ns |   634,034.6 | 0.0286 |      - |     928 B |
  ReadSingleMessage | LargeArguments |     MsgPack |  14,694.8 ns |   678.31 ns |  1,978.66 ns |  14,270.7 ns |    68,051.4 | 1.4038 | 0.0458 |   41784 B |
  ReadSingleMessage |  ManyArguments |     MsgPack |   3,500.9 ns |   117.12 ns |    330.35 ns |   3,419.7 ns |   285,640.8 | 0.0381 |      - |    1392 B |
  ReadSingleMessage |    NoArguments |     MsgPack |     568.9 ns |    18.52 ns |     53.74 ns |     549.4 ns | 1,757,839.5 | 0.0162 |      - |     536 B |
```

TL;DR allocate less and go faster