### PR TITLE
Clean up pipe pair on transport start failure

### DIFF
--- a/src/Microsoft.AspNetCore.Http.Connections.Client/HttpConnection.cs
+++ b/src/Microsoft.AspNetCore.Http.Connections.Client/HttpConnection.cs
@@ -345,6 +345,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
             catch (Exception ex)
             {
                 Log.ErrorStartingTransport(_logger, transport, ex);
+
+                // Clean up pipes and null out transport when we fail to start.
                 pair.Transport.Input.Complete();
                 pair.Transport.Output.Complete();
                 pair.Application.Input.Complete();

--- a/src/Microsoft.AspNetCore.Http.Connections.Client/HttpConnection.cs
+++ b/src/Microsoft.AspNetCore.Http.Connections.Client/HttpConnection.cs
@@ -345,8 +345,11 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
             catch (Exception ex)
             {
                 Log.ErrorStartingTransport(_logger, transport, ex);
+                pair.Transport.Input.Complete();
+                pair.Transport.Output.Complete();
+                pair.Application.Input.Complete();
+                pair.Application.Output.Complete();
                 _transport = null;
-                completePipePair(pair);
                 throw;
             }
 
@@ -355,14 +358,6 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
             _transportPipe = pair.Transport;
 
             Log.TransportStarted(_logger, _transport);
-        }
-
-        private void completePipePair(DuplexPipe.DuplexPipePair duplexPipePair)
-        {
-            duplexPipePair.Transport.Input.Complete();
-            duplexPipePair.Transport.Output.Complete();
-            duplexPipePair.Application.Input.Complete();
-            duplexPipePair.Application.Output.Complete();
         }
 
         private HttpClient CreateHttpClient()

--- a/src/Microsoft.AspNetCore.Http.Connections.Client/HttpConnection.cs
+++ b/src/Microsoft.AspNetCore.Http.Connections.Client/HttpConnection.cs
@@ -346,6 +346,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
             {
                 Log.ErrorStartingTransport(_logger, transport, ex);
                 _transport = null;
+                completePipePair(pair);
                 throw;
             }
 
@@ -354,6 +355,14 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
             _transportPipe = pair.Transport;
 
             Log.TransportStarted(_logger, _transport);
+        }
+
+        private void completePipePair(DuplexPipe.DuplexPipePair duplexPipePair)
+        {
+            duplexPipePair.Transport.Input.Complete();
+            duplexPipePair.Transport.Output.Complete();
+            duplexPipePair.Application.Input.Complete();
+            duplexPipePair.Application.Output.Complete();
         }
 
         private HttpClient CreateHttpClient()

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.ConnectionLifecycle.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.ConnectionLifecycle.cs
@@ -160,6 +160,28 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
             }
 
             [Fact]
+            public async Task PipesAreDisposedAfterTransportFailsToStart()
+            {
+                using (StartLog(out var loggerFactory))
+                {
+                    var writerTcs = new TaskCompletionSource<object>();
+                    var readerTcs = new TaskCompletionSource<object>();
+                    await WithConnectionAsync(
+                        CreateConnection(
+                            loggerFactory: loggerFactory,
+                            transport: new FakeTransport(writerTcs, readerTcs)),
+                        async (connection) =>
+                        {
+                            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => connection.StartAsync(TransferFormat.Text));
+                            Assert.Equal("Unable to connect to the server with any of the available transports.", ex.Message);
+
+                            Assert.True(writerTcs.Task.IsCompleted);
+                            Assert.True(readerTcs.Task.IsCompleted);
+                        });
+                }
+            }
+
+            [Fact]
             public async Task CanDisposeUnstartedConnection()
             {
                 using (StartLog(out var loggerFactory))
@@ -353,6 +375,35 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                             connectResponseTcs.TrySetResult(null);
                             await startTask;
                         });
+                }
+            }
+
+            private class FakeTransport : ITransport
+            {
+                private IDuplexPipe _application;
+                private TaskCompletionSource<object> _writerTcs;
+                private TaskCompletionSource<object> _readerTcs;
+
+                public FakeTransport(TaskCompletionSource<object> writerTcs, TaskCompletionSource<object> readerTcs)
+                {
+                    _writerTcs = writerTcs;
+                    _readerTcs = readerTcs;
+                }
+
+                public Task StartAsync(Uri url, IDuplexPipe application, TransferFormat transferFormat, IConnection connection)
+                {
+                    _application = application;
+                    Action<Exception, object> onCompletedCallback = (ex, tcs) => { ((TaskCompletionSource<object>)tcs).TrySetResult(null); };
+                    _application.Input.OnWriterCompleted(onCompletedCallback, _writerTcs);
+                    _application.Output.OnReaderCompleted(onCompletedCallback, _readerTcs);
+                    throw new Exception();
+                }
+
+                public Task StopAsync()
+                {
+                    _application.Output.Complete();
+                    _application.Input.Complete();
+                    return Task.CompletedTask;
                 }
             }
 


### PR DESCRIPTION
Completing pipes when our transport fails to start.
Issue: https://github.com/aspnet/SignalR/issues/1733