### PR TITLE
 Take advantage of JSON.NET PropertyNameTable

### DIFF
--- a/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/JsonHubProtocol.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/JsonHubProtocol.cs
@@ -19,6 +19,8 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
     {
         private static readonly UTF8Encoding _utf8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
 
+        private static readonly JsonNameTable _nameTable = CreateNameTable();
+
         private const string ResultPropertyName = "result";
         private const string ItemPropertyName = "item";
         private const string InvocationIdPropertyName = "invocationId";
@@ -103,6 +105,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
                 using (var reader = new JsonTextReader(textReader))
                 {
                     reader.ArrayPool = JsonArrayPool<char>.Shared;
+                    _nameTable.Apply(reader);
 
                     JsonUtils.CheckRead(reader);
 
@@ -643,6 +646,21 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
         internal static JsonSerializerSettings CreateDefaultSerializerSettings()
         {
             return new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver() };
+        }
+
+        private static JsonNameTable CreateNameTable()
+        {
+            // Creates a name table with all of the known property names
+            var table = new JsonNameTable();
+            table.Add(ResultPropertyName);
+            table.Add(ItemPropertyName);
+            table.Add(InvocationIdPropertyName);
+            table.Add(TypePropertyName);
+            table.Add(ErrorPropertyName);
+            table.Add(TargetPropertyName);
+            table.Add(ArgumentsPropertyName);
+            table.Add(HeadersPropertyName);
+            return table;
         }
     }
 }

--- a/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/JsonHubProtocol.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/JsonHubProtocol.cs
@@ -121,7 +121,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
                         {
                             case JsonToken.PropertyName:
                                 {
-                                    if (object.ReferenceEquals(reader.Value, TypePropertyName) || string.Equals(reader.Value.ToString(), TypePropertyName))
+                                    if (FastEquals(reader.Value, TypePropertyName))
                                     {
                                         var messageType = JsonUtils.ReadAsInt32(reader, TypePropertyName);
 
@@ -132,20 +132,19 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
 
                                         type = messageType.Value;
                                     }
-                                    else if (object.ReferenceEquals(reader.Value, InvocationIdPropertyName) || string.Equals(reader.Value.ToString(), InvocationIdPropertyName))
+                                    else if (FastEquals(reader.Value, InvocationIdPropertyName))
                                     {
                                         invocationId = JsonUtils.ReadAsString(reader, InvocationIdPropertyName);
                                     }
-                                    else if (object.ReferenceEquals(reader.Value, TargetPropertyName) || string.Equals(reader.Value.ToString(), TargetPropertyName))
+                                    else if (FastEquals(reader.Value, TargetPropertyName))
                                     {
                                         target = JsonUtils.ReadAsString(reader, TargetPropertyName);
                                     }
-                                    else if (object.ReferenceEquals(reader.Value, ErrorPropertyName) || string.Equals(reader.Value.ToString(), ErrorPropertyName))
+                                    else if (FastEquals(reader.Value, ErrorPropertyName))
                                     {
-
                                         error = JsonUtils.ReadAsString(reader, ErrorPropertyName);
                                     }
-                                    else if (object.ReferenceEquals(reader.Value, ResultPropertyName) || string.Equals(reader.Value.ToString(), ResultPropertyName))
+                                    else if (FastEquals(reader.Value, ResultPropertyName))
                                     {
                                         JsonUtils.CheckRead(reader);
 
@@ -163,7 +162,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
                                             result = PayloadSerializer.Deserialize(reader, returnType);
                                         }
                                     }
-                                    else if (object.ReferenceEquals(reader.Value, ItemPropertyName) || string.Equals(reader.Value.ToString(), ItemPropertyName))
+                                    else if (FastEquals(reader.Value, ItemPropertyName))
                                     {
                                         JsonUtils.CheckRead(reader);
 
@@ -180,7 +179,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
                                             item = PayloadSerializer.Deserialize(reader, returnType);
                                         }
                                     }
-                                    else if (object.ReferenceEquals(reader.Value, ArgumentsPropertyName) || string.Equals(reader.Value.ToString(), ArgumentsPropertyName))
+                                    else if (FastEquals(reader.Value, ArgumentsPropertyName))
                                     {
                                         JsonUtils.CheckRead(reader);
 
@@ -209,7 +208,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
                                             }
                                         }
                                     }
-                                    else if (object.ReferenceEquals(reader.Value, HeadersPropertyName) || string.Equals(reader.Value.ToString(), HeadersPropertyName))
+                                    else if (FastEquals(reader.Value, HeadersPropertyName))
                                     {
 
                                         JsonUtils.CheckRead(reader);
@@ -310,6 +309,11 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
             {
                 throw new InvalidDataException("Error reading JSON.", jrex);
             }
+        }
+
+        private static bool FastEquals(object left, string right)
+        {
+            return ReferenceEquals(left, right) || string.Equals(left.ToString(), right);
         }
 
         private Dictionary<string, string> ReadHeaders(JsonTextReader reader)

--- a/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/JsonHubProtocol.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/JsonHubProtocol.cs
@@ -210,7 +210,6 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
                                     }
                                     else if (FastEquals(reader.Value, HeadersPropertyName))
                                     {
-
                                         JsonUtils.CheckRead(reader);
                                         headers = ReadHeaders(reader);
                                     }

--- a/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/JsonNameTable.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/JsonNameTable.cs
@@ -16,8 +16,8 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
     {
         // See https://github.com/JamesNK/Newtonsoft.Json/blob/993215529562866719689206e27e413013d4439c/Src/Newtonsoft.Json/Utilities/PropertyNameTable.cs
         private readonly object _nameTable;
-        private readonly Action<JsonTextReader, object> _nameTableSetter;
-        private readonly Func<string, string> _addMethod;
+        private readonly Action<JsonTextReader, object> _nameTableSetter = (JsonReader, value) => { };
+        private readonly Func<string, string> _addMethod = key => key;
 
         public JsonNameTable()
         {

--- a/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/JsonNameTable.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/JsonNameTable.cs
@@ -1,0 +1,64 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Reflection;
+using Newtonsoft.Json;
+
+namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
+{
+    // JSON.NET has an internal optimization it uses between JsonSerializer and
+    // JsonTextReader to avoid allocating property names that exists as properties on .NET Types.
+    // This class tries to use that same optimization for the known property names
+    // in the JsonHubProtocol
+    internal class JsonNameTable
+    {
+        // See https://github.com/JamesNK/Newtonsoft.Json/blob/993215529562866719689206e27e413013d4439c/Src/Newtonsoft.Json/Utilities/PropertyNameTable.cs
+        private object _nameTable;
+        private Func<string, string> _addMethod;
+
+        private FieldInfo _nameTableFieldInfo;
+
+        public JsonNameTable()
+        {
+            // Find the type in the JSON.NET assembly
+            Type propertyNameTableType = typeof(JsonTextReader).Assembly.GetType("Newtonsoft.Json.Utilities.PropertyNameTable", throwOnError: false);
+
+            // Something might have changed so be defensive
+            if (propertyNameTableType != null)
+            {
+                var addMethod = propertyNameTableType.GetMethod("Add", BindingFlags.Public | BindingFlags.Instance);
+
+                if (addMethod != null)
+                {
+                    try
+                    {
+                        _nameTable = Activator.CreateInstance(propertyNameTableType);
+
+                        _addMethod = (Func<string, string>)addMethod.CreateDelegate(typeof(Func<string, string>), _nameTable);
+                    }
+                    catch
+                    {
+                        // Ignore errors
+                        _nameTable = null;
+
+                        return;
+                    }
+                }
+
+                // REVIEW: Compile an expression tree?
+                _nameTableFieldInfo = typeof(JsonTextReader).GetField("NameTable", BindingFlags.NonPublic | BindingFlags.Instance);
+            }
+        }
+
+        public void Apply(JsonTextReader reader)
+        {
+            _nameTableFieldInfo.SetValue(reader, _nameTable);
+        }
+
+        public void Add(string key)
+        {
+            _addMethod.Invoke(key);
+        }
+    }
+}


### PR DESCRIPTION
- This is a dirty hack to reduce string allocations by taking advantage of the PropertyNameTable on JsonTextReader.
- This is an internal optimization used today by JsonSerializer
so we're borrowing that here.

PS: The performance results aren't great. It looks like it slows things down a bit and the micro benchmarks aren't showing less allocations. dotMemory shows a big difference though.


## https://github.com/aspnet/SignalR/tree/733a3b3c2d911dc0b9585de55fc0fa23af6ca3d0

![image](https://user-images.githubusercontent.com/95136/37873297-b0eba850-2fce-11e8-98ae-332aef8852a1.png)

```
            Method |          Input | HubProtocol |       Mean |     Error |     StdDev |      Op/s |  Gen 0 | Allocated |
------------------ |--------------- |------------ |-----------:|----------:|-----------:|----------:|-------:|----------:|
 ReadSingleMessage |   FewArguments |        Json |   2.564 us | 0.0640 us |  0.1805 us | 390,035.0 | 0.0343 |    1088 B |
 ReadSingleMessage | LargeArguments |        Json | 107.738 us | 5.0070 us | 14.0402 us |   9,281.8 | 1.9531 |   59016 B |
 ReadSingleMessage |  ManyArguments |        Json |   4.395 us | 0.1133 us |  0.3252 us | 227,516.6 | 0.0458 |    1648 B |
 ReadSingleMessage |    NoArguments |        Json |   1.556 us | 0.0431 us |  0.1237 us | 642,509.5 | 0.0229 |     768 B |
```

## https://github.com/aspnet/SignalR/tree/davidfowl/json-reader

![image](https://user-images.githubusercontent.com/95136/37873308-2a149fa2-2fcf-11e8-9950-1a63678b6848.png)

```
           Method |          Input | HubProtocol |       Mean |     Error |     StdDev |    Median |      Op/s |  Gen 0 | Allocated |
------------------ |--------------- |------------ |-----------:|----------:|-----------:|----------:|----------:|-------:|----------:|
 ReadSingleMessage |   FewArguments |        Json |   2.701 us | 0.0937 us |  0.2627 us |  2.625 us | 370,301.2 | 0.0343 |    1088 B |
 ReadSingleMessage | LargeArguments |        Json | 103.064 us | 4.0845 us | 11.6534 us | 99.266 us |   9,702.7 | 1.9531 |   59016 B |
 ReadSingleMessage |  ManyArguments |        Json |   4.573 us | 0.1927 us |  0.5559 us |  4.446 us | 218,662.1 | 0.0458 |    1648 B |
 ReadSingleMessage |    NoArguments |        Json |   1.635 us | 0.0323 us |  0.0659 us |  1.618 us | 611,595.4 | 0.0229 |     768 B |
 ```

1M messages:

## Before

![image](https://user-images.githubusercontent.com/95136/37874120-6f65500c-2fdd-11e8-9587-37159e8f3ee9.png)


## After

![image](https://user-images.githubusercontent.com/95136/37873485-ac308214-2fd2-11e8-9c23-682885c7cf5a.png)

## Update

I see better results for the latest commit but there's too much variance on my machine to trust. I'll measure more and see if anything shows up.