### PR TITLE
Change default handshake timeout

### DIFF
--- a/src/Microsoft.AspNetCore.SignalR.Core/HubOptionsSetup.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/HubOptionsSetup.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.SignalR
 {
     public class HubOptionsSetup : IConfigureOptions<HubOptions>
     {
-        internal static TimeSpan DefaultHandshakeTimeout => TimeSpan.FromSeconds(5);
+        internal static TimeSpan DefaultHandshakeTimeout => TimeSpan.FromSeconds(15);
 
         internal static TimeSpan DefaultKeepAliveInterval => TimeSpan.FromSeconds(15);
 


### PR DESCRIPTION
- 5 seconds seems to be too low for long polling's RTT. We often see super flaky tests and it seems like this is the best fix. Ideally, we would do something more sophisitcated than just timeout the entire time to parse.

/cc @muratg I'd like to get this in for preview2.