### PR TITLE
Fix WebSocketsSupportedConditionAttribute version check

### DIFF
--- a/test/Microsoft.AspNetCore.SignalR.Tests.Utils/WebSocketsSupportedConditionAttribute.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests.Utils/WebSocketsSupportedConditionAttribute.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                 }
 
                 // Windows 8 and greater has sockets
-                if (Environment.Version >= new Version(6, 2))
+                if (Environment.OSVersion.Version >= new Version(6, 2))
                 {
                     return true;
                 }

--- a/test/Microsoft.AspNetCore.SignalR.Tests.Utils/WebSocketsSupportedConditionAttribute.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests.Utils/WebSocketsSupportedConditionAttribute.cs
@@ -20,19 +20,14 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                 // .NET Core 2.1 and greater has sockets
                 return true;
 #else
-                // Non-Windows platforms have sockets
+                // Non-Windows platforms have Websockets
                 if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {
                     return true;
                 }
 
-                // Windows 8 and greater has sockets
-                if (Environment.OSVersion.Version >= new Version(6, 2))
-                {
-                    return true;
-                }
-
-                return false;
+                // Windows 8 and greater has Websockets
+                return Environment.OSVersion.Version >= new Version(6, 2);
 #endif
             }
         }


### PR DESCRIPTION
I think this check is broken.
In checking for Windows 8 or later it was comparing against `Environment.Version` which is 

>a Version object that describes the major, minor, build, and revision numbers of the common language runtime.

Instead of `Environment.OSVersion.Version` which is

> an OperatingSystem object that contains the current platform identifier and version number.
