### PR TITLE
Dispose the http client in DisposeAsync

### DIFF
--- a/src/Microsoft.AspNetCore.Sockets.Client.Http/HttpConnection.cs
+++ b/src/Microsoft.AspNetCore.Sockets.Client.Http/HttpConnection.cs
@@ -190,6 +190,8 @@ namespace Microsoft.AspNetCore.Sockets.Client.Http
                 {
                     Log.SkippingDispose(_logger);
                 }
+
+                _httpClient?.Dispose();
             }
             finally
             {


### PR DESCRIPTION
- This layer of the stack is no longer reusable and this disposable was removed (I assume by mistake) in the big refactoring