### PR TITLE
Cleanup logs during test

### DIFF
--- a/clients/ts/signalr/spec/HttpConnection.spec.ts
+++ b/clients/ts/signalr/spec/HttpConnection.spec.ts
@@ -136,6 +136,7 @@ describe("HttpConnection", () => {
 
     it("start throws after all transports fail", async (done) => {
         const options: IHttpConnectionOptions = {
+            ...commonOptions,
             httpClient: new TestHttpClient()
                 .on("POST", (r) => ({ connectionId: "42", availableTransports: [] }))
                 .on("GET", (r) => { throw new Error("fail"); }),
@@ -343,14 +344,14 @@ describe("HttpConnection", () => {
     describe("startAsync", () => {
         it("throws if no TransferFormat is provided", async () => {
             // Force TypeScript to let us call start incorrectly
-            const connection: any = new HttpConnection("http://tempuri.org");
+            const connection: any = new HttpConnection("http://tempuri.org", commonOptions);
 
             expect(() => connection.start()).toThrowError("The 'transferFormat' argument is required.");
         });
 
         it("throws if an unsupported TransferFormat is provided", async () => {
             // Force TypeScript to let us call start incorrectly
-            const connection: any = new HttpConnection("http://tempuri.org");
+            const connection: any = new HttpConnection("http://tempuri.org", commonOptions);
 
             expect(() => connection.start(42)).toThrowError("Unknown transferFormat value: 42.");
         });

--- a/clients/ts/signalr/spec/HubConnection.spec.ts
+++ b/clients/ts/signalr/spec/HubConnection.spec.ts
@@ -233,7 +233,6 @@ describe("HubConnection", () => {
 
             connection.receive({
                 arguments: ["test"],
-                invocationId: "0",
                 nonblocking: true,
                 target: "message",
                 type: MessageType.Invocation,
@@ -273,7 +272,7 @@ describe("HubConnection", () => {
 
         it("all handlers can be unregistered with just the method name", async () => {
             const connection = new TestConnection();
-            const hubConnection = new HubConnection(connection);
+            const hubConnection = new HubConnection(connection, commonOptions);
 
             connection.receiveHandshakeResponse();
 
@@ -306,7 +305,7 @@ describe("HubConnection", () => {
 
         it("a single handler can be unregistered with the method name and handler", async () => {
             const connection = new TestConnection();
-            const hubConnection = new HubConnection(connection);
+            const hubConnection = new HubConnection(connection, commonOptions);
 
             connection.receiveHandshakeResponse();
 
@@ -339,7 +338,7 @@ describe("HubConnection", () => {
 
         it("can't register the same handler multiple times", async () => {
             const connection = new TestConnection();
-            const hubConnection = new HubConnection(connection);
+            const hubConnection = new HubConnection(connection, commonOptions);
 
             connection.receiveHandshakeResponse();
 


### PR DESCRIPTION
Cleaning up some logs that were printed during spec tests

```
Error: Failed to start the connection: Error: Unable to initialize any of the available transports.
Error: Server requested a response, which is not supported in this version of the client.
Warning: No client method with the name 'inc' found.
Error: Server requested a response, which is not supported in this version of the client.
Error: Server requested a response, which is not supported in this version of the client.
Error: Server requested a response, which is not supported in this version of the client.
```