### PR TITLE
Handle uninitialized connections in disposal (#1786)

### DIFF
--- a/src/Microsoft.AspNetCore.Http.Connections/HttpConnectionContext.cs
+++ b/src/Microsoft.AspNetCore.Http.Connections/HttpConnectionContext.cs
@@ -143,21 +143,21 @@ namespace Microsoft.AspNetCore.Http.Connections
                     // If the application task is faulted, propagate the error to the transport
                     if (ApplicationTask?.IsFaulted == true)
                     {
-                        Transport.Output.Complete(ApplicationTask.Exception.InnerException);
+                        Transport?.Output.Complete(ApplicationTask.Exception.InnerException);
                     }
                     else
                     {
-                        Transport.Output.Complete();
+                        Transport?.Output.Complete();
                     }
 
                     // If the transport task is faulted, propagate the error to the application
                     if (TransportTask?.IsFaulted == true)
                     {
-                        Application.Output.Complete(TransportTask.Exception.InnerException);
+                        Application?.Output.Complete(TransportTask.Exception.InnerException);
                     }
                     else
                     {
-                        Application.Output.Complete();
+                        Application?.Output.Complete();
                     }
 
                     var applicationTask = ApplicationTask ?? Task.CompletedTask;
@@ -180,8 +180,8 @@ namespace Microsoft.AspNetCore.Http.Connections
                 // REVIEW: Should we move this to the read loops?
 
                 // Complete the reading side of the pipes
-                Application.Input.Complete();
-                Transport.Input.Complete();
+                Application?.Input.Complete();
+                Transport?.Input.Complete();
             }
         }
 

--- a/test/Microsoft.AspNetCore.Http.Connections.Tests/HttpConnectionManagerTests.cs
+++ b/test/Microsoft.AspNetCore.Http.Connections.Tests/HttpConnectionManagerTests.cs
@@ -191,6 +191,20 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
         }
 
         [Fact]
+        public async Task DisposeInactiveConnectionWithNoPipes()
+        {
+            var connectionManager = CreateConnectionManager();
+            var connection = connectionManager.CreateConnection();
+
+            Assert.NotNull(connection.ConnectionId);
+            Assert.Null(connection.Transport);
+            Assert.Null(connection.Application);
+
+            await connection.DisposeAsync();
+            Assert.Equal(HttpConnectionContext.ConnectionStatus.Disposed, connection.Status);
+        }
+
+        [Fact]
         public void ScanAfterDisposeNoops()
         {
             var connectionManager = CreateConnectionManager();


### PR DESCRIPTION
- We made a change to not initialize pipes up front
on connection creation. That change make it null ref in disposal because we didn't check if the pipes were initialized.
- Added a test
- Also fixed the EchoConnectionHandler in the functional ts tests.