### PR TITLE
Improve writing single characters with UTF8 writer

### DIFF
--- a/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/Utf8BufferTextWriter.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/Utf8BufferTextWriter.cs
@@ -121,10 +121,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
 
             Debug.Assert(charsUsed == 1);
 
-            if (bytesUsed > 0)
-            {
-                _memoryUsed += bytesUsed;
-            }
+            _memoryUsed += bytesUsed;
         }
 
         public override void Write(string value)

--- a/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/Utf8BufferTextWriter.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/Utf8BufferTextWriter.cs
@@ -5,6 +5,7 @@ using System;
 using System.Buffers;
 using System.Diagnostics;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -86,36 +87,40 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
 
         public override void Write(char value)
         {
-            var destination = GetBuffer();
-
             if (value <= 127)
             {
-                destination[0] = (byte)value;
+                EnsureBuffer();
+                _memory.Span[_memoryUsed] = (byte)value;
                 _memoryUsed++;
             }
             else
             {
-                // Json.NET only writes ASCII characters by themselves, e.g. {}[], etc
-                // this should be an exceptional case
-                var bytesUsed = 0;
-                var charsUsed = 0;
-                unsafe
-                {
-#if NETCOREAPP2_1
-                    _encoder.Convert(new Span<char>(&value, 1), destination, false, out charsUsed, out bytesUsed, out _);
-#else
-                    fixed (byte* destinationBytes = &MemoryMarshal.GetReference(destination))
-                    {
-                        _encoder.Convert(&value, 1, destinationBytes, destination.Length, false, out charsUsed, out bytesUsed, out _);
-                    }
-#endif
-                }
-                Debug.Assert(charsUsed == 1);
+                WriteMultibyteChar(value);
+            }
+        }
 
-                if (bytesUsed > 0)
-                {
-                    _memoryUsed += bytesUsed;
-                }
+        private unsafe void WriteMultibyteChar(char value)
+        {
+            var destination = GetBuffer();
+
+            // Json.NET only writes ASCII characters by themselves, e.g. {}[], etc
+            // this should be an exceptional case
+            var bytesUsed = 0;
+            var charsUsed = 0;
+#if NETCOREAPP2_1
+            _encoder.Convert(new Span<char>(&value, 1), destination, false, out charsUsed, out bytesUsed, out _);
+#else
+            fixed (byte* destinationBytes = &MemoryMarshal.GetReference(destination))
+            {
+                _encoder.Convert(&value, 1, destinationBytes, destination.Length, false, out charsUsed, out bytesUsed, out _);
+            }
+#endif
+
+            Debug.Assert(charsUsed == 1);
+
+            if (bytesUsed > 0)
+            {
+                _memoryUsed += bytesUsed;
             }
         }
 
@@ -124,6 +129,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
             WriteInternal(value.AsSpan());
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private Span<byte> GetBuffer()
         {
             EnsureBuffer();

--- a/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/Utf8BufferTextWriter.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/Utf8BufferTextWriter.cs
@@ -90,16 +90,19 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
             if (value <= 127)
             {
                 EnsureBuffer();
+
+                // Only need to set one byte
+                // Avoid Memory<T>.Slice overhead for perf
                 _memory.Span[_memoryUsed] = (byte)value;
                 _memoryUsed++;
             }
             else
             {
-                WriteMultibyteChar(value);
+                WriteMultiByteChar(value);
             }
         }
 
-        private unsafe void WriteMultibyteChar(char value)
+        private unsafe void WriteMultiByteChar(char value)
         {
             var destination = GetBuffer();
 


### PR DESCRIPTION
Profiled with dotTrace and noticed writing individual chars happened a lot and it was slow. PR with some perf tweaks.

Before
```
             Method |          Input | HubProtocol |        Mean |      Error |     StdDev |        Op/s |  Gen 0 |  Gen 1 | Allocated |
------------------- |--------------- |------------ |------------:|-----------:|-----------:|------------:|-------:|-------:|----------:|
 WriteSingleMessage |   FewArguments |        Json |  2,810.3 ns |  47.737 ns |  39.863 ns |   355,834.0 | 0.1068 |      - |     960 B |
 WriteSingleMessage | LargeArguments |        Json | 51,938.1 ns | 386.560 ns | 322.795 ns |    19,253.7 | 2.1362 |      - |   25168 B |
 WriteSingleMessage |  ManyArguments |        Json |  4,758.5 ns |  19.705 ns |  17.468 ns |   210,150.8 | 0.2441 |      - |    2216 B |
 WriteSingleMessage |    NoArguments |        Json |  1,524.2 ns |   4.845 ns |   4.295 ns |   656,078.3 | 0.0572 |      - |     528 B |
```

After
```
             Method |          Input | HubProtocol |        Mean |        Error |       StdDev |      Median |        Op/s |  Gen 0 |  Gen 1 | Allocated |
------------------- |--------------- |------------ |------------:|-------------:|-------------:|------------:|------------:|-------:|-------:|----------:|
 WriteSingleMessage |   FewArguments |        Json |  2,547.2 ns |    54.650 ns |    48.446 ns |  2,519.7 ns |   392,588.9 | 0.1068 |      - |     960 B |
 WriteSingleMessage | LargeArguments |        Json | 53,085.2 ns |   747.032 ns |   623.806 ns | 52,727.3 ns |    18,837.6 | 2.1362 |      - |   25168 B |
 WriteSingleMessage |  ManyArguments |        Json |  4,585.0 ns |    91.757 ns |   112.685 ns |  4,531.5 ns |   218,103.3 | 0.2441 |      - |    2216 B |
 WriteSingleMessage |    NoArguments |        Json |  1,287.1 ns |     4.177 ns |     3.703 ns |  1,285.9 ns |   776,961.7 | 0.0572 |      - |     528 B |
```