### PR TITLE
Check for Websockets to fix flaky tests

### DIFF
--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.ConnectionLifecycle.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.ConnectionLifecycle.cs
@@ -147,8 +147,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                         await connection.StartAsync(TransferFormat.Text);
                         if (!IsWebSocketsSupported())
                         {
-                            Assert.Equal(passThreshold - 1, startCounter);
-                            return;
+                            passThreshold -= 1;
                         }
                         Assert.Equal(passThreshold, startCounter);
 
@@ -182,33 +181,13 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                             // If websockets aren't supported then we expect one less attmept to start.
                             if (!IsWebSocketsSupported())
                             {
-                                Assert.Equal(availableTransports - 1, startCounter);
-                                return;
+                                availableTransports -= 1;
                             }
                             Assert.Equal(availableTransports, startCounter);
                         });
                 }
             }
 
-            private static bool IsWebSocketsSupported()
-            {
-#if NETCOREAPP2_1
-            // .NET Core 2.1 and above has a managed implementation
-            return true;
-#else
-                bool isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-                if (!isWindows)
-                {
-                    // Assume other OSes have websockets
-                    return true;
-                }
-                else
-                {
-                    // Windows 8 and above has websockets
-                    return Environment.OSVersion.Version >= Windows8Version;
-                }
-#endif
-            }
 
             [Fact]
             public async Task CanStartStoppedConnection()
@@ -484,6 +463,23 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                             await longPollingTransport.Running.OrTimeout();
                         });
                 }
+            }
+
+            private static bool IsWebSocketsSupported()
+            {
+#if NETCOREAPP2_1
+                // .NET Core 2.1 and greater has sockets
+                return true;
+#else
+                // Non-Windows platforms have sockets
+                if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    return true;
+                }
+
+                // Windows 8 and greater has sockets
+                return Environment.OSVersion.Version >= new Version(6, 2);
+#endif
             }
         }
     }

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.ConnectionLifecycle.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.ConnectionLifecycle.cs
@@ -149,8 +149,8 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                         {
                             passThreshold -= 1;
                         }
-                        Assert.Equal(passThreshold, startCounter);
 
+                        Assert.Equal(passThreshold, startCounter);
                     });
                 }
             }
@@ -183,11 +183,11 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                             {
                                 availableTransports -= 1;
                             }
+
                             Assert.Equal(availableTransports, startCounter);
                         });
                 }
             }
-
 
             [Fact]
             public async Task CanStartStoppedConnection()


### PR DESCRIPTION
A couple of the fallback tests were flaky and upon further investigation I found that they were only failing on Win7 and Win2008 but they were failing consistently. 
We were getting 1 less start attempt than we expected which immediately tipped me off that it was a websockets availability issue.
The issue is that in certain scenarios we hit this code path https://github.com/aspnet/SignalR/blob/1fdd6511fadeafa0e77eac1c8f4958682af01560/src/Microsoft.AspNetCore.Sockets.Client.Http/HttpConnection.cs#L246-L250

I added detection of WebSockets in the relevant tests which should take of of this.

Work tracked in issue: https://github.com/aspnet/SignalR/issues/1726
cc @ryanbrandenburg 