### PR TITLE
Rename TransportTypes to HttpTransportTypes

### DIFF
--- a/clients/ts/FunctionalTests/Startup.cs
+++ b/clients/ts/FunctionalTests/Startup.cs
@@ -91,7 +91,7 @@ namespace FunctionalTests
             app.UseSignalR(routes =>
             {
                 routes.MapHub<TestHub>("/testhub");
-                routes.MapHub<TestHub>("/testhub-nowebsockets", options => options.Transports = TransportType.ServerSentEvents | TransportType.LongPolling);
+                routes.MapHub<TestHub>("/testhub-nowebsockets", options => options.Transports = HttpTransportType.ServerSentEvents | HttpTransportType.LongPolling);
                 routes.MapHub<UncreatableHub>("/uncreatable");
                 routes.MapHub<HubWithAuthorization>("/authorizedhub");
             });

--- a/samples/JwtClientSample/Program.cs
+++ b/samples/JwtClientSample/Program.cs
@@ -16,9 +16,9 @@ namespace JwtClientSample
         {
             var app = new Program();
             await Task.WhenAll(
-                app.RunConnection(TransportType.WebSockets),
-                app.RunConnection(TransportType.ServerSentEvents),
-                app.RunConnection(TransportType.LongPolling));
+                app.RunConnection(HttpTransportType.WebSockets),
+                app.RunConnection(HttpTransportType.ServerSentEvents),
+                app.RunConnection(HttpTransportType.LongPolling));
         }
 
         private const string ServerUrl = "http://localhost:54543";
@@ -26,7 +26,7 @@ namespace JwtClientSample
         private readonly ConcurrentDictionary<string, string> _tokens = new ConcurrentDictionary<string, string>();
         private readonly Random _random = new Random();
 
-        private async Task RunConnection(TransportType transportType)
+        private async Task RunConnection(HttpTransportType transportType)
         {
             var userId = "C#" + transportType.ToString();
             _tokens[userId] = await GetJwtToken(userId);
@@ -56,7 +56,7 @@ namespace JwtClientSample
                     if (ticks % 15 == 0)
                     {
                         // no need to refresh the token for websockets
-                        if (transportType != TransportType.WebSockets)
+                        if (transportType != HttpTransportType.WebSockets)
                         {
                             _tokens[userId] = await GetJwtToken(userId);
                             Console.WriteLine($"[{userId}] Token refreshed");

--- a/src/Microsoft.AspNetCore.Http.Connections.Client/DefaultTransportFactory.cs
+++ b/src/Microsoft.AspNetCore.Http.Connections.Client/DefaultTransportFactory.cs
@@ -14,18 +14,18 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
     {
         private readonly HttpClient _httpClient;
         private readonly HttpOptions _httpOptions;
-        private readonly TransportType _requestedTransportType;
+        private readonly HttpTransportType _requestedTransportType;
         private readonly ILoggerFactory _loggerFactory;
         private static volatile bool _websocketsSupported = true;
 
-        public DefaultTransportFactory(TransportType requestedTransportType, ILoggerFactory loggerFactory, HttpClient httpClient, HttpOptions httpOptions)
+        public DefaultTransportFactory(HttpTransportType requestedTransportType, ILoggerFactory loggerFactory, HttpClient httpClient, HttpOptions httpOptions)
         {
-            if (requestedTransportType <= 0 || requestedTransportType > TransportType.All)
+            if (requestedTransportType <= 0 || requestedTransportType > HttpTransportType.All)
             {
                 throw new ArgumentOutOfRangeException(nameof(requestedTransportType));
             }
 
-            if (httpClient == null && requestedTransportType != TransportType.WebSockets)
+            if (httpClient == null && requestedTransportType != HttpTransportType.WebSockets)
             {
                 throw new ArgumentNullException(nameof(httpClient));
             }
@@ -36,9 +36,9 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
             _httpOptions = httpOptions;
         }
 
-        public ITransport CreateTransport(TransportType availableServerTransports)
+        public ITransport CreateTransport(HttpTransportType availableServerTransports)
         {
-            if (_websocketsSupported && (availableServerTransports & TransportType.WebSockets & _requestedTransportType) == TransportType.WebSockets)
+            if (_websocketsSupported && (availableServerTransports & HttpTransportType.WebSockets & _requestedTransportType) == HttpTransportType.WebSockets)
             {
                 try
                 {
@@ -50,12 +50,12 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
                 }
             }
 
-            if ((availableServerTransports & TransportType.ServerSentEvents & _requestedTransportType) == TransportType.ServerSentEvents)
+            if ((availableServerTransports & HttpTransportType.ServerSentEvents & _requestedTransportType) == HttpTransportType.ServerSentEvents)
             {
                 return new ServerSentEventsTransport(_httpClient, _loggerFactory);
             }
 
-            if ((availableServerTransports & TransportType.LongPolling & _requestedTransportType) == TransportType.LongPolling)
+            if ((availableServerTransports & HttpTransportType.LongPolling & _requestedTransportType) == HttpTransportType.LongPolling)
             {
                 return new LongPollingTransport(_httpClient, _loggerFactory);
             }

--- a/src/Microsoft.AspNetCore.Http.Connections.Client/HttpConnection.Log.cs
+++ b/src/Microsoft.AspNetCore.Http.Connections.Client/HttpConnection.Log.cs
@@ -95,7 +95,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
                 _disposed(logger, null);
             }
 
-            public static void StartingTransport(ILogger logger, TransportType transportType, Uri url)
+            public static void StartingTransport(ILogger logger, HttpTransportType transportType, Uri url)
             {
                 if (logger.IsEnabled(LogLevel.Debug))
                 {
@@ -131,7 +131,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
                 _transportNotSupported(logger, transport, null);
             }
 
-            public static void TransportDoesNotSupportTransferFormat(ILogger logger, TransportType transport, TransferFormat transferFormat)
+            public static void TransportDoesNotSupportTransferFormat(ILogger logger, HttpTransportType transport, TransferFormat transferFormat)
             {
                 if (logger.IsEnabled(LogLevel.Debug))
                 {
@@ -139,7 +139,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
                 }
             }
 
-            public static void TransportDisabledByClient(ILogger logger, TransportType transport)
+            public static void TransportDisabledByClient(ILogger logger, HttpTransportType transport)
             {
                 if (logger.IsEnabled(LogLevel.Debug))
                 {
@@ -147,7 +147,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
                 }
             }
 
-            public static void TransportFailed(ILogger logger, TransportType transport, Exception ex)
+            public static void TransportFailed(ILogger logger, HttpTransportType transport, Exception ex)
             {
                 if (logger.IsEnabled(LogLevel.Debug))
                 {

--- a/src/Microsoft.AspNetCore.Http.Connections.Client/HttpConnection.cs
+++ b/src/Microsoft.AspNetCore.Http.Connections.Client/HttpConnection.cs
@@ -37,7 +37,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
         private ITransport _transport;
         private readonly ITransportFactory _transportFactory;
         private string _connectionId;
-        private readonly TransportType _requestedTransportType = TransportType.All;
+        private readonly HttpTransportType _requestedTransportType = HttpTransportType.All;
         private readonly ConnectionLogScope _logScope;
         private readonly IDisposable _scopeDisposable;
         private readonly ILoggerFactory _loggerFactory;
@@ -60,25 +60,25 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
         public IFeatureCollection Features { get; } = new FeatureCollection();
 
         public HttpConnection(Uri url)
-            : this(url, TransportType.All)
+            : this(url, HttpTransportType.All)
         { }
 
-        public HttpConnection(Uri url, TransportType transportType)
+        public HttpConnection(Uri url, HttpTransportType transportType)
             : this(url, transportType, loggerFactory: null)
         {
         }
 
         public HttpConnection(Uri url, ILoggerFactory loggerFactory)
-            : this(url, TransportType.All, loggerFactory, httpOptions: null)
+            : this(url, HttpTransportType.All, loggerFactory, httpOptions: null)
         {
         }
 
-        public HttpConnection(Uri url, TransportType transportType, ILoggerFactory loggerFactory)
+        public HttpConnection(Uri url, HttpTransportType transportType, ILoggerFactory loggerFactory)
             : this(url, transportType, loggerFactory, httpOptions: null)
         {
         }
 
-        public HttpConnection(Uri url, TransportType transportType, ILoggerFactory loggerFactory, HttpOptions httpOptions)
+        public HttpConnection(Uri url, HttpTransportType transportType, ILoggerFactory loggerFactory, HttpOptions httpOptions)
         {
             Url = url ?? throw new ArgumentNullException(nameof(url));
             _loggerFactory = loggerFactory ?? NullLoggerFactory.Instance;
@@ -87,7 +87,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
             _httpOptions = httpOptions;
 
             _requestedTransportType = transportType;
-            if (_requestedTransportType != TransportType.WebSockets)
+            if (_requestedTransportType != HttpTransportType.WebSockets)
             {
                 _httpClient = CreateHttpClient();
             }
@@ -205,7 +205,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
 
         private async Task SelectAndStartTransport(TransferFormat transferFormat)
         {
-            if (_requestedTransportType == TransportType.WebSockets)
+            if (_requestedTransportType == HttpTransportType.WebSockets)
             {
                 Log.StartingTransport(_logger, _requestedTransportType, Url);
                 await StartTransport(Url, _requestedTransportType, transferFormat);
@@ -224,13 +224,13 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
 
                 foreach (var transport in negotiationResponse.AvailableTransports)
                 {
-                    if (!Enum.TryParse<TransportType>(transport.Transport, out var transportType))
+                    if (!Enum.TryParse<HttpTransportType>(transport.Transport, out var transportType))
                     {
                         Log.TransportNotSupported(_logger, transport.Transport);
                         continue;
                     }
 
-                    if (transportType == TransportType.WebSockets && !IsWebSocketsSupported())
+                    if (transportType == HttpTransportType.WebSockets && !IsWebSocketsSupported())
                     {
                         Log.WebSocketsNotSupportedByOperatingSystem(_logger);
                         continue;
@@ -328,7 +328,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
             return Utils.AppendQueryString(url, "id=" + connectionId);
         }
 
-        private async Task StartTransport(Uri connectUrl, TransportType transportType, TransferFormat transferFormat)
+        private async Task StartTransport(Uri connectUrl, HttpTransportType transportType, TransferFormat transferFormat)
         {
             // Create the pipe pair (Application's writer is connected to Transport's reader, and vice versa)
             var options = new PipeOptions(writerScheduler: PipeScheduler.ThreadPool, readerScheduler: PipeScheduler.ThreadPool, useSynchronizationContext: false, pauseWriterThreshold: 0, resumeWriterThreshold: 0);

--- a/src/Microsoft.AspNetCore.Http.Connections.Client/ITransportFactory.cs
+++ b/src/Microsoft.AspNetCore.Http.Connections.Client/ITransportFactory.cs
@@ -5,6 +5,6 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
 {
     public interface ITransportFactory
     {
-        ITransport CreateTransport(TransportType availableServerTransports);
+        ITransport CreateTransport(HttpTransportType availableServerTransports);
     }
 }

--- a/src/Microsoft.AspNetCore.Http.Connections.Common/TransportType.cs
+++ b/src/Microsoft.AspNetCore.Http.Connections.Common/TransportType.cs
@@ -6,7 +6,7 @@ using System;
 namespace Microsoft.AspNetCore.Http.Connections
 {
     [Flags]
-    public enum TransportType
+    public enum HttpTransportType
     {
         WebSockets = 1,
         ServerSentEvents = 2,

--- a/src/Microsoft.AspNetCore.Http.Connections/HttpConnectionDispatcher.Log.cs
+++ b/src/Microsoft.AspNetCore.Http.Connections/HttpConnectionDispatcher.Log.cs
@@ -28,11 +28,11 @@ namespace Microsoft.AspNetCore.Http.Connections
             private static readonly Action<ILogger, long, Exception> _receivedBytes =
                 LoggerMessage.Define<long>(LogLevel.Trace, new EventId(6, "ReceivedBytes"), "Received {Count} bytes.");
 
-            private static readonly Action<ILogger, TransportType, Exception> _transportNotSupported =
-                LoggerMessage.Define<TransportType>(LogLevel.Debug, new EventId(7, "TransportNotSupported"), "{TransportType} transport not supported by this connection handler.");
+            private static readonly Action<ILogger, HttpTransportType, Exception> _transportNotSupported =
+                LoggerMessage.Define<HttpTransportType>(LogLevel.Debug, new EventId(7, "TransportNotSupported"), "{TransportType} transport not supported by this connection handler.");
 
-            private static readonly Action<ILogger, TransportType, TransportType, Exception> _cannotChangeTransport =
-                LoggerMessage.Define<TransportType, TransportType>(LogLevel.Error, new EventId(8, "CannotChangeTransport"), "Cannot change transports mid-connection; currently using {TransportType}, requesting {RequestedTransport}.");
+            private static readonly Action<ILogger, HttpTransportType, HttpTransportType, Exception> _cannotChangeTransport =
+                LoggerMessage.Define<HttpTransportType, HttpTransportType>(LogLevel.Error, new EventId(8, "CannotChangeTransport"), "Cannot change transports mid-connection; currently using {TransportType}, requesting {RequestedTransport}.");
 
             private static readonly Action<ILogger, Exception> _postNotallowedForWebsockets =
                 LoggerMessage.Define(LogLevel.Debug, new EventId(9, "PostNotAllowedForWebSockets"), "POST requests are not allowed for websocket connections.");
@@ -70,12 +70,12 @@ namespace Microsoft.AspNetCore.Http.Connections
                 _receivedBytes(logger, count, null);
             }
 
-            public static void TransportNotSupported(ILogger logger, TransportType transport)
+            public static void TransportNotSupported(ILogger logger, HttpTransportType transport)
             {
                 _transportNotSupported(logger, transport, null);
             }
 
-            public static void CannotChangeTransport(ILogger logger, TransportType transport, TransportType requestTransport)
+            public static void CannotChangeTransport(ILogger logger, HttpTransportType transport, HttpTransportType requestTransport)
             {
                 _cannotChangeTransport(logger, transport, requestTransport, null);
             }

--- a/src/Microsoft.AspNetCore.Http.Connections/HttpConnectionOptions.cs
+++ b/src/Microsoft.AspNetCore.Http.Connections/HttpConnectionOptions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.Http.Connections
     {
         public IList<IAuthorizeData> AuthorizationData { get; } = new List<IAuthorizeData>();
 
-        public TransportType Transports { get; set; } = TransportType.All;
+        public HttpTransportType Transports { get; set; } = HttpTransportType.All;
 
         public WebSocketOptions WebSockets { get; } = new WebSocketOptions();
 

--- a/src/Microsoft.AspNetCore.SignalR.Client/HubConnectionBuilderHttpExtensions.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client/HubConnectionBuilderHttpExtensions.cs
@@ -67,7 +67,7 @@ namespace Microsoft.AspNetCore.SignalR.Client
             return hubConnectionBuilder;
         }
 
-        public static IHubConnectionBuilder WithTransport(this IHubConnectionBuilder hubConnectionBuilder, TransportType transportType)
+        public static IHubConnectionBuilder WithTransport(this IHubConnectionBuilder hubConnectionBuilder, HttpTransportType transportType)
         {
             hubConnectionBuilder.AddSetting(TransportTypeKey, transportType);
             return hubConnectionBuilder;
@@ -184,14 +184,14 @@ namespace Microsoft.AspNetCore.SignalR.Client
             return hubConnectionBuilder;
         }
 
-        public static TransportType GetTransport(this IHubConnectionBuilder hubConnectionBuilder)
+        public static HttpTransportType GetTransport(this IHubConnectionBuilder hubConnectionBuilder)
         {
-            if (hubConnectionBuilder.TryGetSetting<TransportType>(TransportTypeKey, out var transportType))
+            if (hubConnectionBuilder.TryGetSetting<HttpTransportType>(TransportTypeKey, out var transportType))
             {
                 return transportType;
             }
 
-            return TransportType.All;
+            return HttpTransportType.All;
         }
 
         /// <summary>

--- a/test/Microsoft.AspNetCore.Http.Connections.Tests/HttpConnectionDispatcherTests.cs
+++ b/test/Microsoft.AspNetCore.Http.Connections.Tests/HttpConnectionDispatcherTests.cs
@@ -96,9 +96,9 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
         }
 
         [Theory]
-        [InlineData(TransportType.LongPolling)]
-        [InlineData(TransportType.ServerSentEvents)]
-        public async Task CheckThatThresholdValuesAreEnforcedWithSends(TransportType transportType)
+        [InlineData(HttpTransportType.LongPolling)]
+        [InlineData(HttpTransportType.ServerSentEvents)]
+        public async Task CheckThatThresholdValuesAreEnforcedWithSends(HttpTransportType transportType)
         {
             using (StartLog(out var loggerFactory, LogLevel.Debug))
             {
@@ -147,10 +147,10 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
         }
 
         [Theory]
-        [InlineData(TransportType.All)]
-        [InlineData((TransportType)0)]
-        [InlineData(TransportType.LongPolling | TransportType.WebSockets)]
-        public async Task NegotiateReturnsAvailableTransportsAfterFilteringByOptions(TransportType transports)
+        [InlineData(HttpTransportType.All)]
+        [InlineData((HttpTransportType)0)]
+        [InlineData(HttpTransportType.LongPolling | HttpTransportType.WebSockets)]
+        public async Task NegotiateReturnsAvailableTransportsAfterFilteringByOptions(HttpTransportType transports)
         {
             using (StartLog(out var loggerFactory, LogLevel.Debug))
             {
@@ -169,10 +169,10 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                 await dispatcher.ExecuteNegotiateAsync(context, new HttpConnectionOptions { Transports = transports });
 
                 var negotiateResponse = JsonConvert.DeserializeObject<JObject>(Encoding.UTF8.GetString(ms.ToArray()));
-                var availableTransports = (TransportType)0;
+                var availableTransports = (HttpTransportType)0;
                 foreach (var transport in negotiateResponse["availableTransports"])
                 {
-                    var transportType = (TransportType)Enum.Parse(typeof(TransportType), transport.Value<string>("transport"));
+                    var transportType = (HttpTransportType)Enum.Parse(typeof(HttpTransportType), transport.Value<string>("transport"));
                     availableTransports |= transportType;
                 }
 
@@ -181,10 +181,10 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
         }
 
         [Theory]
-        [InlineData(TransportType.WebSockets)]
-        [InlineData(TransportType.ServerSentEvents)]
-        [InlineData(TransportType.LongPolling)]
-        public async Task EndpointsThatAcceptConnectionId404WhenUnknownConnectionIdProvided(TransportType transportType)
+        [InlineData(HttpTransportType.WebSockets)]
+        [InlineData(HttpTransportType.ServerSentEvents)]
+        [InlineData(HttpTransportType.LongPolling)]
+        public async Task EndpointsThatAcceptConnectionId404WhenUnknownConnectionIdProvided(HttpTransportType transportType)
         {
             using (StartLog(out var loggerFactory, LogLevel.Debug))
             {
@@ -263,7 +263,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                 var manager = CreateConnectionManager(loggerFactory);
                 var dispatcher = new HttpConnectionDispatcher(manager, loggerFactory);
                 var connection = manager.CreateConnection();
-                connection.Items[ConnectionMetadataNames.Transport] = TransportType.WebSockets;
+                connection.Items[ConnectionMetadataNames.Transport] = HttpTransportType.WebSockets;
 
                 using (var strm = new MemoryStream())
                 {
@@ -293,9 +293,9 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
         }
 
         [Theory]
-        [InlineData(TransportType.LongPolling)]
-        [InlineData(TransportType.ServerSentEvents)]
-        public async Task PostSendsToConnection(TransportType transportType)
+        [InlineData(HttpTransportType.LongPolling)]
+        [InlineData(HttpTransportType.ServerSentEvents)]
+        public async Task PostSendsToConnection(HttpTransportType transportType)
         {
             using (StartLog(out var loggerFactory, LogLevel.Debug))
             {
@@ -429,9 +429,9 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
         }
 
         [Theory]
-        [InlineData(TransportType.ServerSentEvents)]
-        [InlineData(TransportType.LongPolling)]
-        public async Task EndpointsThatRequireConnectionId400WhenNoConnectionIdProvided(TransportType transportType)
+        [InlineData(HttpTransportType.ServerSentEvents)]
+        [InlineData(HttpTransportType.LongPolling)]
+        public async Task EndpointsThatRequireConnectionId400WhenNoConnectionIdProvided(HttpTransportType transportType)
         {
             using (StartLog(out var loggerFactory, LogLevel.Debug))
             {
@@ -492,48 +492,48 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
         }
 
         [Theory]
-        [InlineData(TransportType.LongPolling, 204)]
-        [InlineData(TransportType.WebSockets, 404)]
-        [InlineData(TransportType.ServerSentEvents, 404)]
-        public async Task EndPointThatOnlySupportsLongPollingRejectsOtherTransports(TransportType transportType, int status)
+        [InlineData(HttpTransportType.LongPolling, 204)]
+        [InlineData(HttpTransportType.WebSockets, 404)]
+        [InlineData(HttpTransportType.ServerSentEvents, 404)]
+        public async Task EndPointThatOnlySupportsLongPollingRejectsOtherTransports(HttpTransportType transportType, int status)
         {
             using (StartLog(out var loggerFactory, LogLevel.Debug))
             {
-                await CheckTransportSupported(TransportType.LongPolling, transportType, status, loggerFactory);
+                await CheckTransportSupported(HttpTransportType.LongPolling, transportType, status, loggerFactory);
             }
         }
 
         [Theory]
-        [InlineData(TransportType.ServerSentEvents, 200)]
-        [InlineData(TransportType.WebSockets, 404)]
-        [InlineData(TransportType.LongPolling, 404)]
-        public async Task EndPointThatOnlySupportsSSERejectsOtherTransports(TransportType transportType, int status)
+        [InlineData(HttpTransportType.ServerSentEvents, 200)]
+        [InlineData(HttpTransportType.WebSockets, 404)]
+        [InlineData(HttpTransportType.LongPolling, 404)]
+        public async Task EndPointThatOnlySupportsSSERejectsOtherTransports(HttpTransportType transportType, int status)
         {
             using (StartLog(out var loggerFactory, LogLevel.Debug))
             {
-                await CheckTransportSupported(TransportType.ServerSentEvents, transportType, status, loggerFactory);
+                await CheckTransportSupported(HttpTransportType.ServerSentEvents, transportType, status, loggerFactory);
             }
         }
 
         [Theory]
-        [InlineData(TransportType.WebSockets, 200)]
-        [InlineData(TransportType.ServerSentEvents, 404)]
-        [InlineData(TransportType.LongPolling, 404)]
-        public async Task EndPointThatOnlySupportsWebSockesRejectsOtherTransports(TransportType transportType, int status)
+        [InlineData(HttpTransportType.WebSockets, 200)]
+        [InlineData(HttpTransportType.ServerSentEvents, 404)]
+        [InlineData(HttpTransportType.LongPolling, 404)]
+        public async Task EndPointThatOnlySupportsWebSockesRejectsOtherTransports(HttpTransportType transportType, int status)
         {
             using (StartLog(out var loggerFactory, LogLevel.Debug))
             {
-                await CheckTransportSupported(TransportType.WebSockets, transportType, status, loggerFactory);
+                await CheckTransportSupported(HttpTransportType.WebSockets, transportType, status, loggerFactory);
             }
         }
 
         [Theory]
-        [InlineData(TransportType.LongPolling, 404)]
-        public async Task EndPointThatOnlySupportsWebSocketsAndSSERejectsLongPolling(TransportType transportType, int status)
+        [InlineData(HttpTransportType.LongPolling, 404)]
+        public async Task EndPointThatOnlySupportsWebSocketsAndSSERejectsLongPolling(HttpTransportType transportType, int status)
         {
             using (StartLog(out var loggerFactory, LogLevel.Debug))
             {
-                await CheckTransportSupported(TransportType.WebSockets | TransportType.ServerSentEvents, transportType, status, loggerFactory);
+                await CheckTransportSupported(HttpTransportType.WebSockets | HttpTransportType.ServerSentEvents, transportType, status, loggerFactory);
             }
         }
 
@@ -548,7 +548,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                 var dispatcher = new HttpConnectionDispatcher(manager, loggerFactory);
 
                 var context = MakeRequest("/foo", connection);
-                SetTransport(context, TransportType.ServerSentEvents);
+                SetTransport(context, HttpTransportType.ServerSentEvents);
 
                 var services = new ServiceCollection();
                 services.AddSingleton<ImmediatelyCompleteConnectionHandler>();
@@ -574,7 +574,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
 
                 var dispatcher = new HttpConnectionDispatcher(manager, loggerFactory);
                 var context = MakeRequest("/foo", connection);
-                SetTransport(context, TransportType.ServerSentEvents);
+                SetTransport(context, HttpTransportType.ServerSentEvents);
 
                 var services = new ServiceCollection();
                 services.AddSingleton<SynchronusExceptionConnectionHandler>();
@@ -652,7 +652,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                 var dispatcher = new HttpConnectionDispatcher(manager, loggerFactory);
 
                 var context = MakeRequest("/foo", connection);
-                SetTransport(context, TransportType.WebSockets);
+                SetTransport(context, HttpTransportType.WebSockets);
 
                 var services = new ServiceCollection();
                 services.AddSingleton<ImmediatelyCompleteConnectionHandler>();
@@ -669,9 +669,9 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
         }
 
         [Theory]
-        [InlineData(TransportType.WebSockets)]
-        [InlineData(TransportType.ServerSentEvents)]
-        public async Task RequestToActiveConnectionId409ForStreamingTransports(TransportType transportType)
+        [InlineData(HttpTransportType.WebSockets)]
+        [InlineData(HttpTransportType.ServerSentEvents)]
+        public async Task RequestToActiveConnectionId409ForStreamingTransports(HttpTransportType transportType)
         {
             using (StartLog(out var loggerFactory, LogLevel.Debug))
             {
@@ -748,9 +748,9 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
         }
 
         [Theory]
-        [InlineData(TransportType.ServerSentEvents)]
-        [InlineData(TransportType.LongPolling)]
-        public async Task RequestToDisposedConnectionIdReturns404(TransportType transportType)
+        [InlineData(HttpTransportType.ServerSentEvents)]
+        [InlineData(HttpTransportType.LongPolling)]
+        public async Task RequestToDisposedConnectionIdReturns404(HttpTransportType transportType)
         {
             using (StartLog(out var loggerFactory, LogLevel.Debug))
             {
@@ -821,7 +821,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                 var dispatcher = new HttpConnectionDispatcher(manager, loggerFactory);
 
                 var context = MakeRequest("/foo", connection);
-                SetTransport(context, TransportType.ServerSentEvents);
+                SetTransport(context, HttpTransportType.ServerSentEvents);
 
                 var services = new ServiceCollection();
                 services.AddSingleton<BlockingConnectionHandler>();
@@ -916,10 +916,10 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
         }
 
         [Theory]
-        [InlineData(TransportType.LongPolling, null)]
-        [InlineData(TransportType.ServerSentEvents, TransferFormat.Text)]
-        [InlineData(TransportType.WebSockets, TransferFormat.Binary | TransferFormat.Text)]
-        public async Task TransferModeSet(TransportType transportType, TransferFormat? expectedTransferFormats)
+        [InlineData(HttpTransportType.LongPolling, null)]
+        [InlineData(HttpTransportType.ServerSentEvents, TransferFormat.Text)]
+        [InlineData(HttpTransportType.WebSockets, TransferFormat.Binary | TransferFormat.Text)]
+        public async Task TransferModeSet(HttpTransportType transportType, TransferFormat? expectedTransferFormats)
         {
             using (StartLog(out var loggerFactory, LogLevel.Debug))
             {
@@ -1333,7 +1333,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                 context.Request.Path = "/foo";
                 context.Request.Method = "POST";
                 context.Response.Body = ms;
-                await dispatcher.ExecuteNegotiateAsync(context, new HttpConnectionOptions { Transports = TransportType.WebSockets });
+                await dispatcher.ExecuteNegotiateAsync(context, new HttpConnectionOptions { Transports = HttpTransportType.WebSockets });
 
                 var negotiateResponse = JsonConvert.DeserializeObject<JObject>(Encoding.UTF8.GetString(ms.ToArray()));
                 var availableTransports = (JArray)negotiateResponse["availableTransports"];
@@ -1386,7 +1386,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
             }
         }
 
-        private static async Task CheckTransportSupported(TransportType supportedTransports, TransportType transportType, int status, ILoggerFactory loggerFactory)
+        private static async Task CheckTransportSupported(HttpTransportType supportedTransports, HttpTransportType transportType, int status, ILoggerFactory loggerFactory)
         {
             var manager = CreateConnectionManager(loggerFactory);
             var connection = manager.CreateConnection();
@@ -1443,14 +1443,14 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
             return context;
         }
 
-        private static void SetTransport(HttpContext context, TransportType transportType)
+        private static void SetTransport(HttpContext context, HttpTransportType transportType)
         {
             switch (transportType)
             {
-                case TransportType.WebSockets:
+                case HttpTransportType.WebSockets:
                     context.Features.Set<IHttpWebSocketFeature>(new TestWebSocketConnectionFeature());
                     break;
-                case TransportType.ServerSentEvents:
+                case HttpTransportType.ServerSentEvents:
                     context.Request.Headers["Accept"] = "text/event-stream";
                     break;
                 default:

--- a/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/HubConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/HubConnectionTests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
 
         [Theory]
         [MemberData(nameof(HubProtocolsAndTransportsAndHubPaths))]
-        public async Task CheckFixedMessage(string protocolName, TransportType transportType, string path)
+        public async Task CheckFixedMessage(string protocolName, HttpTransportType transportType, string path)
         {
             var protocol = HubProtocols[protocolName];
             using (StartLog(out var loggerFactory, $"{nameof(CheckFixedMessage)}_{protocol.Name}_{transportType}_{path.TrimStart('/')}"))
@@ -78,7 +78,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
 
         [Theory]
         [MemberData(nameof(HubProtocolsAndTransportsAndHubPaths))]
-        public async Task CanSendAndReceiveMessage(string protocolName, TransportType transportType, string path)
+        public async Task CanSendAndReceiveMessage(string protocolName, HttpTransportType transportType, string path)
         {
             var protocol = HubProtocols[protocolName];
             using (StartLog(out var loggerFactory, $"{nameof(CanSendAndReceiveMessage)}_{protocol.Name}_{transportType}_{path.TrimStart('/')}"))
@@ -107,7 +107,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
 
         [Theory]
         [MemberData(nameof(HubProtocolsAndTransportsAndHubPaths))]
-        public async Task CanStopAndStartConnection(string protocolName, TransportType transportType, string path)
+        public async Task CanStopAndStartConnection(string protocolName, HttpTransportType transportType, string path)
         {
             var protocol = HubProtocols[protocolName];
             using (StartLog(out var loggerFactory, LogLevel.Trace, $"{nameof(CanStopAndStartConnection)}_{protocol.Name}_{transportType}_{path.TrimStart('/')}"))
@@ -138,7 +138,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
 
         [Theory]
         [MemberData(nameof(HubProtocolsAndTransportsAndHubPaths))]
-        public async Task CanStartConnectionFromClosedEvent(string protocolName, TransportType transportType, string path)
+        public async Task CanStartConnectionFromClosedEvent(string protocolName, HttpTransportType transportType, string path)
         {
             var protocol = HubProtocols[protocolName];
             using (StartLog(out var loggerFactory, LogLevel.Trace, $"{nameof(CanStartConnectionFromClosedEvent)}_{protocol.Name}_{transportType}_{path.TrimStart('/')}"))
@@ -189,14 +189,14 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
             }
         }
 
-        private Func<IConnection> GetHttpConnectionFactory(ILoggerFactory loggerFactory, string path, TransportType transportType)
+        private Func<IConnection> GetHttpConnectionFactory(ILoggerFactory loggerFactory, string path, HttpTransportType transportType)
         {
             return () => new HttpConnection(new Uri(_serverFixture.Url + path), transportType, loggerFactory);
         }
 
         [Theory]
         [MemberData(nameof(HubProtocolsAndTransportsAndHubPaths))]
-        public async Task MethodsAreCaseInsensitive(string protocolName, TransportType transportType, string path)
+        public async Task MethodsAreCaseInsensitive(string protocolName, HttpTransportType transportType, string path)
         {
             var protocol = HubProtocols[protocolName];
             using (StartLog(out var loggerFactory, $"{nameof(MethodsAreCaseInsensitive)}_{protocol.Name}_{transportType}_{path.TrimStart('/')}"))
@@ -226,7 +226,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
 
         [Theory]
         [MemberData(nameof(HubProtocolsAndTransportsAndHubPaths))]
-        public async Task CanInvokeClientMethodFromServer(string protocolName, TransportType transportType, string path)
+        public async Task CanInvokeClientMethodFromServer(string protocolName, HttpTransportType transportType, string path)
         {
             var protocol = HubProtocols[protocolName];
             using (StartLog(out var loggerFactory, LogLevel.Trace, $"{nameof(CanInvokeClientMethodFromServer)}_{protocol.Name}_{transportType}_{path.TrimStart('/')}"))
@@ -259,7 +259,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
 
         [Theory]
         [MemberData(nameof(HubProtocolsAndTransportsAndHubPaths))]
-        public async Task InvokeNonExistantClientMethodFromServer(string protocolName, TransportType transportType, string path)
+        public async Task InvokeNonExistantClientMethodFromServer(string protocolName, HttpTransportType transportType, string path)
         {
             var protocol = HubProtocols[protocolName];
             using (StartLog(out var loggerFactory, LogLevel.Trace, $"{nameof(InvokeNonExistantClientMethodFromServer)}_{protocol.Name}_{transportType}_{path.TrimStart('/')}"))
@@ -299,7 +299,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
 
         [Theory]
         [MemberData(nameof(HubProtocolsAndTransportsAndHubPaths))]
-        public async Task CanStreamClientMethodFromServer(string protocolName, TransportType transportType, string path)
+        public async Task CanStreamClientMethodFromServer(string protocolName, HttpTransportType transportType, string path)
         {
             var protocol = HubProtocols[protocolName];
             using (StartLog(out var loggerFactory, LogLevel.Trace, $"{nameof(CanStreamClientMethodFromServer)}_{protocol.Name}_{transportType}_{path.TrimStart('/')}"))
@@ -328,7 +328,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
 
         [Theory]
         [MemberData(nameof(HubProtocolsAndTransportsAndHubPaths))]
-        public async Task CanCloseStreamMethodEarly(string protocolName, TransportType transportType, string path)
+        public async Task CanCloseStreamMethodEarly(string protocolName, HttpTransportType transportType, string path)
         {
             var protocol = HubProtocols[protocolName];
             using (StartLog(out var loggerFactory, $"{nameof(CanCloseStreamMethodEarly)}_{protocol.Name}_{transportType}_{path.TrimStart('/')}"))
@@ -368,7 +368,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
 
         [Theory]
         [MemberData(nameof(HubProtocolsAndTransportsAndHubPaths))]
-        public async Task StreamDoesNotStartIfTokenAlreadyCanceled(string protocolName, TransportType transportType, string path)
+        public async Task StreamDoesNotStartIfTokenAlreadyCanceled(string protocolName, HttpTransportType transportType, string path)
         {
             var protocol = HubProtocols[protocolName];
             using (StartLog(out var loggerFactory, LogLevel.Trace, $"{nameof(StreamDoesNotStartIfTokenAlreadyCanceled)}_{protocol.Name}_{transportType}_{path.TrimStart('/')}"))
@@ -403,7 +403,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
 
         [Theory]
         [MemberData(nameof(HubProtocolsAndTransportsAndHubPaths))]
-        public async Task ExceptionFromStreamingSentToClient(string protocolName, TransportType transportType, string path)
+        public async Task ExceptionFromStreamingSentToClient(string protocolName, HttpTransportType transportType, string path)
         {
             var protocol = HubProtocols[protocolName];
             using (StartLog(out var loggerFactory, $"{nameof(ExceptionFromStreamingSentToClient)}_{protocol.Name}_{transportType}_{path.TrimStart('/')}"))
@@ -431,7 +431,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
 
         [Theory]
         [MemberData(nameof(HubProtocolsAndTransportsAndHubPaths))]
-        public async Task ServerThrowsHubExceptionIfHubMethodCannotBeResolved(string hubProtocolName, TransportType transportType, string hubPath)
+        public async Task ServerThrowsHubExceptionIfHubMethodCannotBeResolved(string hubProtocolName, HttpTransportType transportType, string hubPath)
         {
             var hubProtocol = HubProtocols[hubProtocolName];
             using (StartLog(out var loggerFactory, $"{nameof(ServerThrowsHubExceptionIfHubMethodCannotBeResolved)}_{hubProtocol.Name}_{transportType}_{hubPath.TrimStart('/')}"))
@@ -458,7 +458,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
 
         [Theory]
         [MemberData(nameof(HubProtocolsAndTransportsAndHubPaths))]
-        public async Task ServerThrowsHubExceptionOnHubMethodArgumentCountMismatch(string hubProtocolName, TransportType transportType, string hubPath)
+        public async Task ServerThrowsHubExceptionOnHubMethodArgumentCountMismatch(string hubProtocolName, HttpTransportType transportType, string hubPath)
         {
             var hubProtocol = HubProtocols[hubProtocolName];
             using (StartLog(out var loggerFactory, $"{nameof(ServerThrowsHubExceptionOnHubMethodArgumentCountMismatch)}_{hubProtocol.Name}_{transportType}_{hubPath.TrimStart('/')}"))
@@ -485,7 +485,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
 
         [Theory]
         [MemberData(nameof(HubProtocolsAndTransportsAndHubPaths))]
-        public async Task ServerThrowsHubExceptionOnHubMethodArgumentTypeMismatch(string hubProtocolName, TransportType transportType, string hubPath)
+        public async Task ServerThrowsHubExceptionOnHubMethodArgumentTypeMismatch(string hubProtocolName, HttpTransportType transportType, string hubPath)
         {
             var hubProtocol = HubProtocols[hubProtocolName];
             using (StartLog(out var loggerFactory, $"{nameof(ServerThrowsHubExceptionOnHubMethodArgumentTypeMismatch)}_{hubProtocol.Name}_{transportType}_{hubPath.TrimStart('/')}"))
@@ -512,7 +512,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
 
         [Theory]
         [MemberData(nameof(HubProtocolsAndTransportsAndHubPaths))]
-        public async Task ServerThrowsHubExceptionIfStreamingHubMethodCannotBeResolved(string hubProtocolName, TransportType transportType, string hubPath)
+        public async Task ServerThrowsHubExceptionIfStreamingHubMethodCannotBeResolved(string hubProtocolName, HttpTransportType transportType, string hubPath)
         {
             var hubProtocol = HubProtocols[hubProtocolName];
             using (StartLog(out var loggerFactory, $"{nameof(ServerThrowsHubExceptionIfStreamingHubMethodCannotBeResolved)}_{hubProtocol.Name}_{transportType}_{hubPath.TrimStart('/')}"))
@@ -540,7 +540,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
 
         [Theory]
         [MemberData(nameof(HubProtocolsAndTransportsAndHubPaths))]
-        public async Task ServerThrowsHubExceptionOnStreamingHubMethodArgumentCountMismatch(string hubProtocolName, TransportType transportType, string hubPath)
+        public async Task ServerThrowsHubExceptionOnStreamingHubMethodArgumentCountMismatch(string hubProtocolName, HttpTransportType transportType, string hubPath)
         {
             var hubProtocol = HubProtocols[hubProtocolName];
             using (StartLog(out var loggerFactory, $"{nameof(ServerThrowsHubExceptionOnStreamingHubMethodArgumentCountMismatch)}_{hubProtocol.Name}_{transportType}_{hubPath.TrimStart('/')}"))
@@ -569,7 +569,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
 
         [Theory]
         [MemberData(nameof(HubProtocolsAndTransportsAndHubPaths))]
-        public async Task ServerThrowsHubExceptionOnStreamingHubMethodArgumentTypeMismatch(string hubProtocolName, TransportType transportType, string hubPath)
+        public async Task ServerThrowsHubExceptionOnStreamingHubMethodArgumentTypeMismatch(string hubProtocolName, HttpTransportType transportType, string hubPath)
         {
             var hubProtocol = HubProtocols[hubProtocolName];
             using (StartLog(out var loggerFactory, $"{nameof(ServerThrowsHubExceptionOnStreamingHubMethodArgumentTypeMismatch)}_{hubProtocol.Name}_{transportType}_{hubPath.TrimStart('/')}"))
@@ -597,7 +597,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
 
         [Theory]
         [MemberData(nameof(HubProtocolsAndTransportsAndHubPaths))]
-        public async Task ServerThrowsHubExceptionIfNonStreamMethodInvokedWithStreamAsync(string hubProtocolName, TransportType transportType, string hubPath)
+        public async Task ServerThrowsHubExceptionIfNonStreamMethodInvokedWithStreamAsync(string hubProtocolName, HttpTransportType transportType, string hubPath)
         {
             var hubProtocol = HubProtocols[hubProtocolName];
             using (StartLog(out var loggerFactory, $"{nameof(ServerThrowsHubExceptionIfNonStreamMethodInvokedWithStreamAsync)}_{hubProtocol.Name}_{transportType}_{hubPath.TrimStart('/')}"))
@@ -624,7 +624,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
 
         [Theory]
         [MemberData(nameof(HubProtocolsAndTransportsAndHubPaths))]
-        public async Task ServerThrowsHubExceptionIfStreamMethodInvokedWithInvoke(string hubProtocolName, TransportType transportType, string hubPath)
+        public async Task ServerThrowsHubExceptionIfStreamMethodInvokedWithInvoke(string hubProtocolName, HttpTransportType transportType, string hubPath)
         {
             var hubProtocol = HubProtocols[hubProtocolName];
             using (StartLog(out var loggerFactory, $"{nameof(ServerThrowsHubExceptionIfStreamMethodInvokedWithInvoke)}_{hubProtocol.Name}_{transportType}_{hubPath.TrimStart('/')}"))
@@ -651,7 +651,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
 
         [Theory]
         [MemberData(nameof(HubProtocolsAndTransportsAndHubPaths))]
-        public async Task ServerThrowsHubExceptionIfBuildingAsyncEnumeratorIsNotPossible(string hubProtocolName, TransportType transportType, string hubPath)
+        public async Task ServerThrowsHubExceptionIfBuildingAsyncEnumeratorIsNotPossible(string hubProtocolName, HttpTransportType transportType, string hubPath)
         {
             var hubProtocol = HubProtocols[hubProtocolName];
             using (StartLog(out var loggerFactory, $"{nameof(ServerThrowsHubExceptionIfBuildingAsyncEnumeratorIsNotPossible)}_{hubProtocol.Name}_{transportType}_{hubPath.TrimStart('/')}"))
@@ -678,7 +678,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
 
         [Theory]
         [MemberData(nameof(TransportTypes))]
-        public async Task ClientCanUseJwtBearerTokenForAuthentication(TransportType transportType)
+        public async Task ClientCanUseJwtBearerTokenForAuthentication(HttpTransportType transportType)
         {
             using (StartLog(out var loggerFactory, $"{nameof(ClientCanUseJwtBearerTokenForAuthentication)}_{transportType}"))
             {
@@ -712,7 +712,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
 
         [Theory]
         [MemberData(nameof(TransportTypes))]
-        public async Task ClientCanSendHeaders(TransportType transportType)
+        public async Task ClientCanSendHeaders(HttpTransportType transportType)
         {
             using (StartLog(out var loggerFactory, $"{nameof(ClientCanSendHeaders)}_{transportType}"))
             {
@@ -753,7 +753,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
 
                 var hubConnection = new HubConnectionBuilder()
                     .WithUrl(_serverFixture.Url + "/default")
-                    .WithTransport(TransportType.WebSockets)
+                    .WithTransport(HttpTransportType.WebSockets)
                     .WithLoggerFactory(loggerFactory)
                     .WithWebSocketOptions(options => options.Cookies = cookieJar)
                     .Build();
@@ -777,7 +777,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
 
         [Theory]
         [MemberData(nameof(TransportTypes))]
-        public async Task CheckHttpConnectionFeatures(TransportType transportType)
+        public async Task CheckHttpConnectionFeatures(HttpTransportType transportType)
         {
             using (StartLog(out var loggerFactory, $"{nameof(CheckHttpConnectionFeatures)}_{transportType}"))
             {
@@ -827,8 +827,8 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
                 {
                     await hubConnection.StartAsync().OrTimeout();
 
-                    var transport = await hubConnection.InvokeAsync<TransportType>(nameof(TestHub.GetActiveTransportName)).OrTimeout();
-                    Assert.Equal(TransportType.LongPolling, transport);
+                    var transport = await hubConnection.InvokeAsync<HttpTransportType>(nameof(TestHub.GetActiveTransportName)).OrTimeout();
+                    Assert.Equal(HttpTransportType.LongPolling, transport);
                 }
                 catch (Exception ex)
                 {
@@ -848,11 +848,11 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
             {
                 foreach (var protocol in HubProtocols)
                 {
-                    foreach (var transport in TransportTypes().SelectMany(t => t).Cast<TransportType>())
+                    foreach (var transport in TransportTypes().SelectMany(t => t).Cast<HttpTransportType>())
                     {
                         foreach (var hubPath in HubPaths)
                         {
-                            if (!(protocol.Value is MessagePackHubProtocol) || transport != TransportType.ServerSentEvents)
+                            if (!(protocol.Value is MessagePackHubProtocol) || transport != HttpTransportType.ServerSentEvents)
                             {
                                 yield return new object[] { protocol.Key, transport, hubPath };
                             }
@@ -876,10 +876,10 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
         {
             if (TestHelpers.IsWebSocketsSupported())
             {
-                yield return new object[] { TransportType.WebSockets };
+                yield return new object[] { HttpTransportType.WebSockets };
             }
-            yield return new object[] { TransportType.ServerSentEvents };
-            yield return new object[] { TransportType.LongPolling };
+            yield return new object[] { HttpTransportType.ServerSentEvents };
+            yield return new object[] { HttpTransportType.LongPolling };
         }
     }
 }

--- a/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/Startup.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/Startup.cs
@@ -58,7 +58,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
                 routes.MapHub<DynamicTestHub>("/dynamic");
                 routes.MapHub<TestHubT>("/hubT");
                 routes.MapHub<HubWithAuthorization>("/authorizedhub");
-                routes.MapHub<TestHub>("/default-nowebsockets", options => options.Transports = TransportType.LongPolling | TransportType.ServerSentEvents);
+                routes.MapHub<TestHub>("/default-nowebsockets", options => options.Transports = HttpTransportType.LongPolling | HttpTransportType.ServerSentEvents);
             });
 
             app.Run(async (context) =>

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.Helpers.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.Helpers.cs
@@ -9,7 +9,7 @@ using Microsoft.AspNetCore.Http.Connections.Client;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
-using HttpTransportType = Microsoft.AspNetCore.Http.Connections.TransportType;
+using HttpTransportType = Microsoft.AspNetCore.Http.Connections.HttpTransportType;
 
 namespace Microsoft.AspNetCore.SignalR.Client.Tests
 {

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.Helpers.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.Helpers.cs
@@ -9,8 +9,6 @@ using Microsoft.AspNetCore.Http.Connections.Client;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
-using HttpTransportType = Microsoft.AspNetCore.Http.Connections.HttpTransportType;
-
 namespace Microsoft.AspNetCore.SignalR.Client.Tests
 {
     public partial class HttpConnectionTests

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.Negotiate.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.Negotiate.cs
@@ -11,7 +11,7 @@ using Moq;
 using Newtonsoft.Json;
 using Xunit;
 
-using TransportType = Microsoft.AspNetCore.Http.Connections.TransportType;
+using HttpTransportType = Microsoft.AspNetCore.Http.Connections.HttpTransportType;
 
 namespace Microsoft.AspNetCore.SignalR.Client.Tests
 {
@@ -40,9 +40,9 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
             }
 
             [Theory]
-            [InlineData((TransportType)0)]
-            [InlineData(TransportType.ServerSentEvents)]
-            public Task ConnectionCannotBeStartedIfNoCommonTransportsBetweenClientAndServer(TransportType serverTransports)
+            [InlineData((HttpTransportType)0)]
+            [InlineData(HttpTransportType.ServerSentEvents)]
+            public Task ConnectionCannotBeStartedIfNoCommonTransportsBetweenClientAndServer(HttpTransportType serverTransports)
             {
                 return RunInvalidNegotiateResponseTest<InvalidOperationException>(ResponseUtils.CreateNegotiationContent(transportTypes: serverTransports), "Unable to connect to the server with any of the available transports.");
             }
@@ -112,7 +112,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
 
                 var transportFactory = new Mock<ITransportFactory>(MockBehavior.Strict);
 
-                transportFactory.Setup(t => t.CreateTransport(TransportType.LongPolling))
+                transportFactory.Setup(t => t.CreateTransport(HttpTransportType.LongPolling))
                     .Returns(new TestTransport(transferFormat: TransferFormat.Text | TransferFormat.Binary));
 
                 await WithConnectionAsync(
@@ -158,7 +158,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
 
                 var transportFactory = new Mock<ITransportFactory>(MockBehavior.Strict);
 
-                transportFactory.Setup(t => t.CreateTransport(TransportType.LongPolling))
+                transportFactory.Setup(t => t.CreateTransport(HttpTransportType.LongPolling))
                     .Returns(new TestTransport(transferFormat: TransferFormat.Text | TransferFormat.Binary));
 
                 await WithConnectionAsync(

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.Negotiate.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.Negotiate.cs
@@ -6,12 +6,11 @@ using System.IO;
 using System.Net;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Http.Connections;
 using Microsoft.AspNetCore.Http.Connections.Client;
 using Moq;
 using Newtonsoft.Json;
 using Xunit;
-
-using HttpTransportType = Microsoft.AspNetCore.Http.Connections.HttpTransportType;
 
 namespace Microsoft.AspNetCore.SignalR.Client.Tests
 {

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.Transport.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.Transport.cs
@@ -13,7 +13,7 @@ using Microsoft.AspNetCore.Http.Connections;
 using Microsoft.AspNetCore.Http.Connections.Client;
 using Xunit;
 
-using HttpTransportType = Microsoft.AspNetCore.Http.Connections.TransportType;
+using HttpTransportType = Microsoft.AspNetCore.Http.Connections.HttpTransportType;
 
 namespace Microsoft.AspNetCore.SignalR.Client.Tests
 {

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.Transport.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.Transport.cs
@@ -13,8 +13,6 @@ using Microsoft.AspNetCore.Http.Connections;
 using Microsoft.AspNetCore.Http.Connections.Client;
 using Xunit;
 
-using HttpTransportType = Microsoft.AspNetCore.Http.Connections.HttpTransportType;
-
 namespace Microsoft.AspNetCore.SignalR.Client.Tests
 {
     public partial class HttpConnectionTests

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.cs
@@ -7,6 +7,7 @@ using System.Net.Http;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Http.Connections;
 using Microsoft.AspNetCore.Http.Connections.Client;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -14,9 +15,6 @@ using Microsoft.Extensions.Logging.Testing;
 using Moq;
 using Xunit;
 using Xunit.Abstractions;
-
-// This is needed because there's a System.Net.TransportType in net461 (it's internal in netcoreapp).
-using HttpTransportType = Microsoft.AspNetCore.Http.Connections.HttpTransportType;
 
 namespace Microsoft.AspNetCore.SignalR.Client.Tests
 {

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.cs
@@ -16,7 +16,7 @@ using Xunit;
 using Xunit.Abstractions;
 
 // This is needed because there's a System.Net.TransportType in net461 (it's internal in netcoreapp).
-using TransportType = Microsoft.AspNetCore.Http.Connections.TransportType;
+using HttpTransportType = Microsoft.AspNetCore.Http.Connections.HttpTransportType;
 
 namespace Microsoft.AspNetCore.SignalR.Client.Tests
 {
@@ -41,9 +41,9 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
         }
 
         [Theory]
-        [InlineData((TransportType)0)]
-        [InlineData(TransportType.All + 1)]
-        public void CannotStartConnectionWithInvalidTransportType(TransportType requestedTransportType)
+        [InlineData((HttpTransportType)0)]
+        [InlineData(HttpTransportType.All + 1)]
+        public void CannotStartConnectionWithInvalidTransportType(HttpTransportType requestedTransportType)
         {
             Assert.Throws<ArgumentOutOfRangeException>(
                 () => new HttpConnection(new Uri("http://fakeuri.org/"), requestedTransportType));

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionBuilderExtensionsTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionBuilderExtensionsTests.cs
@@ -11,7 +11,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Console;
 using Moq;
 using Xunit;
-using TransportType = Microsoft.AspNetCore.Http.Connections.TransportType;
+using HttpTransportType = Microsoft.AspNetCore.Http.Connections.HttpTransportType;
 
 namespace Microsoft.AspNetCore.SignalR.Client.Tests
 {
@@ -117,11 +117,11 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
         }
 
         [Theory]
-        [InlineData(TransportType.All)]
-        [InlineData(TransportType.WebSockets)]
-        [InlineData(TransportType.ServerSentEvents)]
-        [InlineData(TransportType.LongPolling)]
-        public void WithTransportRegistersGivenTransportType(TransportType transportType)
+        [InlineData(HttpTransportType.All)]
+        [InlineData(HttpTransportType.WebSockets)]
+        [InlineData(HttpTransportType.ServerSentEvents)]
+        [InlineData(HttpTransportType.LongPolling)]
+        public void WithTransportRegistersGivenTransportType(HttpTransportType transportType)
         {
             var connectionBuilder = new HubConnectionBuilder();
             connectionBuilder.WithTransport(transportType);

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionBuilderExtensionsTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionBuilderExtensionsTests.cs
@@ -6,12 +6,12 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Security.Cryptography.X509Certificates;
+using Microsoft.AspNetCore.Http.Connections;
 using Microsoft.AspNetCore.SignalR.Internal.Protocol;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Console;
 using Moq;
 using Xunit;
-using HttpTransportType = Microsoft.AspNetCore.Http.Connections.HttpTransportType;
 
 namespace Microsoft.AspNetCore.SignalR.Client.Tests
 {

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/ResponseUtils.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/ResponseUtils.cs
@@ -8,7 +8,7 @@ using System.Net.Http;
 using Microsoft.AspNetCore.Connections;
 using Newtonsoft.Json;
 
-using TransportType = Microsoft.AspNetCore.Http.Connections.TransportType;
+using HttpTransportType = Microsoft.AspNetCore.Http.Connections.HttpTransportType;
 
 namespace Microsoft.AspNetCore.SignalR.Client.Tests
 {
@@ -38,31 +38,31 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
         }
 
         public static string CreateNegotiationContent(string connectionId = "00000000-0000-0000-0000-000000000000",
-            TransportType transportTypes = TransportType.All)
+            HttpTransportType transportTypes = HttpTransportType.All)
         {
             var availableTransports = new List<object>();
 
-            if ((transportTypes & TransportType.WebSockets) != 0)
+            if ((transportTypes & HttpTransportType.WebSockets) != 0)
             {
                 availableTransports.Add(new
                 {
-                    transport = nameof(TransportType.WebSockets),
+                    transport = nameof(HttpTransportType.WebSockets),
                     transferFormats = new[] { nameof(TransferFormat.Text), nameof(TransferFormat.Binary) }
                 });
             }
-            if ((transportTypes & TransportType.ServerSentEvents) != 0)
+            if ((transportTypes & HttpTransportType.ServerSentEvents) != 0)
             {
                 availableTransports.Add(new
                 {
-                    transport = nameof(TransportType.ServerSentEvents),
+                    transport = nameof(HttpTransportType.ServerSentEvents),
                     transferFormats = new[] { nameof(TransferFormat.Text) }
                 });
             }
-            if ((transportTypes & TransportType.LongPolling) != 0)
+            if ((transportTypes & HttpTransportType.LongPolling) != 0)
             {
                 availableTransports.Add(new
                 {
-                    transport = nameof(TransportType.LongPolling),
+                    transport = nameof(HttpTransportType.LongPolling),
                     transferFormats = new[] { nameof(TransferFormat.Text), nameof(TransferFormat.Binary) }
                 });
             }

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/ResponseUtils.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/ResponseUtils.cs
@@ -6,9 +6,8 @@ using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Http.Connections;
 using Newtonsoft.Json;
-
-using HttpTransportType = Microsoft.AspNetCore.Http.Connections.HttpTransportType;
 
 namespace Microsoft.AspNetCore.SignalR.Client.Tests
 {

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/TestTransportFactory.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/TestTransportFactory.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
             _transport = transport;
         }
 
-        public ITransport CreateTransport(TransportType availableServerTransports)
+        public ITransport CreateTransport(HttpTransportType availableServerTransports)
         {
             return _transport;
         }

--- a/test/Microsoft.AspNetCore.SignalR.Redis.Tests/RedisEndToEnd.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Redis.Tests/RedisEndToEnd.cs
@@ -40,7 +40,7 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
         [ConditionalTheory()]
         [SkipIfDockerNotPresent]
         [MemberData(nameof(TransportTypesAndProtocolTypes))]
-        public async Task HubConnectionCanSendAndReceiveMessages(TransportType transportType, string protocolName)
+        public async Task HubConnectionCanSendAndReceiveMessages(HttpTransportType transportType, string protocolName)
         {
             using (StartLog(out var loggerFactory, testName:
                 $"{nameof(HubConnectionCanSendAndReceiveMessages)}_{transportType.ToString()}_{protocolName}"))
@@ -61,7 +61,7 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
         [ConditionalTheory()]
         [SkipIfDockerNotPresent]
         [MemberData(nameof(TransportTypesAndProtocolTypes))]
-        public async Task HubConnectionCanSendAndReceiveGroupMessages(TransportType transportType, string protocolName)
+        public async Task HubConnectionCanSendAndReceiveGroupMessages(HttpTransportType transportType, string protocolName)
         {
             using (StartLog(out var loggerFactory, testName:
                 $"{nameof(HubConnectionCanSendAndReceiveGroupMessages)}_{transportType.ToString()}_{protocolName}"))
@@ -89,7 +89,7 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
             }
         }
 
-        private static HubConnection CreateConnection(string url, TransportType transportType, IHubProtocol protocol, ILoggerFactory loggerFactory)
+        private static HubConnection CreateConnection(string url, HttpTransportType transportType, IHubProtocol protocol, ILoggerFactory loggerFactory)
         {
             return new HubConnectionBuilder()
                 .WithUrl(url)
@@ -99,14 +99,14 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
                 .Build();
         }
 
-        private static IEnumerable<TransportType> TransportTypes()
+        private static IEnumerable<HttpTransportType> TransportTypes()
         {
             if (TestHelpers.IsWebSocketsSupported())
             {
-                yield return TransportType.WebSockets;
+                yield return HttpTransportType.WebSockets;
             }
-            yield return TransportType.ServerSentEvents;
-            yield return TransportType.LongPolling;
+            yield return HttpTransportType.ServerSentEvents;
+            yield return HttpTransportType.LongPolling;
         }
 
         public static IEnumerable<object[]> TransportTypesAndProtocolTypes
@@ -117,7 +117,7 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
                 {
                     yield return new object[] { transport, JsonHubProtocol.ProtocolName };
 
-                    if (transport != TransportType.ServerSentEvents)
+                    if (transport != HttpTransportType.ServerSentEvents)
                     {
                         yield return new object[] { transport, MessagePackHubProtocol.ProtocolName };
                     }

--- a/test/Microsoft.AspNetCore.SignalR.Tests/DefaultTransportFactoryTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/DefaultTransportFactoryTests.cs
@@ -15,21 +15,21 @@ namespace Microsoft.AspNetCore.SignalR.Tests
     public class DefaultTransportFactoryTests
     {
         [Theory]
-        [InlineData((TransportType)0)]
-        [InlineData(TransportType.All + 1)]
-        public void DefaultTransportFactoryCannotBeCreatedWithInvalidTransportType(TransportType transportType)
+        [InlineData((HttpTransportType)0)]
+        [InlineData(HttpTransportType.All + 1)]
+        public void DefaultTransportFactoryCannotBeCreatedWithInvalidTransportType(HttpTransportType transportType)
         {
             Assert.Throws<ArgumentOutOfRangeException>(
                 () => new DefaultTransportFactory(transportType, new LoggerFactory(), new HttpClient(), httpOptions: null));
         }
 
         [Theory]
-        [InlineData(TransportType.All)]
-        [InlineData(TransportType.LongPolling)]
-        [InlineData(TransportType.ServerSentEvents)]
-        [InlineData(TransportType.LongPolling | TransportType.WebSockets)]
-        [InlineData(TransportType.ServerSentEvents | TransportType.WebSockets)]
-        public void DefaultTransportFactoryCannotBeCreatedWithoutHttpClient(TransportType transportType)
+        [InlineData(HttpTransportType.All)]
+        [InlineData(HttpTransportType.LongPolling)]
+        [InlineData(HttpTransportType.ServerSentEvents)]
+        [InlineData(HttpTransportType.LongPolling | HttpTransportType.WebSockets)]
+        [InlineData(HttpTransportType.ServerSentEvents | HttpTransportType.WebSockets)]
+        public void DefaultTransportFactoryCannotBeCreatedWithoutHttpClient(HttpTransportType transportType)
         {
             var exception = Assert.Throws<ArgumentNullException>(
                 () => new DefaultTransportFactory(transportType, new LoggerFactory(), httpClient: null, httpOptions: null));
@@ -40,27 +40,27 @@ namespace Microsoft.AspNetCore.SignalR.Tests
         [Fact]
         public void DefaultTransportFactoryCanBeCreatedWithoutHttpClientIfWebSocketsTransportRequestedExplicitly()
         {
-            new DefaultTransportFactory(TransportType.WebSockets, new LoggerFactory(), httpClient: null, httpOptions: null);
+            new DefaultTransportFactory(HttpTransportType.WebSockets, new LoggerFactory(), httpClient: null, httpOptions: null);
         }
 
         [ConditionalTheory]
-        [InlineData(TransportType.WebSockets, typeof(WebSocketsTransport))]
-        [InlineData(TransportType.ServerSentEvents, typeof(ServerSentEventsTransport))]
-        [InlineData(TransportType.LongPolling, typeof(LongPollingTransport))]
+        [InlineData(HttpTransportType.WebSockets, typeof(WebSocketsTransport))]
+        [InlineData(HttpTransportType.ServerSentEvents, typeof(ServerSentEventsTransport))]
+        [InlineData(HttpTransportType.LongPolling, typeof(LongPollingTransport))]
         [WebSocketsSupportedCondition]
-        public void DefaultTransportFactoryCreatesRequestedTransportIfAvailable(TransportType requestedTransport, Type expectedTransportType)
+        public void DefaultTransportFactoryCreatesRequestedTransportIfAvailable(HttpTransportType requestedTransport, Type expectedTransportType)
         {
             var transportFactory = new DefaultTransportFactory(requestedTransport, loggerFactory: null, httpClient: new HttpClient(), httpOptions: null);
             Assert.IsType(expectedTransportType,
-                transportFactory.CreateTransport(TransportType.All));
+                transportFactory.CreateTransport(HttpTransportType.All));
         }
 
         [Theory]
-        [InlineData(TransportType.WebSockets)]
-        [InlineData(TransportType.ServerSentEvents)]
-        [InlineData(TransportType.LongPolling)]
-        [InlineData(TransportType.All)]
-        public void DefaultTransportFactoryThrowsIfItCannotCreateRequestedTransport(TransportType requestedTransport)
+        [InlineData(HttpTransportType.WebSockets)]
+        [InlineData(HttpTransportType.ServerSentEvents)]
+        [InlineData(HttpTransportType.LongPolling)]
+        [InlineData(HttpTransportType.All)]
+        public void DefaultTransportFactoryThrowsIfItCannotCreateRequestedTransport(HttpTransportType requestedTransport)
         {
             var transportFactory =
                 new DefaultTransportFactory(requestedTransport, loggerFactory: null, httpClient: new HttpClient(), httpOptions: null);
@@ -75,34 +75,34 @@ namespace Microsoft.AspNetCore.SignalR.Tests
         public void DefaultTransportFactoryCreatesWebSocketsTransportIfAvailable()
         {
             Assert.IsType<WebSocketsTransport>(
-                new DefaultTransportFactory(TransportType.All, loggerFactory: null, httpClient: new HttpClient(), httpOptions: null)
-                    .CreateTransport(TransportType.All));
+                new DefaultTransportFactory(HttpTransportType.All, loggerFactory: null, httpClient: new HttpClient(), httpOptions: null)
+                    .CreateTransport(HttpTransportType.All));
         }
 
         [Theory]
-        [InlineData(TransportType.All, typeof(ServerSentEventsTransport))]
-        [InlineData(TransportType.ServerSentEvents, typeof(ServerSentEventsTransport))]
-        [InlineData(TransportType.LongPolling, typeof(LongPollingTransport))]
-        public void DefaultTransportFactoryCreatesRequestedTransportIfAvailable_Win7(TransportType requestedTransport, Type expectedTransportType)
+        [InlineData(HttpTransportType.All, typeof(ServerSentEventsTransport))]
+        [InlineData(HttpTransportType.ServerSentEvents, typeof(ServerSentEventsTransport))]
+        [InlineData(HttpTransportType.LongPolling, typeof(LongPollingTransport))]
+        public void DefaultTransportFactoryCreatesRequestedTransportIfAvailable_Win7(HttpTransportType requestedTransport, Type expectedTransportType)
         {
             if (!TestHelpers.IsWebSocketsSupported())
             {
                 var transportFactory = new DefaultTransportFactory(requestedTransport, loggerFactory: null, httpClient: new HttpClient(), httpOptions: null);
                 Assert.IsType(expectedTransportType,
-                    transportFactory.CreateTransport(TransportType.All));
+                    transportFactory.CreateTransport(HttpTransportType.All));
             }
         }
 
         [Theory]
-        [InlineData(TransportType.WebSockets)]
-        public void DefaultTransportFactoryThrowsIfItCannotCreateRequestedTransport_Win7(TransportType requestedTransport)
+        [InlineData(HttpTransportType.WebSockets)]
+        public void DefaultTransportFactoryThrowsIfItCannotCreateRequestedTransport_Win7(HttpTransportType requestedTransport)
         {
             if (!TestHelpers.IsWebSocketsSupported())
             {
                 var transportFactory =
                     new DefaultTransportFactory(requestedTransport, loggerFactory: null, httpClient: new HttpClient(), httpOptions: null);
                 var ex = Assert.Throws<InvalidOperationException>(
-                    () => transportFactory.CreateTransport(TransportType.All));
+                    () => transportFactory.CreateTransport(HttpTransportType.All));
 
                 Assert.Equal("No requested transports available on the server.", ex.Message);
             }

--- a/test/Microsoft.AspNetCore.SignalR.Tests/EndToEndTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/EndToEndTests.cs
@@ -72,7 +72,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
 
         [Theory]
         [MemberData(nameof(TransportTypes))]
-        public async Task CanStartAndStopConnectionUsingGivenTransport(TransportType transportType)
+        public async Task CanStartAndStopConnectionUsingGivenTransport(HttpTransportType transportType)
         {
             var url = _serverFixture.Url + "/echo";
             var connection = new HttpConnection(new Uri(url), transportType);
@@ -170,7 +170,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                     .Returns<HttpRequestMessage, CancellationToken>(
                         (request, cancellationToken) => Task.FromException<HttpResponseMessage>(new InvalidOperationException("HTTP requests should not be sent.")));
 
-                var connection = new HttpConnection(new Uri(url), TransportType.WebSockets, loggerFactory, new HttpOptions { HttpMessageHandler = (httpMessageHandler) => mockHttpHandler.Object });
+                var connection = new HttpConnection(new Uri(url), HttpTransportType.WebSockets, loggerFactory, new HttpOptions { HttpMessageHandler = (httpMessageHandler) => mockHttpHandler.Object });
 
                 try
                 {
@@ -198,7 +198,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
 
         [Theory]
         [MemberData(nameof(TransportTypesAndTransferFormats))]
-        public async Task ConnectionCanSendAndReceiveMessages(TransportType transportType, TransferFormat requestedTransferFormat)
+        public async Task ConnectionCanSendAndReceiveMessages(HttpTransportType transportType, TransferFormat requestedTransferFormat)
         {
             using (StartLog(out var loggerFactory, minLogLevel: LogLevel.Trace, testName: $"ConnectionCanSendAndReceiveMessages_{transportType.ToString()}_{requestedTransferFormat.ToString()}"))
             {
@@ -269,7 +269,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                 var logger = loggerFactory.CreateLogger<EndToEndTests>();
 
                 var url = _serverFixture.Url + "/echo";
-                var connection = new HttpConnection(new Uri(url), TransportType.WebSockets, loggerFactory);
+                var connection = new HttpConnection(new Uri(url), HttpTransportType.WebSockets, loggerFactory);
 
                 try
                 {
@@ -308,7 +308,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
         {
             try
             {
-                await ServerClosesConnectionWithErrorIfHubCannotBeCreated(TransportType.WebSockets);
+                await ServerClosesConnectionWithErrorIfHubCannotBeCreated(HttpTransportType.WebSockets);
                 Assert.True(false, "Expected error was not thrown.");
             }
             catch
@@ -322,7 +322,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
         {
             try
             {
-                await ServerClosesConnectionWithErrorIfHubCannotBeCreated(TransportType.LongPolling);
+                await ServerClosesConnectionWithErrorIfHubCannotBeCreated(HttpTransportType.LongPolling);
                 Assert.True(false, "Expected error was not thrown.");
             }
             catch
@@ -331,7 +331,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             }
         }
 
-        private async Task ServerClosesConnectionWithErrorIfHubCannotBeCreated(TransportType transportType)
+        private async Task ServerClosesConnectionWithErrorIfHubCannotBeCreated(HttpTransportType transportType)
         {
             using (StartLog(out var loggerFactory, testName: $"ConnectionCanSendAndReceiveMessages_{transportType.ToString()}"))
             {
@@ -393,7 +393,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
         {
             private ITransport _transport;
 
-            public ITransport CreateTransport(TransportType availableServerTransports)
+            public ITransport CreateTransport(HttpTransportType availableServerTransports)
             {
                 if (_transport == null)
                 {
@@ -458,10 +458,10 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             {
                 if (TestHelpers.IsWebSocketsSupported())
                 {
-                    yield return new object[] { TransportType.WebSockets };
+                    yield return new object[] { HttpTransportType.WebSockets };
                 }
-                yield return new object[] { TransportType.ServerSentEvents };
-                yield return new object[] { TransportType.LongPolling };
+                yield return new object[] { HttpTransportType.ServerSentEvents };
+                yield return new object[] { HttpTransportType.LongPolling };
             }
         }
 
@@ -473,7 +473,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                 {
                     yield return new[] { transport[0], TransferFormat.Text };
 
-                    if ((TransportType)transport[0] != TransportType.ServerSentEvents)
+                    if ((HttpTransportType)transport[0] != HttpTransportType.ServerSentEvents)
                     {
                         yield return new[] { transport[0], TransferFormat.Binary };
                     }


### PR DESCRIPTION
Avoiding naming conflicts by renaming our TransportType enums to HttpTransportTypes.
Issue: https://github.com/aspnet/SignalR/issues/1807