### PR TITLE
Removed excessive null check because string.Join can't return null

### DIFF
--- a/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/HubMethodInvocationMessage.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/HubMethodInvocationMessage.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.ExceptionServices;
 
@@ -72,7 +71,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
             string args;
             try
             {
-                args = string.Join(", ", Arguments?.Select(a => a?.ToString())) ?? string.Empty;
+                args = string.Join(", ", Arguments?.Select(a => a?.ToString()));
             }
             catch (Exception ex)
             {
@@ -98,7 +97,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
             string args;
             try
             {
-                args = string.Join(", ", Arguments?.Select(a => a?.ToString())) ?? string.Empty;
+                args = string.Join(", ", Arguments?.Select(a => a?.ToString()));
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Removed excessive null check because method string.Join can't return null.
If Arguments is null then we will get ArgumentNullException.