### PR TITLE
Change IHubProtocol interface to support partial parsing

### DIFF
--- a/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/DefaultHubDispatcherBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/DefaultHubDispatcherBenchmark.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Pipelines;
@@ -58,8 +59,9 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
                 return true;
             }
 
-            public bool TryParseMessages(ReadOnlyMemory<byte> input, IInvocationBinder binder, IList<HubMessage> messages)
+            public bool TryParseMessage(ref ReadOnlySequence<byte> input, IInvocationBinder binder, out HubMessage message)
             {
+                message = null;
                 return false;
             }
 

--- a/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/HubProtocolBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/HubProtocolBenchmark.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
 using BenchmarkDotNet.Attributes;
@@ -59,8 +60,8 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
         [Benchmark]
         public void ReadSingleMessage()
         {
-            var messages = new List<HubMessage>();
-            if (!_hubProtocol.TryParseMessages(_binaryInput, _binder, messages))
+            var data = new ReadOnlySequence<byte>(_binaryInput);
+            if (!_hubProtocol.TryParseMessage(ref data, _binder, out _))
             {
                 throw new InvalidOperationException("Failed to read message");
             }

--- a/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/MessageParserBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/MessageParserBenchmark.cs
@@ -51,8 +51,8 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
         [Benchmark]
         public void SingleTextMessage()
         {
-            ReadOnlyMemory<byte> buffer = _textInput;
-            if (!TextMessageParser.TryParseMessage(ref buffer, out _))
+            var data = new ReadOnlySequence<byte>(_textInput);
+            if (!TextMessageParser.TryParseMessage(ref data, out _))
             {
                 throw new InvalidOperationException("Failed to parse");
             }

--- a/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/MessageParserBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/MessageParserBenchmark.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Buffers;
 using System.IO;
 using BenchmarkDotNet.Attributes;
 using Microsoft.AspNetCore.SignalR.Internal.Formatters;
@@ -40,8 +41,8 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
         [Benchmark]
         public void SingleBinaryMessage()
         {
-            ReadOnlyMemory<byte> buffer = _binaryInput;
-            if (!BinaryMessageParser.TryParseMessage(ref buffer, out _))
+            var data = new ReadOnlySequence<byte>(_binaryInput);
+            if (!BinaryMessageParser.TryParseMessage(ref data, out _))
             {
                 throw new InvalidOperationException("Failed to parse");
             }

--- a/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.Log.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.Log.cs
@@ -96,20 +96,8 @@ namespace Microsoft.AspNetCore.SignalR.Client
             private static readonly Action<ILogger, Exception> _sendingHubHandshake =
                 LoggerMessage.Define(LogLevel.Debug, new EventId(28, "SendingHubHandshake"), "Sending Hub Handshake.");
 
-            private static readonly Action<ILogger, int, Exception> _parsingMessages =
-                LoggerMessage.Define<int>(LogLevel.Debug, new EventId(29, "ParsingMessages"), "Received {Count} bytes. Parsing message(s).");
-
-            private static readonly Action<ILogger, int, Exception> _receivingMessages =
-                LoggerMessage.Define<int>(LogLevel.Debug, new EventId(30, "ReceivingMessages"), "Received {MessageCount} message(s).");
-
             private static readonly Action<ILogger, Exception> _receivedPing =
                 LoggerMessage.Define(LogLevel.Trace, new EventId(31, "ReceivedPing"), "Received a ping message.");
-
-            private static readonly Action<ILogger, int, Exception> _processedMessages =
-                LoggerMessage.Define<int>(LogLevel.Debug, new EventId(32, "ProcessedMessages"), "Finished processing {MessageCount} message(s).");
-
-            private static readonly Action<ILogger, int, Exception> _failedParsing =
-                LoggerMessage.Define<int>(LogLevel.Warning, new EventId(33, "FailedParsing"), "No messages parsed from {Count} byte(s).");
 
             private static readonly Action<ILogger, string, Exception> _errorInvokingClientSideMethod =
                 LoggerMessage.Define<string>(LogLevel.Error, new EventId(34, "ErrorInvokingClientSideMethod"), "Invoking client side method '{MethodName}' failed.");
@@ -329,29 +317,9 @@ namespace Microsoft.AspNetCore.SignalR.Client
                 _sendingHubHandshake(logger, null);
             }
 
-            public static void ParsingMessages(ILogger logger, int byteCount)
-            {
-                _parsingMessages(logger, byteCount, null);
-            }
-
-            public static void ReceivingMessages(ILogger logger, int messageCount)
-            {
-                _receivingMessages(logger, messageCount, null);
-            }
-
             public static void ReceivedPing(ILogger logger)
             {
                 _receivedPing(logger, null);
-            }
-
-            public static void ProcessedMessages(ILogger logger, int messageCount)
-            {
-                _processedMessages(logger, messageCount, null);
-            }
-
-            public static void FailedParsing(ILogger logger, int byteCount)
-            {
-                _failedParsing(logger, byteCount, null);
             }
 
             public static void ErrorInvokingClientSideMethod(ILogger logger, string methodName, Exception exception)

--- a/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.cs
@@ -541,8 +541,10 @@ namespace Microsoft.AspNetCore.SignalR.Client
                     }
                     finally
                     {
-                        // The buffer was sliced up to where it was consumed, so we can just advance to the start
-                        _connectionState.Connection.Transport.Input.AdvanceTo(buffer.Start);
+                        // The buffer was sliced up to where it was consumed, so we can just advance to the start.
+                        // We mark examined as buffer.End so that if we didn't receive a full frame, we'll wait for more data
+                        // before yielding the read again.
+                        _connectionState.Connection.Transport.Input.AdvanceTo(buffer.Start, buffer.End);
                     }
                 }
             }
@@ -614,8 +616,10 @@ namespace Microsoft.AspNetCore.SignalR.Client
                     }
                     finally
                     {
-                        // The buffer was sliced up to where it was consumed, so we can just advance to the start
-                        connectionState.Connection.Transport.Input.AdvanceTo(buffer.Start);
+                        // The buffer was sliced up to where it was consumed, so we can just advance to the start.
+                        // We mark examined as buffer.End so that if we didn't receive a full frame, we'll wait for more data
+                        // before yielding the read again.
+                        connectionState.Connection.Transport.Input.AdvanceTo(buffer.Start, buffer.End);
                     }
                 }
             }

--- a/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.cs
@@ -178,7 +178,7 @@ namespace Microsoft.AspNetCore.SignalR.Client
 
                 CheckDisposed();
                 connectionState = _connectionState;
-                
+
                 // Set the stopping flag so that any invocations after this get a useful error message instead of
                 // silently failing or throwing an error about the pipe being completed.
                 if (connectionState != null)
@@ -374,74 +374,53 @@ namespace Microsoft.AspNetCore.SignalR.Client
             }
         }
 
-        private async Task<(bool close, Exception exception)> ProcessMessagesAsync(ReadOnlySequence<byte> buffer, ConnectionState connectionState)
+        private async Task<(bool close, Exception exception)> ProcessMessagesAsync(HubMessage message, ConnectionState connectionState)
         {
-            Log.ProcessingMessage(_logger, buffer.Length);
-
-            // TODO: Don't ToArray it :)
-            var data = buffer.ToArray();
-
-            var currentData = new ReadOnlyMemory<byte>(data);
-            Log.ParsingMessages(_logger, currentData.Length);
-
-            var messages = new List<HubMessage>();
-            if (_protocol.TryParseMessages(currentData, connectionState, messages))
+            InvocationRequest irq;
+            switch (message)
             {
-                Log.ReceivingMessages(_logger, messages.Count);
-                foreach (var message in messages)
-                {
-                    InvocationRequest irq;
-                    switch (message)
+                case InvocationMessage invocation:
+                    Log.ReceivedInvocation(_logger, invocation.InvocationId, invocation.Target,
+                        invocation.ArgumentBindingException != null ? null : invocation.Arguments);
+                    await DispatchInvocationAsync(invocation);
+                    break;
+                case CompletionMessage completion:
+                    if (!connectionState.TryRemoveInvocation(completion.InvocationId, out irq))
                     {
-                        case InvocationMessage invocation:
-                            Log.ReceivedInvocation(_logger, invocation.InvocationId, invocation.Target,
-                                invocation.ArgumentBindingException != null ? null : invocation.Arguments);
-                            await DispatchInvocationAsync(invocation);
-                            break;
-                        case CompletionMessage completion:
-                            if (!connectionState.TryRemoveInvocation(completion.InvocationId, out irq))
-                            {
-                                Log.DroppedCompletionMessage(_logger, completion.InvocationId);
-                            }
-                            else
-                            {
-                                DispatchInvocationCompletion(completion, irq);
-                                irq.Dispose();
-                            }
-                            break;
-                        case StreamItemMessage streamItem:
-                            // Complete the invocation with an error, we don't support streaming (yet)
-                            if (!connectionState.TryGetInvocation(streamItem.InvocationId, out irq))
-                            {
-                                Log.DroppedStreamMessage(_logger, streamItem.InvocationId);
-                                return (close: false, exception: null);
-                            }
-                            await DispatchInvocationStreamItemAsync(streamItem, irq);
-                            break;
-                        case CloseMessage close:
-                            if (string.IsNullOrEmpty(close.Error))
-                            {
-                                Log.ReceivedClose(_logger);
-                                return (close: true, exception: null);
-                            }
-                            else
-                            {
-                                Log.ReceivedCloseWithError(_logger, close.Error);
-                                return (close: true, exception: new HubException($"The server closed the connection with the following error: {close.Error}"));
-                            }
-                        case PingMessage _:
-                            Log.ReceivedPing(_logger);
-                            // Nothing to do on receipt of a ping.
-                            break;
-                        default:
-                            throw new InvalidOperationException($"Unexpected message type: {message.GetType().FullName}");
+                        Log.DroppedCompletionMessage(_logger, completion.InvocationId);
                     }
-                }
-                Log.ProcessedMessages(_logger, messages.Count);
-            }
-            else
-            {
-                Log.FailedParsing(_logger, data.Length);
+                    else
+                    {
+                        DispatchInvocationCompletion(completion, irq);
+                        irq.Dispose();
+                    }
+                    break;
+                case StreamItemMessage streamItem:
+                    // Complete the invocation with an error, we don't support streaming (yet)
+                    if (!connectionState.TryGetInvocation(streamItem.InvocationId, out irq))
+                    {
+                        Log.DroppedStreamMessage(_logger, streamItem.InvocationId);
+                        return (close: false, exception: null);
+                    }
+                    await DispatchInvocationStreamItemAsync(streamItem, irq);
+                    break;
+                case CloseMessage close:
+                    if (string.IsNullOrEmpty(close.Error))
+                    {
+                        Log.ReceivedClose(_logger);
+                        return (close: true, exception: null);
+                    }
+                    else
+                    {
+                        Log.ReceivedCloseWithError(_logger, close.Error);
+                        return (close: true, exception: new HubException($"The server closed the connection with the following error: {close.Error}"));
+                    }
+                case PingMessage _:
+                    Log.ReceivedPing(_logger);
+                    // Nothing to do on receipt of a ping.
+                    break;
+                default:
+                    throw new InvalidOperationException($"Unexpected message type: {message.GetType().FullName}");
             }
 
             return (close: false, exception: null);
@@ -536,16 +515,13 @@ namespace Microsoft.AspNetCore.SignalR.Client
                 {
                     var result = await _connectionState.Connection.Transport.Input.ReadAsync();
                     var buffer = result.Buffer;
-                    var consumed = buffer.Start;
 
                     try
                     {
                         // Read first message out of the incoming data
                         if (!buffer.IsEmpty && TextMessageParser.TryParseMessage(ref buffer, out var payload))
                         {
-                            // Buffer was advanced to the end of the message by TryParseMessage
-                            consumed = buffer.Start;
-                            var message = HandshakeProtocol.ParseResponseMessage(payload.ToArray());
+                            var message = HandshakeProtocol.ParseResponseMessage(payload);
 
                             if (!string.IsNullOrEmpty(message.Error))
                             {
@@ -565,7 +541,7 @@ namespace Microsoft.AspNetCore.SignalR.Client
                     }
                     finally
                     {
-                        _connectionState.Connection.Transport.Input.AdvanceTo(consumed);
+                        _connectionState.Connection.Transport.Input.AdvanceTo(buffer.Start);
                     }
                 }
             }
@@ -594,8 +570,6 @@ namespace Microsoft.AspNetCore.SignalR.Client
                 {
                     var result = await connectionState.Connection.Transport.Input.ReadAsync();
                     var buffer = result.Buffer;
-                    var consumed = buffer.End; // TODO: Support partial messages
-                    var examined = buffer.End;
 
                     try
                     {
@@ -608,12 +582,27 @@ namespace Microsoft.AspNetCore.SignalR.Client
                         {
                             ResetTimeoutTimer(timeoutTimer);
 
-                            // We have data, process it
-                            var (close, exception) = await ProcessMessagesAsync(buffer, connectionState);
+                            Log.ProcessingMessage(_logger, buffer.Length);
+
+                            var close = false;
+
+                            while (_protocol.TryParseMessage(ref buffer, connectionState, out var message))
+                            {
+                                Exception exception;
+
+                                // We have data, process it
+                                (close, exception) = await ProcessMessagesAsync(message, connectionState);
+                                if (close)
+                                {
+                                    // Closing because we got a close frame, possibly with an error in it.
+                                    connectionState.CloseException = exception;
+                                    break;
+                                }
+                            }
+
+                            // If we're closing stop everything
                             if (close)
                             {
-                                // Closing because we got a close frame, possibly with an error in it.
-                                connectionState.CloseException = exception;
                                 break;
                             }
                         }
@@ -624,7 +613,7 @@ namespace Microsoft.AspNetCore.SignalR.Client
                     }
                     finally
                     {
-                        connectionState.Connection.Transport.Input.AdvanceTo(consumed, examined);
+                        connectionState.Connection.Transport.Input.AdvanceTo(buffer.Start);
                     }
                 }
             }
@@ -633,7 +622,7 @@ namespace Microsoft.AspNetCore.SignalR.Client
                 Log.ServerDisconnectedWithError(_logger, ex);
                 connectionState.CloseException = ex;
             }
-            
+
             // Clear the connectionState field
             await WaitConnectionLockAsync();
             try

--- a/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.cs
@@ -519,18 +519,19 @@ namespace Microsoft.AspNetCore.SignalR.Client
                     try
                     {
                         // Read first message out of the incoming data
-                        if (!buffer.IsEmpty && TextMessageParser.TryParseMessage(ref buffer, out var payload))
+                        if (!buffer.IsEmpty)
                         {
-                            var message = HandshakeProtocol.ParseResponseMessage(payload);
-
-                            if (!string.IsNullOrEmpty(message.Error))
+                            if (HandshakeProtocol.TryParseResponseMessage(ref buffer, out var message))
                             {
-                                Log.HandshakeServerError(_logger, message.Error);
-                                throw new HubException(
-                                    $"Unable to complete handshake with the server due to an error: {message.Error}");
-                            }
+                                if (!string.IsNullOrEmpty(message.Error))
+                                {
+                                    Log.HandshakeServerError(_logger, message.Error);
+                                    throw new HubException(
+                                        $"Unable to complete handshake with the server due to an error: {message.Error}");
+                                }
 
-                            break;
+                                break;
+                            }
                         }
                         else if (result.IsCompleted)
                         {

--- a/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.cs
@@ -613,6 +613,7 @@ namespace Microsoft.AspNetCore.SignalR.Client
                     }
                     finally
                     {
+                        // The buffer was sliced up to where it was consumed, so we can just advance to the start
                         connectionState.Connection.Transport.Input.AdvanceTo(buffer.Start);
                     }
                 }

--- a/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.cs
@@ -541,6 +541,7 @@ namespace Microsoft.AspNetCore.SignalR.Client
                     }
                     finally
                     {
+                        // The buffer was sliced up to where it was consumed, so we can just advance to the start
                         _connectionState.Connection.Transport.Input.AdvanceTo(buffer.Start);
                     }
                 }

--- a/src/Microsoft.AspNetCore.SignalR.Common/Internal/Formatters/TextMessageParser.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Common/Internal/Formatters/TextMessageParser.cs
@@ -24,22 +24,5 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Formatters
 
             return true;
         }
-
-        public static bool TryParseMessage(ref ReadOnlyMemory<byte> buffer, out ReadOnlyMemory<byte> payload)
-        {
-            var index = buffer.Span.IndexOf(TextMessageFormatter.RecordSeparator);
-            if (index == -1)
-            {
-                payload = default;
-                return false;
-            }
-
-            payload = buffer.Slice(0, index);
-
-            // Skip record separator
-            buffer = buffer.Slice(index + 1);
-
-            return true;
-        }
     }
 }

--- a/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/IHubProtocol.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/IHubProtocol.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
 using Microsoft.AspNetCore.Connections;
@@ -16,7 +17,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
 
         TransferFormat TransferFormat { get; }
 
-        bool TryParseMessages(ReadOnlyMemory<byte> input, IInvocationBinder binder, IList<HubMessage> messages);
+        bool TryParseMessage(ref ReadOnlySequence<byte> input, IInvocationBinder binder, out HubMessage messages);
 
         void WriteMessage(HubMessage message, Stream output);
 

--- a/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/IHubProtocol.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/IHubProtocol.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
 
         TransferFormat TransferFormat { get; }
 
-        bool TryParseMessage(ref ReadOnlySequence<byte> input, IInvocationBinder binder, out HubMessage messages);
+        bool TryParseMessage(ref ReadOnlySequence<byte> input, IInvocationBinder binder, out HubMessage message);
 
         void WriteMessage(HubMessage message, Stream output);
 

--- a/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/JsonHubProtocol.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/JsonHubProtocol.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.ExceptionServices;
@@ -54,27 +55,27 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
             return version == Version;
         }
 
-        public bool TryParseMessages(ReadOnlyMemory<byte> input, IInvocationBinder binder, IList<HubMessage> messages)
+        public bool TryParseMessage(ref ReadOnlySequence<byte> input, IInvocationBinder binder, out HubMessage message)
         {
-            while (TextMessageParser.TryParseMessage(ref input, out var payload))
-            {
-                var textReader = Utf8BufferTextReader.Get(payload);
+            message = null;
 
-                try
-                {
-                    var message = ParseMessage(textReader, binder);
-                    if (message != null)
-                    {
-                        messages.Add(message);
-                    }
-                }
-                finally
-                {
-                    Utf8BufferTextReader.Return(textReader);
-                }
+            if (!TextMessageParser.TryParseMessage(ref input, out var payload))
+            {
+                return false;
             }
 
-            return messages.Count > 0;
+            var textReader = Utf8BufferTextReader.Get(payload);
+
+            try
+            {
+                message = ParseMessage(textReader, binder);
+            }
+            finally
+            {
+                Utf8BufferTextReader.Return(textReader);
+            }
+
+            return message != null;
         }
 
         public void WriteMessage(HubMessage message, Stream output)

--- a/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/JsonHubProtocol.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/JsonHubProtocol.cs
@@ -57,10 +57,9 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
 
         public bool TryParseMessage(ref ReadOnlySequence<byte> input, IInvocationBinder binder, out HubMessage message)
         {
-            message = null;
-
             if (!TextMessageParser.TryParseMessage(ref input, out var payload))
             {
+                message = null;
                 return false;
             }
 

--- a/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/Utf8BufferTextReader.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/Utf8BufferTextReader.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Buffers;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -10,7 +11,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
 {
     internal class Utf8BufferTextReader : TextReader
     {
-        private ReadOnlyMemory<byte> _utf8Buffer;
+        private ReadOnlySequence<byte> _utf8Buffer;
         private Decoder _decoder;
 
         [ThreadStatic]
@@ -25,7 +26,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
             _decoder = Encoding.UTF8.GetDecoder();
         }
 
-        public static Utf8BufferTextReader Get(ReadOnlyMemory<byte> utf8Buffer)
+        public static Utf8BufferTextReader Get(in ReadOnlySequence<byte> utf8Buffer)
         {
             var reader = _cachedInstance;
             if (reader == null)
@@ -55,7 +56,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
 #endif
         }
 
-        public void SetBuffer(ReadOnlyMemory<byte> utf8Buffer)
+        public void SetBuffer(in ReadOnlySequence<byte> utf8Buffer)
         {
             _utf8Buffer = utf8Buffer;
             _decoder.Reset();
@@ -68,7 +69,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
                 return 0;
             }
 
-            var source = _utf8Buffer.Span;
+            var source = _utf8Buffer.First.Span;
             var bytesUsed = 0;
             var charsUsed = 0;
 #if NETCOREAPP2_1

--- a/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionContext.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionContext.cs
@@ -221,14 +221,12 @@ namespace Microsoft.AspNetCore.SignalR
                     {
                         var result = await _connectionContext.Transport.Input.ReadAsync(cts.Token);
                         var buffer = result.Buffer;
-                        var consumed = buffer.End;
-                        var examined = buffer.End;
 
                         try
                         {
                             if (!buffer.IsEmpty)
                             {
-                                if (HandshakeProtocol.TryParseRequestMessage(buffer, out var handshakeRequestMessage, out consumed, out examined))
+                                if (HandshakeProtocol.TryParseRequestMessage(ref buffer, out var handshakeRequestMessage))
                                 {
                                     Protocol = protocolResolver.GetProtocol(handshakeRequestMessage.Protocol, supportedProtocols);
                                     if (Protocol == null)
@@ -288,7 +286,7 @@ namespace Microsoft.AspNetCore.SignalR
                         }
                         finally
                         {
-                            _connectionContext.Transport.Input.AdvanceTo(consumed, examined);
+                            _connectionContext.Transport.Input.AdvanceTo(buffer.Start);
                         }
                     }
                 }

--- a/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionContext.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionContext.cs
@@ -286,8 +286,10 @@ namespace Microsoft.AspNetCore.SignalR
                         }
                         finally
                         {
-                            // The buffer was sliced up to where it was consumed, so we can just advance to the start
-                            _connectionContext.Transport.Input.AdvanceTo(buffer.Start);
+                            // The buffer was sliced up to where it was consumed, so we can just advance to the start.
+                            // We mark examined as buffer.End so that if we didn't receive a full frame, we'll wait for more data
+                            // before yielding the read again.
+                            _connectionContext.Transport.Input.AdvanceTo(buffer.Start, buffer.End);
                         }
                     }
                 }

--- a/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionContext.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionContext.cs
@@ -286,6 +286,7 @@ namespace Microsoft.AspNetCore.SignalR
                         }
                         finally
                         {
+                            // The buffer was sliced up to where it was consumed, so we can just advance to the start
                             _connectionContext.Transport.Input.AdvanceTo(buffer.Start);
                         }
                     }

--- a/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionHandler.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionHandler.cs
@@ -183,8 +183,10 @@ namespace Microsoft.AspNetCore.SignalR
                     }
                     finally
                     {
-                        // The buffer was sliced up to where it was consumed, so we can just advance to the start
-                        connection.Input.AdvanceTo(buffer.Start);
+                        // The buffer was sliced up to where it was consumed, so we can just advance to the start.
+                        // We mark examined as buffer.End so that if we didn't receive a full frame, we'll wait for more data
+                        // before yielding the read again.
+                        connection.Input.AdvanceTo(buffer.Start, buffer.End);
                     }
                 }
             }

--- a/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionHandler.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionHandler.cs
@@ -183,6 +183,7 @@ namespace Microsoft.AspNetCore.SignalR
                     }
                     finally
                     {
+                        // The buffer was sliced up to where it was consumed, so we can just advance to the start
                         connection.Input.AdvanceTo(buffer.Start);
                     }
                 }

--- a/src/Microsoft.AspNetCore.SignalR.Protocols.MsgPack/Internal/Protocol/MessagePackHubProtocol.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Protocols.MsgPack/Internal/Protocol/MessagePackHubProtocol.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -46,21 +47,34 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
             return version == Version;
         }
 
-        public bool TryParseMessages(ReadOnlyMemory<byte> input, IInvocationBinder binder, IList<HubMessage> messages)
+        public bool TryParseMessage(ref ReadOnlySequence<byte> input, IInvocationBinder binder, out HubMessage message)
         {
-            while (BinaryMessageParser.TryParseMessage(ref input, out var payload))
+            message = null;
+
+            if (!BinaryMessageParser.TryParseMessage(ref input, out var payload))
             {
-                var isArray = MemoryMarshal.TryGetArray(payload, out var arraySegment);
-                // This will never be false unless we started using un-managed buffers
-                Debug.Assert(isArray);
-                var message = ParseMessage(arraySegment.Array, arraySegment.Offset, binder);
-                if (message != null)
-                {
-                    messages.Add(message);
-                }
+                return false;
             }
 
-            return messages.Count > 0;
+            var arraySegment = GetArraySegment(payload);
+
+            message = ParseMessage(arraySegment.Array, arraySegment.Offset, binder);
+
+            return message != null;
+        }
+
+        private static ArraySegment<byte> GetArraySegment(ReadOnlySequence<byte> input)
+        {
+            if (input.IsSingleSegment)
+            {
+                var isArray = MemoryMarshal.TryGetArray(input.First, out var arraySegment);
+                // This will never be false unless we started using un-managed buffers
+                Debug.Assert(isArray);
+                return arraySegment;
+            }
+
+            // Should be rare
+            return new ArraySegment<byte>(input.ToArray());
         }
 
         private static HubMessage ParseMessage(byte[] input, int startOffset, IInvocationBinder binder)

--- a/src/Microsoft.AspNetCore.SignalR.Protocols.MsgPack/Internal/Protocol/MessagePackHubProtocol.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Protocols.MsgPack/Internal/Protocol/MessagePackHubProtocol.cs
@@ -49,10 +49,9 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
 
         public bool TryParseMessage(ref ReadOnlySequence<byte> input, IInvocationBinder binder, out HubMessage message)
         {
-            message = null;
-
             if (!BinaryMessageParser.TryParseMessage(ref input, out var payload))
             {
+                message = null;
                 return false;
             }
 

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
@@ -144,7 +145,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                 return true;
             }
 
-            public bool TryParseMessages(ReadOnlyMemory<byte> input, IInvocationBinder binder, IList<HubMessage> messages)
+            public bool TryParseMessage(ref ReadOnlySequence<byte> input, IInvocationBinder binder, out HubMessage message)
             {
                 if (_error != null)
                 {
@@ -152,7 +153,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                 }
                 if (_parsed != null)
                 {
-                    messages.Add(_parsed);
+                    message = _parsed;
                     return true;
                 }
 

--- a/test/Microsoft.AspNetCore.SignalR.Common.Tests/Internal/Formatters/BinaryMessageFormatterTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Common.Tests/Internal/Formatters/BinaryMessageFormatterTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -113,7 +114,7 @@ namespace Microsoft.AspNetCore.Sockets.Tests.Internal.Formatters
             {
                 BinaryMessageFormatter.WriteLengthPrefix(payload.Length, ms);
                 ms.Write(payload, 0, payload.Length);
-                var buffer = new ReadOnlyMemory<byte>(ms.ToArray());
+                var buffer = new ReadOnlySequence<byte>(ms.ToArray());
                 Assert.True(BinaryMessageParser.TryParseMessage(ref buffer, out var roundtripped));
                 Assert.Equal(payload, roundtripped.ToArray());
             }

--- a/test/Microsoft.AspNetCore.SignalR.Common.Tests/Internal/Formatters/TextMessageParserTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Common.Tests/Internal/Formatters/TextMessageParserTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Buffers;
 using System.Text;
 using Microsoft.AspNetCore.SignalR.Internal.Formatters;
 using Xunit;
@@ -13,7 +14,7 @@ namespace Microsoft.AspNetCore.SignalR.Common.Tests.Internal.Formatters
         [Fact]
         public void ReadMessage()
         {
-            var message = new ReadOnlyMemory<byte>(Encoding.UTF8.GetBytes("ABC\u001e"));
+            var message = new ReadOnlySequence<byte>(Encoding.UTF8.GetBytes("ABC\u001e"));
 
             Assert.True(TextMessageParser.TryParseMessage(ref message, out var payload));
             Assert.Equal("ABC", Encoding.UTF8.GetString(payload.ToArray()));
@@ -23,14 +24,14 @@ namespace Microsoft.AspNetCore.SignalR.Common.Tests.Internal.Formatters
         [Fact]
         public void TryReadingIncompleteMessage()
         {
-            var message = new ReadOnlyMemory<byte>(Encoding.UTF8.GetBytes("ABC"));
+            var message = new ReadOnlySequence<byte>(Encoding.UTF8.GetBytes("ABC"));
             Assert.False(TextMessageParser.TryParseMessage(ref message, out var payload));
         }
 
         [Fact]
         public void TryReadingMultipleMessages()
         {
-            var message = new ReadOnlyMemory<byte>(Encoding.UTF8.GetBytes("ABC\u001eXYZ\u001e"));
+            var message = new ReadOnlySequence<byte>(Encoding.UTF8.GetBytes("ABC\u001eXYZ\u001e"));
             Assert.True(TextMessageParser.TryParseMessage(ref message, out var payload));
             Assert.Equal("ABC", Encoding.UTF8.GetString(payload.ToArray()));
             Assert.True(TextMessageParser.TryParseMessage(ref message, out payload));
@@ -40,7 +41,7 @@ namespace Microsoft.AspNetCore.SignalR.Common.Tests.Internal.Formatters
         [Fact]
         public void IncompleteTrailingMessage()
         {
-            var message = new ReadOnlyMemory<byte>(Encoding.UTF8.GetBytes("ABC\u001eXYZ\u001e123"));
+            var message = new ReadOnlySequence<byte>(Encoding.UTF8.GetBytes("ABC\u001eXYZ\u001e123"));
             Assert.True(TextMessageParser.TryParseMessage(ref message, out var payload));
             Assert.Equal("ABC", Encoding.UTF8.GetString(payload.ToArray()));
             Assert.True(TextMessageParser.TryParseMessage(ref message, out payload));

--- a/test/Microsoft.AspNetCore.SignalR.Common.Tests/Internal/Protocol/HandshakeProtocolTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Common.Tests/Internal/Protocol/HandshakeProtocolTests.cs
@@ -18,9 +18,9 @@ namespace Microsoft.AspNetCore.SignalR.Common.Tests.Internal.Protocol
         [InlineData("{\"protocol\":null,\"version\":123}\u001e", null, 123)]
         public void ParsingHandshakeRequestMessageSuccessForValidMessages(string json, string protocol, int version)
         {
-            var message = Encoding.UTF8.GetBytes(json);
+            var message = new ReadOnlySequence<byte>(Encoding.UTF8.GetBytes(json));
 
-            Assert.True(HandshakeProtocol.TryParseRequestMessage(new ReadOnlySequence<byte>(message), out var deserializedMessage, out _, out _));
+            Assert.True(HandshakeProtocol.TryParseRequestMessage(ref message, out var deserializedMessage));
 
             Assert.Equal(protocol, deserializedMessage.Protocol);
             Assert.Equal(version, deserializedMessage.Version);
@@ -33,7 +33,7 @@ namespace Microsoft.AspNetCore.SignalR.Common.Tests.Internal.Protocol
         [InlineData("{}\u001e", null)]
         public void ParsingHandshakeResponseMessageSuccessForValidMessages(string json, string error)
         {
-            var message = Encoding.UTF8.GetBytes(json);
+            var message = new ReadOnlySequence<byte>(Encoding.UTF8.GetBytes(json));
 
             var response = HandshakeProtocol.ParseResponseMessage(message);
 
@@ -43,9 +43,9 @@ namespace Microsoft.AspNetCore.SignalR.Common.Tests.Internal.Protocol
         [Fact]
         public void ParsingHandshakeRequestNotCompleteReturnsFalse()
         {
-            var message = Encoding.UTF8.GetBytes("42");
+            var message = new ReadOnlySequence<byte>(Encoding.UTF8.GetBytes("42"));
 
-            Assert.False(HandshakeProtocol.TryParseRequestMessage(new ReadOnlySequence<byte>(message), out _, out _, out _));
+            Assert.False(HandshakeProtocol.TryParseRequestMessage(ref message, out _));
         }
 
         [Theory]
@@ -59,10 +59,10 @@ namespace Microsoft.AspNetCore.SignalR.Common.Tests.Internal.Protocol
         [InlineData("{\"protocol\":null,\"version\":\"123\"}\u001e", "Expected 'version' to be of type Integer.")]
         public void ParsingHandshakeRequestMessageThrowsForInvalidMessages(string payload, string expectedMessage)
         {
-            var message = Encoding.UTF8.GetBytes(payload);
+            var message = new ReadOnlySequence<byte>(Encoding.UTF8.GetBytes(payload));
 
             var exception = Assert.Throws<InvalidDataException>(() =>
-                Assert.True(HandshakeProtocol.TryParseRequestMessage(new ReadOnlySequence<byte>(message), out _, out _, out _)));
+                Assert.True(HandshakeProtocol.TryParseRequestMessage(ref message, out _)));
 
             Assert.Equal(expectedMessage, exception.Message);
         }
@@ -74,7 +74,7 @@ namespace Microsoft.AspNetCore.SignalR.Common.Tests.Internal.Protocol
         [InlineData("[]", "Unexpected JSON Token Type 'Array'. Expected a JSON Object.")]
         public void ParsingHandshakeResponseMessageThrowsForInvalidMessages(string payload, string expectedMessage)
         {
-            var message = Encoding.UTF8.GetBytes(payload);
+            var message = new ReadOnlySequence<byte>(Encoding.UTF8.GetBytes(payload));
 
             var exception = Assert.Throws<InvalidDataException>(() =>
                 HandshakeProtocol.ParseResponseMessage(message));

--- a/test/Microsoft.AspNetCore.SignalR.Common.Tests/Internal/Protocol/HandshakeProtocolTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Common.Tests/Internal/Protocol/HandshakeProtocolTests.cs
@@ -35,8 +35,7 @@ namespace Microsoft.AspNetCore.SignalR.Common.Tests.Internal.Protocol
         {
             var message = new ReadOnlySequence<byte>(Encoding.UTF8.GetBytes(json));
 
-            var response = HandshakeProtocol.ParseResponseMessage(message);
-
+            Assert.True(HandshakeProtocol.TryParseResponseMessage(ref message, out var response));
             Assert.Equal(error, response.Error);
         }
 
@@ -68,16 +67,16 @@ namespace Microsoft.AspNetCore.SignalR.Common.Tests.Internal.Protocol
         }
 
         [Theory]
-        [InlineData("42", "Unexpected JSON Token Type 'Integer'. Expected a JSON Object.")]
-        [InlineData("\"42\"", "Unexpected JSON Token Type 'String'. Expected a JSON Object.")]
-        [InlineData("null", "Unexpected JSON Token Type 'Null'. Expected a JSON Object.")]
-        [InlineData("[]", "Unexpected JSON Token Type 'Array'. Expected a JSON Object.")]
+        [InlineData("42\u001e", "Unexpected JSON Token Type 'Integer'. Expected a JSON Object.")]
+        [InlineData("\"42\"\u001e", "Unexpected JSON Token Type 'String'. Expected a JSON Object.")]
+        [InlineData("null\u001e", "Unexpected JSON Token Type 'Null'. Expected a JSON Object.")]
+        [InlineData("[]\u001e", "Unexpected JSON Token Type 'Array'. Expected a JSON Object.")]
         public void ParsingHandshakeResponseMessageThrowsForInvalidMessages(string payload, string expectedMessage)
         {
             var message = new ReadOnlySequence<byte>(Encoding.UTF8.GetBytes(payload));
 
             var exception = Assert.Throws<InvalidDataException>(() =>
-                HandshakeProtocol.ParseResponseMessage(message));
+                HandshakeProtocol.TryParseRequestMessage(ref message, out _));
 
             Assert.Equal(expectedMessage, exception.Message);
         }

--- a/test/Microsoft.AspNetCore.SignalR.Common.Tests/Internal/Protocol/Utf8BufferTextReaderTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Common.Tests/Internal/Protocol/Utf8BufferTextReaderTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.SignalR.Common.Tests.Internal.Protocol
         [Fact]
         public void ReadingWhenCharBufferBigEnough()
         {
-            var buffer = Encoding.UTF8.GetBytes("Hello World");
+            var buffer = new ReadOnlySequence<byte>(Encoding.UTF8.GetBytes("Hello World"));
             var reader = new Utf8BufferTextReader();
             reader.SetBuffer(buffer);
 
@@ -28,7 +28,7 @@ namespace Microsoft.AspNetCore.SignalR.Common.Tests.Internal.Protocol
         [Fact]
         public void ReadingUnicodeWhenCharBufferBigEnough()
         {
-            var buffer = Encoding.UTF8.GetBytes("a\u00E4\u00E4\u00a9o");
+            var buffer = new ReadOnlySequence<byte>(Encoding.UTF8.GetBytes("a\u00E4\u00E4\u00a9o"));
             var reader = new Utf8BufferTextReader();
             reader.SetBuffer(buffer);
 
@@ -46,7 +46,7 @@ namespace Microsoft.AspNetCore.SignalR.Common.Tests.Internal.Protocol
         [Fact]
         public void ReadingWhenCharBufferBigEnoughAndNotStartingFromZero()
         {
-            var buffer = Encoding.UTF8.GetBytes("Hello World");
+            var buffer = new ReadOnlySequence<byte>(Encoding.UTF8.GetBytes("Hello World"));
             var reader = new Utf8BufferTextReader();
             reader.SetBuffer(buffer);
 
@@ -60,7 +60,7 @@ namespace Microsoft.AspNetCore.SignalR.Common.Tests.Internal.Protocol
         [Fact]
         public void ReadingWhenBufferTooSmall()
         {
-            var buffer = Encoding.UTF8.GetBytes("Hello World");
+            var buffer = new ReadOnlySequence<byte>(Encoding.UTF8.GetBytes("Hello World"));
             var reader = new Utf8BufferTextReader();
             reader.SetBuffer(buffer);
 
@@ -92,7 +92,7 @@ namespace Microsoft.AspNetCore.SignalR.Common.Tests.Internal.Protocol
         [Fact]
         public void ReadingUnicodeWhenBufferTooSmall()
         {
-            var buffer = Encoding.UTF8.GetBytes("\u00E4\u00E4\u00E5");
+            var buffer = new ReadOnlySequence<byte>(Encoding.UTF8.GetBytes("\u00E4\u00E4\u00E5"));
             var reader = new Utf8BufferTextReader();
             reader.SetBuffer(buffer);
 

--- a/test/Microsoft.AspNetCore.SignalR.Tests.Utils/TestClient.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests.Utils/TestClient.cs
@@ -83,7 +83,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                 // note that the handshake response might not immediately be readable
                 // e.g. server is waiting for request, times out after configured duration,
                 // and sends response with timeout error
-                HandshakeResponseMessage = (HandshakeResponseMessage) await ReadAsync(true).OrTimeout();
+                HandshakeResponseMessage = (HandshakeResponseMessage)await ReadAsync(true).OrTimeout();
             }
 
             return connection;
@@ -237,13 +237,12 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                 }
                 else
                 {
-                    // read first message out of the incoming data
-                    if (!TextMessageParser.TryParseMessage(ref buffer, out var payload))
+                    // read first message out of the incoming data 
+                    if (!HandshakeProtocol.TryParseResponseMessage(ref buffer, out var responseMessage))
                     {
                         throw new InvalidDataException("Unable to parse payload as a handshake response message.");
                     }
-
-                    return HandshakeProtocol.ParseResponseMessage(payload);
+                    return responseMessage;
                 }
             }
             finally

--- a/test/Microsoft.AspNetCore.SignalR.Tests.Utils/TestClient.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests.Utils/TestClient.cs
@@ -27,7 +27,6 @@ namespace Microsoft.AspNetCore.SignalR.Tests
         private readonly IHubProtocol _protocol;
         private readonly IInvocationBinder _invocationBinder;
         private readonly CancellationTokenSource _cts;
-        private readonly Queue<HubMessage> _messages = new Queue<HubMessage>();
 
         public DefaultConnectionContext Connection { get; }
         public Task Connected => ((TaskCompletionSource<bool>)Connection.Items["ConnectedTask"]).Task;
@@ -220,41 +219,26 @@ namespace Microsoft.AspNetCore.SignalR.Tests
 
         public HubMessage TryRead(bool isHandshake = false)
         {
-            if (_messages.Count > 0)
-            {
-                return _messages.Dequeue();
-            }
-
             if (!Connection.Application.Input.TryRead(out var result))
             {
                 return null;
             }
 
             var buffer = result.Buffer;
-            var consumed = buffer.End;
-            var examined = consumed;
 
             try
             {
                 if (!isHandshake)
                 {
-                    var messages = new List<HubMessage>();
-                    if (_protocol.TryParseMessages(result.Buffer.ToArray(), _invocationBinder, messages))
+                    if (_protocol.TryParseMessage(ref buffer, _invocationBinder, out var message))
                     {
-                        foreach (var m in messages)
-                        {
-                            _messages.Enqueue(m);
-                        }
-
-                        return _messages.Dequeue();
+                        return message;
                     }
                 }
                 else
                 {
-                    HandshakeProtocol.TryReadMessageIntoSingleMemory(buffer, out consumed, out examined, out var data);
-
                     // read first message out of the incoming data
-                    if (!TextMessageParser.TryParseMessage(ref data, out var payload))
+                    if (!TextMessageParser.TryParseMessage(ref buffer, out var payload))
                     {
                         throw new InvalidDataException("Unable to parse payload as a handshake response message.");
                     }
@@ -264,7 +248,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             }
             finally
             {
-                Connection.Application.Input.AdvanceTo(consumed, examined);
+                Connection.Application.Input.AdvanceTo(buffer.Start);
             }
 
             return null;


### PR DESCRIPTION
- These are the finishing touches before we disable batching on the
C# client and on the server. We're changing the IHubProtocol interface to
modify the input buffer with what was consumed. We're also changing it
to parse a single message at a time to be match what output writing does.
- Removes ToArray() in the optimistic case where things fit into a single buffer (for the most part)

TODO: 
- ~Run benchmarks to see if this API change helps or hurts. There are alternate patterns we can try if this hurts.~
- Add some tests for multiple buffers (we have nice helper for this in Common that I can import). This isn't really important until we disable buffering.

## Baseline:

```
             Method |          Input | HubProtocol |        Mean |      Error |     StdDev |        Op/s |  Gen 0 |  Gen 1 | Allocated |
------------------- |--------------- |------------ |------------:|-----------:|-----------:|------------:|-------:|-------:|----------:|
  ReadSingleMessage |   FewArguments |        Json |  2,209.2 ns |  29.370 ns |  26.035 ns |   452,660.9 | 0.0343 |      - |    1120 B |
  ReadSingleMessage |   FewArguments |     MsgPack |  1,483.3 ns |  23.293 ns |  21.788 ns |   674,178.7 | 0.0248 |      - |     832 B |
  ReadSingleMessage | LargeArguments |        Json | 84,852.6 ns | 350.418 ns | 273.583 ns |    11,785.1 | 1.8311 |      - |   59016 B |
  ReadSingleMessage | LargeArguments |     MsgPack | 11,470.6 ns |  98.080 ns |  86.946 ns |    87,179.1 | 1.4038 | 0.0610 |   41688 B |
  ReadSingleMessage |  ManyArguments |        Json |  3,876.9 ns |  69.640 ns |  58.153 ns |   257,935.1 | 0.0534 |      - |    1680 B |
  ReadSingleMessage |  ManyArguments |     MsgPack |  2,983.5 ns |  54.243 ns |  50.739 ns |   335,179.1 | 0.0381 |      - |    1296 B |
  ReadSingleMessage |    NoArguments |        Json |  1,130.0 ns |  10.981 ns |   9.734 ns |   884,923.8 | 0.0229 |      - |     744 B |
  ReadSingleMessage |    NoArguments |     MsgPack |    471.7 ns |   5.856 ns |   4.890 ns | 2,119,972.0 | 0.0134 |      - |     440 B |
```


## PR

```
             Method |          Input | HubProtocol |        Mean |        Error |       StdDev |        Op/s |  Gen 0 |  Gen 1 | Allocated |
------------------- |--------------- |------------ |------------:|-------------:|-------------:|------------:|-------:|-------:|----------:|
  ReadSingleMessage |   FewArguments |        Json |  2,292.1 ns |    37.037 ns |    34.644 ns |   436,285.5 | 0.0305 |      - |    1024 B |
  ReadSingleMessage |   FewArguments |     MsgPack |  1,536.4 ns |    10.784 ns |     9.560 ns |   650,869.1 | 0.0229 |      - |     736 B |
  ReadSingleMessage | LargeArguments |        Json | 85,141.1 ns | 1,078.927 ns |   900.953 ns |    11,745.2 | 1.9531 |      - |   58920 B |
  ReadSingleMessage | LargeArguments |     MsgPack | 11,789.1 ns |   157.994 ns |   140.057 ns |    84,824.2 | 1.4038 | 0.0610 |   41592 B |
  ReadSingleMessage |  ManyArguments |        Json |  4,016.4 ns |    78.962 ns |    69.998 ns |   248,976.4 | 0.0458 |      - |    1584 B |
  ReadSingleMessage |  ManyArguments |     MsgPack |  3,154.0 ns |    33.661 ns |    29.840 ns |   317,054.2 | 0.0381 |      - |    1200 B |
  ReadSingleMessage |    NoArguments |        Json |  1,184.8 ns |    23.713 ns |    21.021 ns |   844,039.7 | 0.0191 |      - |     648 B |
  ReadSingleMessage |    NoArguments |     MsgPack |    567.2 ns |     6.209 ns |     5.808 ns | 1,763,059.7 | 0.0105 |      - |     344 B |
 ```

It's slower and allocates less 😄. 

A few things to consider:
- The microbenchmark is testing a single buffer and there's more overhead in a `ReadOnlyMemory<byte>` vs a `ReadOnlySequence<byte>`. Slicing a ReadOnlySequence is slower and that could explain the overhead.
- Since we're parsing a single message, we can avoid allocating a list (the list could be cached per connection and constantly cleared after parsing).

Contributes to #1508