### PR TITLE
fix #1727 by adding polyfills for IE

### DIFF
--- a/clients/ts/signalr/src/Utils.ts
+++ b/clients/ts/signalr/src/Utils.ts
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-jasmine.DEFAULT_TIMEOUT_INTERVAL = 20000;
-
 export class Arg {
     public static isRequired(val: any, name: string): void {
         if (val === null || val === undefined) {

--- a/clients/ts/signalr/src/browser-index.ts
+++ b/clients/ts/signalr/src/browser-index.ts
@@ -5,4 +5,20 @@
 
 import "es6-promise/dist/es6-promise.auto.js";
 
+// Copy from Array.prototype into Uint8Array to polyfill on IE. It's OK because the implementations of indexOf and slice use properties
+// that exist on Uint8Array with the same name, and JavaScript is magic.
+// We make them 'writable' because the Buffer polyfill messes with it as well.
+if (!Uint8Array.prototype.indexOf) {
+    Object.defineProperty(Uint8Array.prototype, "indexOf", {
+        value: Array.prototype.indexOf,
+        writable: true,
+    });
+}
+if (!Uint8Array.prototype.slice) {
+    Object.defineProperty(Uint8Array.prototype, "slice", {
+        value: Array.prototype.slice,
+        writable: true,
+    });
+}
+
 export * from "./index";


### PR DESCRIPTION
While waiting for benchmarks to run I grabbed this one off the queue.

Turns out the failures in Edge were just the flakiness we're seeing everywhere. We pass everywhere now, after some small polyfills for IE (see below).

**Preview 2 Consideration**: We _may_ want to consider taking this for Preview 2. Without it, Binary support in IE is broken due to the use of `Uint8Array.indexOf` and `Uint8Array.slice`, neither of which IE supports. This would not need to fully re-spin everything since it only affects the JS client. Also, maybe we're OK with Binary in IE being broken in Preview 2. Just wanted to raise it.

![image](https://user-images.githubusercontent.com/7574/38279846-208709b8-3757-11e8-8829-ce3426490a5f.png)
