### PR TITLE
Add ability to remove all handlers with just the method name

### DIFF
--- a/clients/ts/signalr/spec/HubConnection.spec.ts
+++ b/clients/ts/signalr/spec/HubConnection.spec.ts
@@ -272,7 +272,6 @@ describe("HubConnection", () => {
         });
 
         it("all handlers can be unregistered with just the method name", async () => {
-            const warnings: string[] = [];
             const connection = new TestConnection();
             const hubConnection = new HubConnection(connection);
 
@@ -280,8 +279,9 @@ describe("HubConnection", () => {
 
             let count = 0;
             const handler = () => { count++; };
+            const secondHandler = () => { count++; };
             hubConnection.on("inc", handler);
-            hubConnection.on("inc", handler);
+            hubConnection.on("inc", secondHandler);
 
             connection.receive({
                 arguments: [],
@@ -305,7 +305,6 @@ describe("HubConnection", () => {
         });
 
         it("a single handler can be unregistered with the method name and handler", async () => {
-            const warnings: string[] = [];
             const connection = new TestConnection();
             const hubConnection = new HubConnection(connection);
 
@@ -313,8 +312,9 @@ describe("HubConnection", () => {
 
             let count = 0;
             const handler = () => { count++; };
+            const secondHandler = () => { count++; };
             hubConnection.on("inc", handler);
-            hubConnection.on("inc", handler);
+            hubConnection.on("inc", secondHandler);
 
             connection.receive({
                 arguments: [],
@@ -335,6 +335,28 @@ describe("HubConnection", () => {
             });
 
             expect(count).toBe(3);
+        });
+
+        it("can't register the same handler multiple times", async () => {
+            const connection = new TestConnection();
+            const hubConnection = new HubConnection(connection);
+
+            connection.receiveHandshakeResponse();
+
+            let count = 0;
+            const handler = () => { count++; };
+            hubConnection.on("inc", handler);
+            hubConnection.on("inc", handler);
+
+            connection.receive({
+                arguments: [],
+                invocationId: "0",
+                nonblocking: true,
+                target: "inc",
+                type: MessageType.Invocation,
+            });
+
+            expect(count).toBe(1);
         });
 
         it("callback invoked when servers invokes a method on the client", async () => {

--- a/clients/ts/signalr/spec/HubConnection.spec.ts
+++ b/clients/ts/signalr/spec/HubConnection.spec.ts
@@ -271,7 +271,7 @@ describe("HubConnection", () => {
             expect(warnings).toEqual(["No client method with the name 'message' found."]);
         });
 
-        it("all handlers can be unnregistered with just the method name", async () => {
+        it("all handlers can be unregistered with just the method name", async () => {
             const warnings: string[] = [];
             const connection = new TestConnection();
             const hubConnection = new HubConnection(connection);

--- a/clients/ts/signalr/spec/HubConnection.spec.ts
+++ b/clients/ts/signalr/spec/HubConnection.spec.ts
@@ -271,6 +271,72 @@ describe("HubConnection", () => {
             expect(warnings).toEqual(["No client method with the name 'message' found."]);
         });
 
+        it("all handlers can be unnregistered with just the method name", async () => {
+            const warnings: string[] = [];
+            const connection = new TestConnection();
+            const hubConnection = new HubConnection(connection);
+
+            connection.receiveHandshakeResponse();
+
+            let count = 0;
+            const handler = () => { count++; };
+            hubConnection.on("inc", handler);
+            hubConnection.on("inc", handler);
+
+            connection.receive({
+                arguments: [],
+                invocationId: "0",
+                nonblocking: true,
+                target: "inc",
+                type: MessageType.Invocation,
+            });
+
+            hubConnection.off("inc");
+
+            connection.receive({
+                arguments: [],
+                invocationId: "0",
+                nonblocking: true,
+                target: "inc",
+                type: MessageType.Invocation,
+            });
+
+            expect(count).toBe(2);
+        });
+
+        it("a single handler can be unnregistered with the method name and handler", async () => {
+            const warnings: string[] = [];
+            const connection = new TestConnection();
+            const hubConnection = new HubConnection(connection);
+
+            connection.receiveHandshakeResponse();
+
+            let count = 0;
+            const handler = () => { count++; };
+            hubConnection.on("inc", handler);
+            hubConnection.on("inc", handler);
+
+            connection.receive({
+                arguments: [],
+                invocationId: "0",
+                nonblocking: true,
+                target: "inc",
+                type: MessageType.Invocation,
+            });
+
+            hubConnection.off("inc", handler);
+
+            connection.receive({
+                arguments: [],
+                invocationId: "0",
+                nonblocking: true,
+                target: "inc",
+                type: MessageType.Invocation,
+            });
+
+            expect(count).toBe(3);
+        });
+
         it("callback invoked when servers invokes a method on the client", async () => {
             const connection = new TestConnection();
             const hubConnection = new HubConnection(connection, commonOptions);

--- a/clients/ts/signalr/spec/HubConnection.spec.ts
+++ b/clients/ts/signalr/spec/HubConnection.spec.ts
@@ -304,7 +304,7 @@ describe("HubConnection", () => {
             expect(count).toBe(2);
         });
 
-        it("a single handler can be unnregistered with the method name and handler", async () => {
+        it("a single handler can be unregistered with the method name and handler", async () => {
             const warnings: string[] = [];
             const connection = new TestConnection();
             const hubConnection = new HubConnection(connection);

--- a/clients/ts/signalr/src/HubConnection.ts
+++ b/clients/ts/signalr/src/HubConnection.ts
@@ -317,7 +317,9 @@ export class HubConnection {
         }
 
         // Preventing adding the same handler multiple times.
-        if (this.methods[methodName].indexOf(newMethod) !== -1) { return; }
+        if (this.methods[methodName].indexOf(newMethod) !== -1) {
+            return;
+         }
 
         this.methods[methodName].push(newMethod);
     }

--- a/clients/ts/signalr/src/HubConnection.ts
+++ b/clients/ts/signalr/src/HubConnection.ts
@@ -319,8 +319,8 @@ export class HubConnection {
         this.methods[methodName].push(method);
     }
 
-    public off(methodName: string, method: (...args: any[]) => void) {
-        if (!methodName || !method) {
+    public off(methodName: string, method?: (...args: any[]) => void) {
+        if (!methodName) {
             return;
         }
 
@@ -329,13 +329,18 @@ export class HubConnection {
         if (!handlers) {
             return;
         }
-        const removeIdx = handlers.indexOf(method);
-        if (removeIdx !== -1) {
-            handlers.splice(removeIdx, 1);
-            if (handlers.length === 0) {
-                delete this.methods[methodName];
+        if (method) {
+            const removeIdx = handlers.indexOf(method);
+            if (removeIdx !== -1) {
+                handlers.splice(removeIdx, 1);
+                if (handlers.length === 0) {
+                    delete this.methods[methodName];
+                }
             }
+        } else {
+            delete this.methods[methodName];
         }
+
     }
 
     public onclose(callback: ConnectionClosed) {

--- a/clients/ts/signalr/src/HubConnection.ts
+++ b/clients/ts/signalr/src/HubConnection.ts
@@ -306,8 +306,8 @@ export class HubConnection {
         return p;
     }
 
-    public on(methodName: string, method: (...args: any[]) => void) {
-        if (!methodName || !method) {
+    public on(methodName: string, newMethod: (...args: any[]) => void) {
+        if (!methodName || !newMethod) {
             return;
         }
 
@@ -316,7 +316,12 @@ export class HubConnection {
             this.methods[methodName] = [];
         }
 
-        this.methods[methodName].push(method);
+        // Preventing adding the same handler multiple times.
+        for (const method of this.methods[methodName]) {
+            if (method === newMethod) { return; }
+        }
+
+        this.methods[methodName].push(newMethod);
     }
 
     public off(methodName: string, method?: (...args: any[]) => void) {

--- a/clients/ts/signalr/src/HubConnection.ts
+++ b/clients/ts/signalr/src/HubConnection.ts
@@ -317,9 +317,7 @@ export class HubConnection {
         }
 
         // Preventing adding the same handler multiple times.
-        for (const method of this.methods[methodName]) {
-            if (method === newMethod) { return; }
-        }
+        if (this.methods[methodName].indexOf(newMethod) !== -1) { return; }
 
         this.methods[methodName].push(newMethod);
     }


### PR DESCRIPTION
Issue: https://github.com/aspnet/SignalR/issues/1677
This allows you to remove all handlers for a method with just the method name. 
You can still pass in the method name and handler to off to just remove that specific call back.
I added tests for both scenarios. 