### PR TITLE
Small changes

### DIFF
--- a/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/HubMessage.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/HubMessage.cs
@@ -12,9 +12,8 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
         {
         }
 
-        // Initialize with capacity 2 for the 2 built in protocols
         private object _lock = new object();
-        private readonly List<SerializedMessage> _serializedMessages = new List<SerializedMessage>(2);
+        private List<SerializedMessage> _serializedMessages;
 
         public byte[] WriteMessage(IHubProtocol protocol)
         {
@@ -25,7 +24,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
 
             lock (_lock)
             {
-                for (var i = 0; i < _serializedMessages.Count; i++)
+                for (var i = 0; i < _serializedMessages?.Count; i++)
                 {
                     if (_serializedMessages[i].Protocol.Equals(protocol))
                     {
@@ -34,6 +33,12 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
                 }
 
                 var bytes = protocol.WriteToArray(this);
+
+                if (_serializedMessages == null)
+                {
+                    // Initialize with capacity 2 for the 2 built in protocols
+                    _serializedMessages = new List<SerializedMessage>(2);
+                }
 
                 // We don't want to balloon memory if someone writes a poor IHubProtocolResolver
                 // So we cap how many caches we store and worst case just serialize the message for every connection

--- a/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/JsonHubProtocol.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/JsonHubProtocol.cs
@@ -559,7 +559,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
 
         private object[] BindArguments(JsonTextReader reader, IReadOnlyList<Type> paramTypes)
         {
-            var arguments = new object[paramTypes.Count];
+            object[] arguments = null;
             var paramIndex = 0;
             var argumentsCount = 0;
 
@@ -572,7 +572,12 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
                         throw new InvalidDataException($"Invocation provides {argumentsCount} argument(s) but target expects {paramTypes.Count}.");
                     }
 
-                    return arguments;
+                    return arguments ?? Array.Empty<object>();
+                }
+
+                if (arguments == null)
+                {
+                    arguments = new object[paramTypes.Count];
                 }
 
                 try
@@ -608,11 +613,17 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
 
         private object[] BindArguments(JArray args, IReadOnlyList<Type> paramTypes)
         {
-            var arguments = new object[args.Count];
-            if (paramTypes.Count != arguments.Length)
+            if (paramTypes.Count != args.Count)
             {
-                throw new InvalidDataException($"Invocation provides {arguments.Length} argument(s) but target expects {paramTypes.Count}.");
+                throw new InvalidDataException($"Invocation provides {args.Count} argument(s) but target expects {paramTypes.Count}.");
             }
+
+            if (paramTypes.Count == 0)
+            {
+                return Array.Empty<object>();
+            }
+
+            var arguments = new object[args.Count];
 
             try
             {


### PR DESCRIPTION
- Don't allocate for empty arrays.
- Don't allocate the list of pre-serialized messages until writing