### PR TITLE
ThreadStatic MemoryBufferWriter

### DIFF
--- a/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/HubConnectionContextBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/HubConnectionContextBenchmark.cs
@@ -30,10 +30,15 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
         [GlobalSetup]
         public void GlobalSetup()
         {
-            using (var memoryBufferWriter = new MemoryBufferWriter())
+            var memoryBufferWriter = MemoryBufferWriter.Get();
+            try
             {
                 HandshakeProtocol.WriteRequestMessage(new HandshakeRequestMessage("json", 1), memoryBufferWriter);
                 _handshakeRequestResult = new ReadResult(new ReadOnlySequence<byte>(memoryBufferWriter.ToArray()), false, false);
+            }
+            finally
+            {
+                MemoryBufferWriter.Return(memoryBufferWriter);
             }
 
             _pipe = new TestDuplexPipe();

--- a/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/HubConnectionSendBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/HubConnectionSendBenchmark.cs
@@ -24,13 +24,18 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
         [GlobalSetup]
         public void GlobalSetup()
         {
-            using (var writer = new MemoryBufferWriter())
+            var writer = MemoryBufferWriter.Get();
+            try
             {
                 HandshakeProtocol.WriteResponseMessage(HandshakeResponseMessage.Empty, writer);
                 var handshakeResponseResult = new ReadResult(new ReadOnlySequence<byte>(writer.ToArray()), false, false);
 
                 _pipe = new TestDuplexPipe();
                 _pipe.AddReadResult(new ValueTask<ReadResult>(handshakeResponseResult));
+            }
+            finally
+            {
+                MemoryBufferWriter.Return(writer);
             }
 
             _tcs = new TaskCompletionSource<ReadResult>();

--- a/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/HubConnectionStartBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/HubConnectionStartBenchmark.cs
@@ -26,10 +26,15 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
         [GlobalSetup]
         public void GlobalSetup()
         {
-            using (var writer = new MemoryBufferWriter())
+            var writer = MemoryBufferWriter.Get();
+            try
             {
                 HandshakeProtocol.WriteResponseMessage(HandshakeResponseMessage.Empty, writer);
                 _handshakeResponseResult = new ReadResult(new ReadOnlySequence<byte>(writer.ToArray()), false, false);
+            }
+            finally
+            {
+                MemoryBufferWriter.Return(writer);
             }
 
             _pipe = new TestDuplexPipe();

--- a/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/MessageParserBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/MessageParserBenchmark.cs
@@ -24,21 +24,31 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
         {
             var buffer = new byte[MessageLength];
             Random.NextBytes(buffer);
-            using (var writer = new MemoryBufferWriter())
+            var writer = MemoryBufferWriter.Get();
+            try
             {
                 BinaryMessageFormatter.WriteLengthPrefix(buffer.Length, writer);
                 writer.Write(buffer);
                 _binaryInput = writer.ToArray();
             }
+            finally
+            {
+                MemoryBufferWriter.Return(writer);
+            }
 
             buffer = new byte[MessageLength];
             Random.NextBytes(buffer);
-            using (var writer = new MemoryBufferWriter())
+            writer = MemoryBufferWriter.Get();
+            try
             {
                 writer.Write(buffer);
                 TextMessageFormatter.WriteRecordSeparator(writer);
 
                 _textInput = writer.ToArray();
+            }
+            finally
+            {
+                MemoryBufferWriter.Return(writer);
             }
         }
 

--- a/src/Microsoft.AspNetCore.SignalR.Common/Internal/MemoryBufferWriter.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Common/Internal/MemoryBufferWriter.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal
         internal List<byte[]> Segments { get; }
         internal int Position { get; private set; }
 
-        public MemoryBufferWriter(int segmentSize = 2048)
+        private MemoryBufferWriter(int segmentSize = 2048)
         {
             _segmentSize = segmentSize;
 
@@ -59,6 +59,9 @@ namespace Microsoft.AspNetCore.SignalR.Internal
                 ArrayPool<byte>.Shared.Return(writer.Segments[i]);
             }
             writer.Segments.Clear();
+            writer._bytesWritten = 0;
+            writer.Position = 0;
+
         }
 
         public Memory<byte> CurrentSegment => Segments.Count > 0 ? Segments[Segments.Count - 1] : null;

--- a/src/Microsoft.AspNetCore.SignalR.Common/Internal/MemoryBufferWriter.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Common/Internal/MemoryBufferWriter.cs
@@ -34,7 +34,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal
                 writer = new MemoryBufferWriter();
             }
 
-            // Taken off the the thread static
+            // Taken off the thread static
             _cachedInstance = null;
 #if DEBUG
             if (writer._inUse)
@@ -61,10 +61,9 @@ namespace Microsoft.AspNetCore.SignalR.Internal
             writer.Segments.Clear();
             writer._bytesWritten = 0;
             writer.Position = 0;
-
         }
 
-        public Memory<byte> CurrentSegment => Segments.Count > 0 ? Segments[Segments.Count - 1] : null;
+        public Memory<byte> CurrentSegment => Segments[Segments.Count - 1];
 
         public void Advance(int count)
         {
@@ -82,7 +81,9 @@ namespace Microsoft.AspNetCore.SignalR.Internal
                 Position = 0;
             }
 
-            return CurrentSegment.Slice(Position, CurrentSegment.Length - Position);
+            // Cache property access
+            var currentSegment = CurrentSegment;
+            return currentSegment.Slice(Position, currentSegment.Length - Position);
         }
 
         public Span<byte> GetSpan(int sizeHint = 0)

--- a/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/HubMessage.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/HubMessage.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.IO;
 
 namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
 {
@@ -14,6 +13,8 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
 
         private object _lock = new object();
         private List<SerializedMessage> _serializedMessages;
+        SerializedMessage message1;
+        SerializedMessage message2;
 
         public byte[] WriteMessage(IHubProtocol protocol)
         {
@@ -24,9 +25,19 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
 
             lock (_lock)
             {
+                if (ReferenceEquals(message1.Protocol, protocol))
+                {
+                    return message1.Message;
+                }
+
+                if (ReferenceEquals(message2.Protocol, protocol))
+                {
+                    return message2.Message;
+                }
+
                 for (var i = 0; i < _serializedMessages?.Count; i++)
                 {
-                    if (_serializedMessages[i].Protocol.Equals(protocol))
+                    if (ReferenceEquals(_serializedMessages[i].Protocol, protocol))
                     {
                         return _serializedMessages[i].Message;
                     }
@@ -34,17 +45,27 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
 
                 var bytes = protocol.WriteToArray(this);
 
-                if (_serializedMessages == null)
+                if (message1.Protocol == null)
                 {
-                    // Initialize with capacity 2 for the 2 built in protocols
-                    _serializedMessages = new List<SerializedMessage>(2);
+                    message1 = new SerializedMessage(protocol, bytes);
                 }
-
-                // We don't want to balloon memory if someone writes a poor IHubProtocolResolver
-                // So we cap how many caches we store and worst case just serialize the message for every connection
-                if (_serializedMessages.Count < 10)
+                else if (message2.Protocol == null)
                 {
-                    _serializedMessages.Add(new SerializedMessage(protocol, bytes));
+                    message2 = new SerializedMessage(protocol, bytes);
+                }
+                else
+                {
+                    if (_serializedMessages == null)
+                    {
+                        _serializedMessages = new List<SerializedMessage>();
+                    }
+
+                    // We don't want to balloon memory if someone writes a poor IHubProtocolResolver
+                    // So we cap how many caches we store and worst case just serialize the message for every connection
+                    if (_serializedMessages.Count < 10)
+                    {
+                        _serializedMessages.Add(new SerializedMessage(protocol, bytes));
+                    }
                 }
 
                 return bytes;

--- a/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/HubMessage.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/HubMessage.cs
@@ -13,8 +13,8 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
 
         private object _lock = new object();
         private List<SerializedMessage> _serializedMessages;
-        SerializedMessage message1;
-        SerializedMessage message2;
+        private SerializedMessage _message1;
+        private SerializedMessage _message2;
 
         public byte[] WriteMessage(IHubProtocol protocol)
         {
@@ -25,14 +25,14 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
 
             lock (_lock)
             {
-                if (ReferenceEquals(message1.Protocol, protocol))
+                if (ReferenceEquals(_message1.Protocol, protocol))
                 {
-                    return message1.Message;
+                    return _message1.Message;
                 }
 
-                if (ReferenceEquals(message2.Protocol, protocol))
+                if (ReferenceEquals(_message2.Protocol, protocol))
                 {
-                    return message2.Message;
+                    return _message2.Message;
                 }
 
                 for (var i = 0; i < _serializedMessages?.Count; i++)
@@ -45,13 +45,13 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
 
                 var bytes = protocol.WriteToArray(this);
 
-                if (message1.Protocol == null)
+                if (_message1.Protocol == null)
                 {
-                    message1 = new SerializedMessage(protocol, bytes);
+                    _message1 = new SerializedMessage(protocol, bytes);
                 }
-                else if (message2.Protocol == null)
+                else if (_message2.Protocol == null)
                 {
-                    message2 = new SerializedMessage(protocol, bytes);
+                    _message2 = new SerializedMessage(protocol, bytes);
                 }
                 else
                 {

--- a/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/HubProtocolExtensions.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/HubProtocolExtensions.cs
@@ -7,10 +7,15 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
     {
         public static byte[] WriteToArray(this IHubProtocol hubProtocol, HubMessage message)
         {
-            using (var writer = new MemoryBufferWriter())
+            var writer = MemoryBufferWriter.Get();
+            try
             {
                 hubProtocol.WriteMessage(message, writer);
                 return writer.ToArray();
+            }
+            finally
+            {
+                MemoryBufferWriter.Return(writer);
             }
         }
     }

--- a/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionContext.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionContext.cs
@@ -41,10 +41,15 @@ namespace Microsoft.AspNetCore.SignalR
 
         static HubConnectionContext()
         {
-            using (var memoryBufferWriter = new MemoryBufferWriter())
+            var memoryBufferWriter = MemoryBufferWriter.Get();
+            try
             {
                 HandshakeProtocol.WriteResponseMessage(HandshakeResponseMessage.Empty, memoryBufferWriter);
                 _successHandshakeResponseData = memoryBufferWriter.ToArray();
+            }
+            finally
+            {
+                MemoryBufferWriter.Return(memoryBufferWriter);
             }
         }
 

--- a/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionContext.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionContext.cs
@@ -113,9 +113,10 @@ namespace Microsoft.AspNetCore.SignalR
                 // So that we don't serialize the HubMessage for every single connection
                 var buffer = message.WriteMessage(Protocol);
 
-                _connectionContext.Transport.Output.Write(buffer);
+                var output = _connectionContext.Transport.Output;
+                output.Write(buffer);
 
-                return _connectionContext.Transport.Output.FlushAsync();
+                return output.FlushAsync();
             }
             catch (Exception ex)
             {

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/TestConnection.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/TestConnection.cs
@@ -75,10 +75,15 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
         {
             var s = await ReadSentTextMessageAsync();
 
-            using (var output = new MemoryBufferWriter())
+            var output = MemoryBufferWriter.Get();
+            try
             {
                 HandshakeProtocol.WriteResponseMessage(HandshakeResponseMessage.Empty, output);
                 await Application.Output.WriteAsync(output.ToArray());
+            }
+            finally
+            {
+                MemoryBufferWriter.Return(output);
             }
 
             return s;

--- a/test/Microsoft.AspNetCore.SignalR.Common.Tests/Internal/Protocol/JsonHubProtocolTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Common.Tests/Internal/Protocol/JsonHubProtocolTests.cs
@@ -114,12 +114,17 @@ namespace Microsoft.AspNetCore.SignalR.Common.Tests.Internal.Protocol
 
             var protocol = new JsonHubProtocol(Options.Create(protocolOptions));
 
-            using (var writer = new MemoryBufferWriter())
+            var writer = MemoryBufferWriter.Get();
+            try
             {
                 protocol.WriteMessage(message, writer);
                 var json = Encoding.UTF8.GetString(writer.ToArray());
 
                 Assert.Equal(expectedOutput, json);
+            }
+            finally
+            {
+                MemoryBufferWriter.Return(writer);
             }
         }
 

--- a/test/Microsoft.AspNetCore.SignalR.Common.Tests/Internal/Protocol/MessagePackHubProtocolTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Common.Tests/Internal/Protocol/MessagePackHubProtocolTests.cs
@@ -445,11 +445,16 @@ namespace Microsoft.AspNetCore.SignalR.Common.Tests.Internal.Protocol
 
         private static byte[] Frame(byte[] input)
         {
-            using (var stream = new MemoryBufferWriter())
+            var stream = MemoryBufferWriter.Get();
+            try
             {
                 BinaryMessageFormatter.WriteLengthPrefix(input.Length, stream);
                 stream.Write(input);
                 return stream.ToArray();
+            }
+            finally
+            {
+                MemoryBufferWriter.Return(stream);
             }
         }
 
@@ -487,10 +492,15 @@ namespace Microsoft.AspNetCore.SignalR.Common.Tests.Internal.Protocol
         private static byte[] Write(HubMessage message)
         {
             var protocol = new MessagePackHubProtocol();
-            using (var writer = new MemoryBufferWriter())
+            var writer = MemoryBufferWriter.Get();
+            try
             {
                 protocol.WriteMessage(message, writer);
                 return writer.ToArray();
+            }
+            finally
+            {
+                MemoryBufferWriter.Return(writer);
             }
         }
 

--- a/test/Microsoft.AspNetCore.SignalR.Tests.Utils/TestClient.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests.Utils/TestClient.cs
@@ -66,10 +66,15 @@ namespace Microsoft.AspNetCore.SignalR.Tests
         {
             if (sendHandshakeRequestMessage)
             {
-                using (var memoryBufferWriter = new MemoryBufferWriter())
+                var memoryBufferWriter = MemoryBufferWriter.Get();
+                try
                 {
                     HandshakeProtocol.WriteRequestMessage(new HandshakeRequestMessage(_protocol.Name, _protocol.Version), memoryBufferWriter);
                     await Connection.Application.Output.WriteAsync(memoryBufferWriter.ToArray());
+                }
+                finally
+                {
+                    MemoryBufferWriter.Return(memoryBufferWriter);
                 }
             }
 


### PR DESCRIPTION
Before:
```
             Method |          Input | HubProtocol |      Mean |     Error |    StdDev |      Op/s |  Gen 0 | Allocated |
------------------- |--------------- |------------ |----------:|----------:|----------:|----------:|-------:|----------:|
 WriteSingleMessage |   FewArguments |        Json |  2.769 us | 0.0549 us | 0.0610 us | 361,104.3 | 0.0076 |     960 B |
 WriteSingleMessage |   FewArguments |     MsgPack |  1.911 us | 0.0382 us | 0.0839 us | 523,259.5 | 0.0076 |     704 B |
 WriteSingleMessage | LargeArguments |        Json | 68.896 us | 1.3741 us | 2.1393 us |  14,514.6 | 0.2441 |   25168 B |
 WriteSingleMessage | LargeArguments |     MsgPack | 20.272 us | 0.3968 us | 0.5160 us |  49,328.2 | 0.7324 |   62320 B |
 WriteSingleMessage |  ManyArguments |        Json |  5.207 us | 0.1025 us | 0.1140 us | 192,061.5 | 0.0229 |    2216 B |
 WriteSingleMessage |  ManyArguments |     MsgPack |  3.416 us | 0.0659 us | 0.0616 us | 292,710.0 | 0.0076 |     976 B |
 WriteSingleMessage |    NoArguments |        Json |  1.592 us | 0.0314 us | 0.0533 us | 628,212.1 | 0.0038 |     528 B |
 WriteSingleMessage |    NoArguments |     MsgPack |  1.055 us | 0.0208 us | 0.0298 us | 948,170.3 | 0.0038 |     456 B |

```

After:
```
             Method |          Input | HubProtocol |        Mean |       Error |    StdDev |        Op/s |  Gen 0 | Allocated |
------------------- |--------------- |------------ |------------:|------------:|----------:|------------:|-------:|----------:|
 WriteSingleMessage |   FewArguments |        Json |  2,355.9 ns |    46.97 ns |  50.26 ns |   424,464.4 | 0.0076 |     824 B |
 WriteSingleMessage |   FewArguments |     MsgPack |  1,859.0 ns |    24.75 ns |  21.94 ns |   537,937.8 | 0.0057 |     568 B |
 WriteSingleMessage | LargeArguments |        Json | 60,844.7 ns | 1,008.38 ns | 893.91 ns |    16,435.3 | 0.2441 |   24792 B |
 WriteSingleMessage | LargeArguments |     MsgPack | 18,209.9 ns |   364.07 ns | 566.82 ns |    54,915.1 | 0.7324 |   61944 B |
 WriteSingleMessage |  ManyArguments |        Json |  5,235.2 ns |   102.50 ns |  95.88 ns |   191,015.6 | 0.0153 |    2080 B |
 WriteSingleMessage |  ManyArguments |     MsgPack |  3,256.3 ns |    61.68 ns |  63.34 ns |   307,098.4 | 0.0076 |     840 B |
 WriteSingleMessage |    NoArguments |        Json |  1,413.0 ns |    27.86 ns |  56.28 ns |   707,718.9 | 0.0038 |     392 B |
 WriteSingleMessage |    NoArguments |     MsgPack |    928.1 ns |    18.34 ns |  22.52 ns | 1,077,422.1 | 0.0029 |     320 B |
```