### PR TITLE
Preserialize for all formats when sending through Redis

### DIFF
--- a/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/HubConnectionContextBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/HubConnectionContextBenchmark.cs
@@ -49,7 +49,7 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
             _successHubProtocolResolver = new TestHubProtocolResolver(new JsonHubProtocol());
             _failureHubProtocolResolver = new TestHubProtocolResolver(null);
             _userIdProvider = new TestUserIdProvider();
-            _supportedProtocols = new List<string> {"json"};
+            _supportedProtocols = new List<string> { "json" };
         }
 
         [Benchmark]
@@ -83,8 +83,11 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
     {
         private readonly IHubProtocol _instance;
 
+        public IReadOnlyList<IHubProtocol> AllProtocols { get; }
+
         public TestHubProtocolResolver(IHubProtocol instance)
         {
+            AllProtocols = new[] { instance };
             _instance = instance;
         }
 

--- a/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks.csproj
+++ b/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -12,6 +12,8 @@
     <ProjectReference Include="..\..\src\Microsoft.AspNetCore.SignalR.Common\Microsoft.AspNetCore.SignalR.Common.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.AspNetCore.SignalR.Client.Core\Microsoft.AspNetCore.SignalR.Client.Core.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.AspNetCore.SignalR.Protocols.MsgPack\Microsoft.AspNetCore.SignalR.Protocols.MsgPack.csproj" />
+    <ProjectReference Include="..\..\src\Microsoft.AspNetCore.SignalR.Redis\Microsoft.AspNetCore.SignalR.Redis.csproj" />
+    <ProjectReference Include="..\..\test\Microsoft.AspNetCore.SignalR.Tests.Utils\Microsoft.AspNetCore.SignalR.Tests.Utils.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/RedisHubLifetimeManagerBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/RedisHubLifetimeManagerBenchmark.cs
@@ -1,0 +1,203 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Buffers;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.SignalR.Internal;
+using Microsoft.AspNetCore.SignalR.Internal.Protocol;
+using Microsoft.AspNetCore.SignalR.Redis;
+using Microsoft.AspNetCore.SignalR.Tests;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
+{
+    public class RedisHubLifetimeManagerBenchmark
+    {
+        private RedisHubLifetimeManager<TestHub> _manager1;
+        private RedisHubLifetimeManager<TestHub> _manager2;
+        private TestClient[] _clients;
+        private object[] _args;
+        private List<string> _excludedIds = new List<string>();
+        private List<string> _sendIds = new List<string>();
+        private List<string> _groups = new List<string>();
+        private List<string> _users = new List<string>();
+
+        private const int ClientCount = 20;
+
+        [Params(2, 20)]
+        public int ProtocolCount { get; set; }
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            var server = new TestRedisServer();
+            var logger = NullLogger<RedisHubLifetimeManager<TestHub>>.Instance;
+            var protocols = GenerateProtocols(ProtocolCount).ToArray();
+            var options = Options.Create(new RedisOptions()
+            {
+                Factory = t => new TestConnectionMultiplexer(server)
+            });
+            var resolver = new DefaultHubProtocolResolver(protocols, NullLogger<DefaultHubProtocolResolver>.Instance);
+
+            _manager1 = new RedisHubLifetimeManager<TestHub>(logger, options, resolver);
+            _manager2 = new RedisHubLifetimeManager<TestHub>(logger, options, resolver);
+
+            async Task ConnectClient(TestClient client, IHubProtocol protocol, string userId, string group)
+            {
+                await _manager2.OnConnectedAsync(HubConnectionContextUtils.Create(client.Connection, protocol, userId));
+                await _manager2.AddGroupAsync(client.Connection.ConnectionId, "Everyone");
+                await _manager2.AddGroupAsync(client.Connection.ConnectionId, group);
+            }
+
+            // Connect clients
+            _clients = new TestClient[ClientCount];
+            var tasks = new Task[ClientCount];
+            for (var i = 0; i < _clients.Length; i++)
+            {
+                var protocol = protocols[i % ProtocolCount];
+                _clients[i] = new TestClient(protocol: protocol);
+
+                string group;
+                string user;
+                if ((i % 2) == 0)
+                {
+                    group = "Evens";
+                    user = "EvenUser";
+                    _excludedIds.Add(_clients[i].Connection.ConnectionId);
+                }
+                else
+                {
+                    group = "Odds";
+                    user = "OddUser";
+                    _sendIds.Add(_clients[i].Connection.ConnectionId);
+                }
+
+                tasks[i] = ConnectClient(_clients[i], protocol, user, group);
+                _ = ConsumeAsync(_clients[i]);
+            }
+
+            Task.WaitAll(tasks);
+
+            _groups.Add("Evens");
+            _groups.Add("Odds");
+            _users.Add("EvenUser");
+            _users.Add("OddUser");
+
+            _args = new object[] {"Foo"};
+        }
+
+        private IEnumerable<IHubProtocol> GenerateProtocols(int protocolCount)
+        {
+            for (var i = 0; i < protocolCount; i++)
+            {
+                yield return ((i % 2) == 0)
+                    ? new WrappedHubProtocol($"json_{i}", new JsonHubProtocol())
+                    : new WrappedHubProtocol($"msgpack_{i}", new MessagePackHubProtocol());
+            }
+        }
+
+        private async Task ConsumeAsync(TestClient testClient)
+        {
+            while (await testClient.ReadAsync() != null)
+            {
+                // Just dump the message
+            }
+        }
+
+        [Benchmark]
+        public async Task SendAll()
+        {
+            await _manager1.SendAllAsync("Test", _args);
+        }
+
+        [Benchmark]
+        public async Task SendGroup()
+        {
+            await _manager1.SendGroupAsync("Everyone", "Test", _args);
+        }
+
+        [Benchmark]
+        public async Task SendUser()
+        {
+            await _manager1.SendUserAsync("EvenUser", "Test", _args);
+        }
+
+        [Benchmark]
+        public async Task SendConnection()
+        {
+            await _manager1.SendConnectionAsync(_clients[0].Connection.ConnectionId, "Test", _args);
+        }
+
+        [Benchmark]
+        public async Task SendConnections()
+        {
+            await _manager1.SendConnectionsAsync(_sendIds, "Test", _args);
+        }
+
+        [Benchmark]
+        public async Task SendAllExcept()
+        {
+            await _manager1.SendAllExceptAsync("Test", _args, _excludedIds);
+        }
+
+        [Benchmark]
+        public async Task SendGroupExcept()
+        {
+            await _manager1.SendGroupExceptAsync("Everyone", "Test", _args, _excludedIds);
+        }
+
+        [Benchmark]
+        public async Task SendGroups()
+        {
+            await _manager1.SendGroupsAsync(_groups, "Test", _args);
+        }
+
+        [Benchmark]
+        public async Task SendUsers()
+        {
+            await _manager1.SendUsersAsync(_users, "Test", _args);
+        }
+
+        public class TestHub : Hub
+        {
+        }
+
+        private class WrappedHubProtocol : IHubProtocol
+        {
+            private readonly string _name;
+            private readonly IHubProtocol _innerProtocol;
+
+            public string Name => _name;
+
+            public int Version => _innerProtocol.Version;
+
+            public TransferFormat TransferFormat => _innerProtocol.TransferFormat;
+
+            public WrappedHubProtocol(string name, IHubProtocol innerProtocol)
+            {
+                _name = name;
+                _innerProtocol = innerProtocol;
+            }
+
+            public bool TryParseMessage(ref ReadOnlySequence<byte> input, IInvocationBinder binder, out HubMessage message)
+            {
+                return _innerProtocol.TryParseMessage(ref input, binder, out message);
+            }
+
+            public void WriteMessage(HubMessage message, IBufferWriter<byte> output)
+            {
+                _innerProtocol.WriteMessage(message, output);
+            }
+
+            public bool IsVersionSupported(int version)
+            {
+                return _innerProtocol.IsVersionSupported(version);
+            }
+        }
+    }
+}

--- a/samples/SignalRSamples/Startup.cs
+++ b/samples/SignalRSamples/Startup.cs
@@ -28,7 +28,7 @@ namespace SignalRSamples
             {
                 options.SerializationContext.DictionarySerlaizationOptions.KeyTransformer = DictionaryKeyTransformers.LowerCamel;
             });
-            // .AddRedis();
+            //.AddRedis();
 
             services.AddCors(o =>
             {

--- a/src/Microsoft.AspNetCore.SignalR.Core/DefaultHubLifetimeManager.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/DefaultHubLifetimeManager.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.SignalR.Internal;
 using Microsoft.AspNetCore.SignalR.Internal.Protocol;
 using Microsoft.Extensions.Logging;
 
@@ -210,9 +211,9 @@ namespace Microsoft.AspNetCore.SignalR
             return Task.CompletedTask;
         }
 
-        private InvocationMessage CreateInvocationMessage(string methodName, object[] args)
+        private SerializedHubMessage CreateInvocationMessage(string methodName, object[] args)
         {
-            return new InvocationMessage(target: methodName, argumentBindingException: null, arguments: args);
+            return new SerializedHubMessage(new InvocationMessage(target: methodName, argumentBindingException: null, arguments: args));
         }
 
         public override Task SendUserAsync(string userId, string methodName, object[] args)

--- a/src/Microsoft.AspNetCore.SignalR.Core/Internal/DefaultHubProtocolResolver.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/Internal/DefaultHubProtocolResolver.cs
@@ -7,21 +7,25 @@ using System.Linq;
 using Microsoft.AspNetCore.SignalR.Internal.Protocol;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.SignalR.Internal
 {
     public class DefaultHubProtocolResolver : IHubProtocolResolver
     {
         private readonly ILogger<DefaultHubProtocolResolver> _logger;
+        private readonly List<IHubProtocol> _hubProtocols;
         private readonly Dictionary<string, IHubProtocol> _availableProtocols;
+
+        public IReadOnlyList<IHubProtocol> AllProtocols => _hubProtocols;
 
         public DefaultHubProtocolResolver(IEnumerable<IHubProtocol> availableProtocols, ILogger<DefaultHubProtocolResolver> logger)
         {
             _logger = logger ?? NullLogger<DefaultHubProtocolResolver>.Instance;
             _availableProtocols = new Dictionary<string, IHubProtocol>(StringComparer.OrdinalIgnoreCase);
 
-            foreach (var protocol in availableProtocols)
+            // We might get duplicates in _hubProtocols, but we're going to check it and throw in just a sec.
+            _hubProtocols = availableProtocols.ToList();
+            foreach (var protocol in _hubProtocols)
             {
                 if (_availableProtocols.ContainsKey(protocol.Name))
                 {

--- a/src/Microsoft.AspNetCore.SignalR.Core/Internal/IHubProtocolResolver.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/Internal/IHubProtocolResolver.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
@@ -8,6 +8,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal
 {
     public interface IHubProtocolResolver
     {
+        IReadOnlyList<IHubProtocol> AllProtocols { get; }
         IHubProtocol GetProtocol(string protocolName, IList<string> supportedProtocols);
     }
 }

--- a/src/Microsoft.AspNetCore.SignalR.Core/Internal/SerializedHubMessage.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/Internal/SerializedHubMessage.cs
@@ -1,0 +1,161 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.AspNetCore.SignalR.Internal.Protocol;
+
+namespace Microsoft.AspNetCore.SignalR.Internal
+{
+    /// <summary>
+    /// This class is designed to support the framework. The API is subject to breaking changes.
+    /// Represents a serialization cache for a single message.
+    /// </summary>
+    public class SerializedHubMessage
+    {
+        private SerializedMessage _cachedItem1;
+        private SerializedMessage _cachedItem2;
+        private IList<SerializedMessage> _cachedItems;
+
+        public HubMessage Message { get; }
+
+        private SerializedHubMessage()
+        {
+        }
+
+        public SerializedHubMessage(HubMessage message)
+        {
+            Message = message;
+        }
+
+        public ReadOnlyMemory<byte> GetSerializedMessage(IHubProtocol protocol)
+        {
+            if (!TryGetCached(protocol.Name, out var serialized))
+            {
+                if (Message == null)
+                {
+                    throw new InvalidOperationException(
+                        "This message was received from another server that did not have the requested protocol available.");
+                }
+
+                serialized = protocol.WriteToArray(Message);
+                SetCache(protocol.Name, serialized);
+            }
+
+            return serialized;
+        }
+
+        public static void WriteAllSerializedVersions(BinaryWriter writer, HubMessage message, IReadOnlyList<IHubProtocol> protocols)
+        {
+            // The serialization format is based on BinaryWriter
+            // * 1 byte number of protocols
+            // * For each protocol:
+            //   * Length-prefixed string using 7-bit variable length encoding (length depends on BinaryWriter's encoding)
+            //   * 4 byte length of the buffer
+            //   * N byte buffer
+
+            if (protocols.Count > byte.MaxValue)
+            {
+                throw new InvalidOperationException($"Can't serialize cache containing more than {byte.MaxValue} entries");
+            }
+
+            writer.Write((byte)protocols.Count);
+            foreach (var protocol in protocols)
+            {
+                writer.Write(protocol.Name);
+
+                var buffer = protocol.WriteToArray(message);
+                writer.Write(buffer.Length);
+                writer.Write(buffer);
+            }
+        }
+
+        public static SerializedHubMessage ReadAllSerializedVersions(BinaryReader reader)
+        {
+            var cache = new SerializedHubMessage();
+            var count = reader.ReadByte();
+            for (var i = 0; i < count; i++)
+            {
+                var protocol = reader.ReadString();
+                var length = reader.ReadInt32();
+                var serialized = reader.ReadBytes(length);
+                cache.SetCache(protocol, serialized);
+            }
+
+            return cache;
+        }
+
+        private void SetCache(string protocolName, byte[] serialized)
+        {
+            if (_cachedItem1.ProtocolName == null)
+            {
+                _cachedItem1 = new SerializedMessage(protocolName, serialized);
+            }
+            else if (_cachedItem2.ProtocolName == null)
+            {
+                _cachedItem2 = new SerializedMessage(protocolName, serialized);
+            }
+            else
+            {
+                if (_cachedItems == null)
+                {
+                    _cachedItems = new List<SerializedMessage>();
+                }
+
+                foreach (var item in _cachedItems)
+                {
+                    if (string.Equals(item.ProtocolName, protocolName, StringComparison.Ordinal))
+                    {
+                        // No need to add
+                        return;
+                    }
+                }
+
+                _cachedItems.Add(new SerializedMessage(protocolName, serialized));
+            }
+        }
+
+        private bool TryGetCached(string protocolName, out byte[] result)
+        {
+            if (string.Equals(_cachedItem1.ProtocolName, protocolName, StringComparison.Ordinal))
+            {
+                result = _cachedItem1.Serialized;
+                return true;
+            }
+
+            if (string.Equals(_cachedItem2.ProtocolName, protocolName, StringComparison.Ordinal))
+            {
+                result = _cachedItem2.Serialized;
+                return true;
+            }
+
+            if (_cachedItems != null)
+            {
+                foreach (var serializedMessage in _cachedItems)
+                {
+                    if (string.Equals(serializedMessage.ProtocolName, protocolName, StringComparison.Ordinal))
+                    {
+                        result = serializedMessage.Serialized;
+                        return true;
+                    }
+                }
+            }
+
+            result = default;
+            return false;
+        }
+
+        private readonly struct SerializedMessage
+        {
+            public string ProtocolName { get; }
+            public byte[] Serialized { get; }
+
+            public SerializedMessage(string protocolName, byte[] serialized)
+            {
+                ProtocolName = protocolName;
+                Serialized = serialized;
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.SignalR.Core/Microsoft.AspNetCore.SignalR.Core.csproj
+++ b/src/Microsoft.AspNetCore.SignalR.Core/Microsoft.AspNetCore.SignalR.Core.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.AspNetCore.SignalR.Common\Microsoft.AspNetCore.SignalR.Common.csproj" />
+    <ProjectReference Include="..\Microsoft.AspNetCore.SignalR.Protocols.Json\Microsoft.AspNetCore.SignalR.Protocols.Json.csproj" />
   </ItemGroup>
 
   <ItemGroup>
@@ -17,7 +18,6 @@
     <PackageReference Include="Microsoft.Extensions.ClosedGenericMatcher.Sources" PrivateAssets="All" Version="$(MicrosoftExtensionsClosedGenericMatcherSourcesPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.ObjectMethodExecutor.Sources" PrivateAssets="All" Version="$(MicrosoftExtensionsObjectMethodExecutorSourcesPackageVersion)" />
     <PackageReference Include="System.Reflection.Emit" Version="$(SystemReflectionEmitPackageVersion)" />
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
     <PackageReference Include="System.Threading.Channels" Version="$(SystemThreadingChannelsPackageVersion)" />
   </ItemGroup>
 

--- a/src/Microsoft.AspNetCore.SignalR.Core/Microsoft.AspNetCore.SignalR.Core.csproj
+++ b/src/Microsoft.AspNetCore.SignalR.Core/Microsoft.AspNetCore.SignalR.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Real-time communication framework for ASP.NET Core.</Description>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <RootNamespace>Microsoft.AspNetCore.SignalR</RootNamespace>
   </PropertyGroup>
 

--- a/src/Microsoft.AspNetCore.SignalR.Core/Microsoft.AspNetCore.SignalR.Core.csproj
+++ b/src/Microsoft.AspNetCore.SignalR.Core/Microsoft.AspNetCore.SignalR.Core.csproj
@@ -2,13 +2,12 @@
 
   <PropertyGroup>
     <Description>Real-time communication framework for ASP.NET Core.</Description>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Microsoft.AspNetCore.SignalR</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.AspNetCore.SignalR.Common\Microsoft.AspNetCore.SignalR.Common.csproj" />
-    <ProjectReference Include="..\Microsoft.AspNetCore.SignalR.Protocols.Json\Microsoft.AspNetCore.SignalR.Protocols.Json.csproj" />
   </ItemGroup>
 
   <ItemGroup>
@@ -18,6 +17,7 @@
     <PackageReference Include="Microsoft.Extensions.ClosedGenericMatcher.Sources" PrivateAssets="All" Version="$(MicrosoftExtensionsClosedGenericMatcherSourcesPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.ObjectMethodExecutor.Sources" PrivateAssets="All" Version="$(MicrosoftExtensionsObjectMethodExecutorSourcesPackageVersion)" />
     <PackageReference Include="System.Reflection.Emit" Version="$(SystemReflectionEmitPackageVersion)" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
     <PackageReference Include="System.Threading.Channels" Version="$(SystemThreadingChannelsPackageVersion)" />
   </ItemGroup>
 

--- a/src/Microsoft.AspNetCore.SignalR.Redis/Internal/GroupAction.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Redis/Internal/GroupAction.cs
@@ -1,0 +1,15 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.SignalR.Redis.Internal
+{
+    // The size of the enum is defined by the protocol. Do not change it. If you need more than 255 items,
+    // add an additional enum.
+    public enum GroupAction : byte
+    {
+        // These numbers are used by the protocol, do not change them and always use explicit assignment
+        // when adding new items to this enum. 0 is intentionally omitted
+        Add = 1,
+        Remove = 2,
+    }
+}

--- a/src/Microsoft.AspNetCore.SignalR.Redis/Internal/RedisChannels.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Redis/Internal/RedisChannels.cs
@@ -1,0 +1,75 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.AspNetCore.SignalR.Redis.Internal
+{
+    internal class RedisChannels
+    {
+        private readonly string _prefix;
+
+        /// <summary>
+        /// Gets the name of the channel for sending to all connections.
+        /// </summary>
+        /// <remarks>
+        /// The payload on this channel is <see cref="RedisInvocation"/> objects containing
+        /// invocations to be sent to all connections
+        /// </remarks>
+        public string All { get; }
+
+        /// <summary>
+        /// Gets the name of the internal channel for group management messages.
+        /// </summary>
+        public string GroupManagement { get; }
+
+        public RedisChannels(string prefix)
+        {
+            _prefix = prefix;
+
+            All = prefix + ":all";
+            GroupManagement = prefix + ":internal:groups";
+        }
+
+        /// <summary>
+        /// Gets the name of the channel for sending a message to a specific connection.
+        /// </summary>
+        /// <param name="connectionId">The ID of the connection to get the channel for.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public string Connection(string connectionId)
+        {
+            return _prefix + ":connection:" + connectionId;
+        }
+
+        /// <summary>
+        /// Gets the name of the channel for sending a message to a named group of connections.
+        /// </summary>
+        /// <param name="groupName">The name of the group to get the channel for.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public string Group(string groupName)
+        {
+            return _prefix + ":group:" + groupName;
+        }
+
+        /// <summary>
+        /// Gets the name of the channel for sending a message to all collections associated with a user.
+        /// </summary>
+        /// <param name="userId">The ID of the user to get the channel for.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public string User(string userId)
+        {
+            return _prefix + ":user:" + userId;
+        }
+
+        /// <summary>
+        /// Gets the name of the acknowledgement channel for the specified server.
+        /// </summary>
+        /// <param name="serverName">The name of the server to get the acknowledgement channel for.</param>
+        /// <returns></returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public string Ack(string serverName)
+        {
+            return _prefix + ":internal:ack:" + serverName;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.SignalR.Redis/Internal/RedisGroupCommand.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Redis/Internal/RedisGroupCommand.cs
@@ -1,0 +1,39 @@
+namespace Microsoft.AspNetCore.SignalR.Redis.Internal
+{
+    public readonly struct RedisGroupCommand
+    {
+        /// <summary>
+        /// Gets the ID of the group command.
+        /// </summary>
+        public int Id { get; }
+
+        /// <summary>
+        /// Gets the name of the server that sent the command.
+        /// </summary>
+        public string ServerName { get; }
+
+        /// <summary>
+        /// Gets the action to be performed on the group.
+        /// </summary>
+        public GroupAction Action { get; }
+
+        /// <summary>
+        /// Gets the group on which the action is performed.
+        /// </summary>
+        public string GroupName { get; }
+
+        /// <summary>
+        /// Gets the ID of the connection to be added or removed from the group.
+        /// </summary>
+        public string ConnectionId { get; }
+
+        public RedisGroupCommand(int id, string serverName, GroupAction action, string groupName, string connectionId)
+        {
+            Id = id;
+            ServerName = serverName;
+            Action = action;
+            GroupName = groupName;
+            ConnectionId = connectionId;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.SignalR.Redis/Internal/RedisInvocation.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Redis/Internal/RedisInvocation.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+using Microsoft.AspNetCore.SignalR.Internal;
+using Microsoft.AspNetCore.SignalR.Internal.Protocol;
+
+namespace Microsoft.AspNetCore.SignalR.Redis.Internal
+{
+    public readonly struct RedisInvocation
+    {
+        /// <summary>
+        /// Gets a list of connections that should be excluded from this invocation.
+        /// May be null to indicate that no connections are to be excluded.
+        /// </summary>
+        public IReadOnlyList<string> ExcludedIds { get; }
+
+        /// <summary>
+        /// Gets the message serialization cache containing serialized payloads for the message.
+        /// </summary>
+        public SerializedHubMessage Message { get; }
+
+        public RedisInvocation(SerializedHubMessage message, IReadOnlyList<string> excludedIds)
+        {
+            Message = message;
+            ExcludedIds = excludedIds;
+        }
+
+        public static RedisInvocation Create(string target, object[] arguments, IReadOnlyList<string> excludedIds = null)
+        {
+            return new RedisInvocation(
+                new SerializedHubMessage(new InvocationMessage(target, argumentBindingException: null, arguments)),
+                excludedIds);
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.SignalR.Redis/Internal/RedisProtocol.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Redis/Internal/RedisProtocol.cs
@@ -1,0 +1,170 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Microsoft.AspNetCore.SignalR.Internal;
+using Microsoft.AspNetCore.SignalR.Internal.Protocol;
+
+namespace Microsoft.AspNetCore.SignalR.Redis.Internal
+{
+    public class RedisProtocol
+    {
+        private readonly IReadOnlyList<IHubProtocol> _protocols;
+        private static readonly Encoding _utf8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+
+        public RedisProtocol(IReadOnlyList<IHubProtocol> protocols)
+        {
+            _protocols = protocols;
+        }
+
+        // The Redis Protocol:
+        // * The message type is known in advance because messages are sent to different channels based on type
+        // * Invocations are sent to the All, Group, Connection and User channels
+        // * Group Commands are sent to the GroupManagement channel
+        // * Acks are sent to the Acknowledgement channel.
+        // * See the Write[type] methods for a description of the protocol for each in-depth.
+        // * The "Variable length integer" is the length-prefixing format used by BinaryReader/BinaryWriter:
+        //   * https://docs.microsoft.com/en-us/dotnet/api/system.io.binarywriter.write?view=netstandard-2.0
+        // * The "Length prefixed string" is the string format used by BinaryReader/BinaryWriter:
+        //   * A 7-bit variable length integer encodes the length in bytes, followed by the encoded string in UTF-8.
+
+        public byte[] WriteInvocation(string methodName, object[] args) =>
+            WriteInvocation(methodName, args, excludedIds: null);
+
+        public byte[] WriteInvocation(string methodName, object[] args, IReadOnlyList<string> excludedIds)
+        {
+            // Redis Invocation Format:
+            // * Variable length integer: Number of excluded Ids
+            // * For each excluded Id:
+            //   * Length prefixed string: ID
+            // * SerializedHubMessage encoded by the format described by that type.
+
+            using (var stream = new MemoryStream())
+            using (var writer = new BinaryWriterWithVarInt(stream, _utf8NoBom))
+            {
+                if (excludedIds != null)
+                {
+                    writer.WriteVarInt(excludedIds.Count);
+                    foreach (var id in excludedIds)
+                    {
+                        writer.Write(id);
+                    }
+                }
+                else
+                {
+                    writer.WriteVarInt(0);
+                }
+
+                SerializedHubMessage.WriteAllSerializedVersions(writer, new InvocationMessage(methodName, argumentBindingException: null, args), _protocols);
+                return stream.ToArray();
+            }
+        }
+
+        public byte[] WriteGroupCommand(RedisGroupCommand command)
+        {
+            // Group Command Format:
+            // * Variable length integer: Id
+            // * Length prefixed string: ServerName
+            // * 1 byte: Action
+            // * Length prefixed string: GroupName
+            // * Length prefixed string: ConnectionId
+
+            using (var stream = new MemoryStream())
+            using (var writer = new BinaryWriterWithVarInt(stream, _utf8NoBom))
+            {
+                writer.WriteVarInt(command.Id);
+                writer.Write(command.ServerName);
+                writer.Write((byte)command.Action);
+                writer.Write(command.GroupName);
+                writer.Write(command.ConnectionId);
+                return stream.ToArray();
+            }
+        }
+
+        public byte[] WriteAck(int messageId)
+        {
+            // Acknowledgement Format:
+            // * Variable length integer: Id
+
+            using (var stream = new MemoryStream())
+            using (var writer = new BinaryWriterWithVarInt(stream, _utf8NoBom))
+            {
+                writer.WriteVarInt(messageId);
+                return stream.ToArray();
+            }
+        }
+
+        public RedisInvocation ReadInvocation(byte[] data)
+        {
+            // See WriteInvocation for format.
+
+            using (var stream = new MemoryStream(data))
+            using (var reader = new BinaryReaderWithVarInt(stream, _utf8NoBom))
+            {
+                IReadOnlyList<string> excludedIds = null;
+
+                var idCount = reader.ReadVarInt();
+                if (idCount > 0)
+                {
+                    var ids = new string[idCount];
+                    for (var i = 0; i < idCount; i++)
+                    {
+                        ids[i] = reader.ReadString();
+                    }
+
+                    excludedIds = ids;
+                }
+
+                var message = SerializedHubMessage.ReadAllSerializedVersions(reader);
+                return new RedisInvocation(message, excludedIds);
+            }
+        }
+
+        public RedisGroupCommand ReadGroupCommand(byte[] data)
+        {
+            // See WriteGroupCommand for format.
+            using (var stream = new MemoryStream(data))
+            using (var reader = new BinaryReaderWithVarInt(stream, _utf8NoBom))
+            {
+                var id = reader.ReadVarInt();
+                var serverName = reader.ReadString();
+                var action = (GroupAction)reader.ReadByte();
+                var groupName = reader.ReadString();
+                var connectionId = reader.ReadString();
+
+                return new RedisGroupCommand(id, serverName, action, groupName, connectionId);
+            }
+        }
+
+        public int ReadAck(byte[] data)
+        {
+            // See WriteAck for format
+            using (var stream = new MemoryStream(data))
+            using (var reader = new BinaryReaderWithVarInt(stream, _utf8NoBom))
+            {
+                return reader.ReadVarInt();
+            }
+        }
+
+        // Kinda cheaty way to get access to write the 7-bit varint format directly
+        private class BinaryWriterWithVarInt : BinaryWriter
+        {
+            public BinaryWriterWithVarInt(Stream output, Encoding encoding) : base(output, encoding)
+            {
+            }
+
+            public void WriteVarInt(int value) => Write7BitEncodedInt(value);
+        }
+
+        private class BinaryReaderWithVarInt : BinaryReader
+        {
+            public BinaryReaderWithVarInt(Stream input, Encoding encoding) : base(input, encoding)
+            {
+            }
+
+            public int ReadVarInt() => Read7BitEncodedInt();
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.SignalR.Redis/RedisLog.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Redis/RedisLog.cs
@@ -6,13 +6,14 @@ using System.Linq;
 using Microsoft.Extensions.Logging;
 using StackExchange.Redis;
 
-namespace Microsoft.AspNetCore.SignalR.Redis.Internal
+namespace Microsoft.AspNetCore.SignalR.Redis
 {
-    internal static class RedisLoggerExtensions
+    // We don't want to use our nested static class here because RedisHubLifetimeManager is generic.
+    // We'd end up creating separate instances of all the LoggerMessage.Define values for each Hub.
+    internal static class RedisLog
     {
-        // Category: RedisHubLifetimeManager<THub>
-        private static readonly Action<ILogger, string, Exception> _connectingToEndpoints =
-            LoggerMessage.Define<string>(LogLevel.Information, new EventId(1, "ConnectingToEndpoints"), "Connecting to Redis endpoints: {Endpoints}.");
+        private static readonly Action<ILogger, string, string, Exception> _connectingToEndpoints =
+            LoggerMessage.Define<string, string>(LogLevel.Information, new EventId(1, "ConnectingToEndpoints"), "Connecting to Redis endpoints: {Endpoints}. Using Server Name: {ServerName}");
 
         private static readonly Action<ILogger, Exception> _connected =
             LoggerMessage.Define(LogLevel.Information, new EventId(2, "Connected"), "Connected to Redis.");
@@ -44,65 +45,75 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Internal
         private static readonly Action<ILogger, Exception> _internalMessageFailed =
             LoggerMessage.Define(LogLevel.Warning, new EventId(11, "InternalMessageFailed"), "Error processing message for internal server message.");
 
-        public static void ConnectingToEndpoints(this ILogger logger, EndPointCollection endpoints)
+        public static void ConnectingToEndpoints(ILogger logger, EndPointCollection endpoints, string serverName)
         {
             if (logger.IsEnabled(LogLevel.Information))
             {
                 if (endpoints.Count > 0)
                 {
-                    _connectingToEndpoints(logger, string.Join(", ", endpoints.Select(e => EndPointCollection.ToString(e))), null);
+                    _connectingToEndpoints(logger, string.Join(", ", endpoints.Select(e => EndPointCollection.ToString(e))), serverName, null);
                 }
             }
         }
 
-        public static void Connected(this ILogger logger)
+        public static void Connected(ILogger logger)
         {
             _connected(logger, null);
         }
 
-        public static void Subscribing(this ILogger logger, string channelName)
+        public static void Subscribing(ILogger logger, string channelName)
         {
             _subscribing(logger, channelName, null);
         }
 
-        public static void ReceivedFromChannel(this ILogger logger, string channelName)
+        public static void ReceivedFromChannel(ILogger logger, string channelName)
         {
             _receivedFromChannel(logger, channelName, null);
         }
 
-        public static void PublishToChannel(this ILogger logger, string channelName)
+        public static void PublishToChannel(ILogger logger, string channelName)
         {
             _publishToChannel(logger, channelName, null);
         }
 
-        public static void Unsubscribe(this ILogger logger, string channelName)
+        public static void Unsubscribe(ILogger logger, string channelName)
         {
             _unsubscribe(logger, channelName, null);
         }
 
-        public static void NotConnected(this ILogger logger)
+        public static void NotConnected(ILogger logger)
         {
             _notConnected(logger, null);
         }
 
-        public static void ConnectionRestored(this ILogger logger)
+        public static void ConnectionRestored(ILogger logger)
         {
             _connectionRestored(logger, null);
         }
 
-        public static void ConnectionFailed(this ILogger logger, Exception exception)
+        public static void ConnectionFailed(ILogger logger, Exception exception)
         {
             _connectionFailed(logger, exception);
         }
 
-        public static void FailedWritingMessage(this ILogger logger, Exception exception)
+        public static void FailedWritingMessage(ILogger logger, Exception exception)
         {
             _failedWritingMessage(logger, exception);
         }
 
-        public static void InternalMessageFailed(this ILogger logger, Exception exception)
+        public static void InternalMessageFailed(ILogger logger, Exception exception)
         {
             _internalMessageFailed(logger, exception);
+        }
+
+        // This isn't DefineMessage-based because it's just the simple TextWriter logging from ConnectionMultiplexer
+        public static void ConnectionMultiplexerMessage(ILogger logger, string message)
+        {
+            if (logger.IsEnabled(LogLevel.Debug))
+            {
+                // We tag it with EventId 100 though so it can be pulled out of logs easily.
+                logger.LogDebug(new EventId(100, "RedisConnectionLog"), message);
+            }
         }
     }
 }

--- a/test/Microsoft.AspNetCore.SignalR.Redis.Tests/RedisHubLifetimeManagerTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Redis.Tests/RedisHubLifetimeManagerTests.cs
@@ -5,11 +5,15 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Channels;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.SignalR.Internal;
 using Microsoft.AspNetCore.SignalR.Internal.Protocol;
 using Microsoft.AspNetCore.SignalR.Tests;
-using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
+using MsgPack.Serialization;
+using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Serialization;
 using Xunit;
 
 namespace Microsoft.AspNetCore.SignalR.Redis.Tests
@@ -19,14 +23,12 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
         [Fact]
         public async Task InvokeAllAsyncWritesToAllConnectionsOutput()
         {
+            var server = new TestRedisServer();
+
             using (var client1 = new TestClient())
             using (var client2 = new TestClient())
             {
-                var manager = new RedisHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<RedisHubLifetimeManager<MyHub>>(),
-                Options.Create(new RedisOptions()
-                {
-                    Factory = t => new TestConnectionMultiplexer()
-                }));
+                var manager = CreateLifetimeManager(server);
                 var connection1 = HubConnectionContextUtils.Create(client1.Connection);
                 var connection2 = HubConnectionContextUtils.Create(client2.Connection);
 
@@ -41,16 +43,43 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
         }
 
         [Fact]
+        public async Task InvokeAllExceptAsyncExcludesSpecifiedConnections()
+        {
+            var server = new TestRedisServer();
+
+            using (var client1 = new TestClient())
+            using (var client2 = new TestClient())
+            using (var client3 = new TestClient())
+            {
+                var manager1 = CreateLifetimeManager(server);
+                var manager2 = CreateLifetimeManager(server);
+                var manager3 = CreateLifetimeManager(server);
+
+                var connection1 = HubConnectionContextUtils.Create(client1.Connection);
+                var connection2 = HubConnectionContextUtils.Create(client2.Connection);
+                var connection3 = HubConnectionContextUtils.Create(client3.Connection);
+
+                await manager1.OnConnectedAsync(connection1).OrTimeout();
+                await manager2.OnConnectedAsync(connection2).OrTimeout();
+                await manager3.OnConnectedAsync(connection3).OrTimeout();
+
+                await manager1.SendAllExceptAsync("Hello", new object[] { "World" }, new [] { client3.Connection.ConnectionId }).OrTimeout();
+
+                await AssertMessageAsync(client1);
+                await AssertMessageAsync(client2);
+                Assert.Null(client3.TryRead());
+            }
+        }
+
+        [Fact]
         public async Task InvokeAllAsyncDoesNotWriteToDisconnectedConnectionsOutput()
         {
+            var server = new TestRedisServer();
+
             using (var client1 = new TestClient())
             using (var client2 = new TestClient())
             {
-                var manager = new RedisHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<RedisHubLifetimeManager<MyHub>>(),
-                Options.Create(new RedisOptions()
-                {
-                    Factory = t => new TestConnectionMultiplexer()
-                }));
+                var manager = CreateLifetimeManager(server);
                 var connection1 = HubConnectionContextUtils.Create(client1.Connection);
                 var connection2 = HubConnectionContextUtils.Create(client2.Connection);
 
@@ -70,14 +99,12 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
         [Fact]
         public async Task InvokeGroupAsyncWritesToAllConnectionsInGroupOutput()
         {
+            var server = new TestRedisServer();
+
             using (var client1 = new TestClient())
             using (var client2 = new TestClient())
             {
-                var manager = new RedisHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<RedisHubLifetimeManager<MyHub>>(),
-                Options.Create(new RedisOptions()
-                {
-                    Factory = t => new TestConnectionMultiplexer()
-                }));
+                var manager = CreateLifetimeManager(server);
                 var connection1 = HubConnectionContextUtils.Create(client1.Connection);
                 var connection2 = HubConnectionContextUtils.Create(client2.Connection);
 
@@ -96,14 +123,12 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
         [Fact]
         public async Task InvokeGroupExceptAsyncWritesToAllValidConnectionsInGroupOutput()
         {
+            var server = new TestRedisServer();
+
             using (var client1 = new TestClient())
             using (var client2 = new TestClient())
             {
-                var manager = new RedisHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<RedisHubLifetimeManager<MyHub>>(),
-                Options.Create(new RedisOptions()
-                {
-                    Factory = t => new TestConnectionMultiplexer()
-                }));
+                var manager = CreateLifetimeManager(server);
                 var connection1 = HubConnectionContextUtils.Create(client1.Connection);
                 var connection2 = HubConnectionContextUtils.Create(client2.Connection);
 
@@ -124,13 +149,11 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
         [Fact]
         public async Task InvokeConnectionAsyncWritesToConnectionOutput()
         {
+            var server = new TestRedisServer();
+
             using (var client = new TestClient())
             {
-                var manager = new RedisHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<RedisHubLifetimeManager<MyHub>>(),
-                Options.Create(new RedisOptions()
-                {
-                    Factory = t => new TestConnectionMultiplexer()
-                }));
+                var manager = CreateLifetimeManager(server);
                 var connection = HubConnectionContextUtils.Create(client.Connection);
 
                 await manager.OnConnectedAsync(connection).OrTimeout();
@@ -144,27 +167,19 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
         [Fact]
         public async Task InvokeConnectionAsyncOnNonExistentConnectionDoesNotThrow()
         {
-            var manager = new RedisHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<RedisHubLifetimeManager<MyHub>>(),
-            Options.Create(new RedisOptions()
-            {
-                Factory = t => new TestConnectionMultiplexer()
-            }));
+            var server = new TestRedisServer();
+
+            var manager = CreateLifetimeManager(server);
             await manager.SendConnectionAsync("NotARealConnectionId", "Hello", new object[] { "World" }).OrTimeout();
         }
 
         [Fact]
         public async Task InvokeAllAsyncWithMultipleServersWritesToAllConnectionsOutput()
         {
-            var manager1 = new RedisHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<RedisHubLifetimeManager<MyHub>>(),
-            Options.Create(new RedisOptions()
-            {
-                Factory = t => new TestConnectionMultiplexer()
-            }));
-            var manager2 = new RedisHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<RedisHubLifetimeManager<MyHub>>(),
-            Options.Create(new RedisOptions()
-            {
-                Factory = t => new TestConnectionMultiplexer()
-            }));
+            var server = new TestRedisServer();
+
+            var manager1 = CreateLifetimeManager(server);
+            var manager2 = CreateLifetimeManager(server);
 
             using (var client1 = new TestClient())
             using (var client2 = new TestClient())
@@ -185,16 +200,10 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
         [Fact]
         public async Task InvokeAllAsyncWithMultipleServersDoesNotWriteToDisconnectedConnectionsOutput()
         {
-            var manager1 = new RedisHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<RedisHubLifetimeManager<MyHub>>(),
-            Options.Create(new RedisOptions()
-            {
-                Factory = t => new TestConnectionMultiplexer()
-            }));
-            var manager2 = new RedisHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<RedisHubLifetimeManager<MyHub>>(),
-            Options.Create(new RedisOptions()
-            {
-                Factory = t => new TestConnectionMultiplexer()
-            }));
+            var server = new TestRedisServer();
+
+            var manager1 = CreateLifetimeManager(server);
+            var manager2 = CreateLifetimeManager(server);
 
             using (var client1 = new TestClient())
             using (var client2 = new TestClient())
@@ -218,16 +227,10 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
         [Fact]
         public async Task InvokeConnectionAsyncOnServerWithoutConnectionWritesOutputToConnection()
         {
-            var manager1 = new RedisHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<RedisHubLifetimeManager<MyHub>>(),
-            Options.Create(new RedisOptions()
-            {
-                Factory = t => new TestConnectionMultiplexer()
-            }));
-            var manager2 = new RedisHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<RedisHubLifetimeManager<MyHub>>(),
-            Options.Create(new RedisOptions()
-            {
-                Factory = t => new TestConnectionMultiplexer()
-            }));
+            var server = new TestRedisServer();
+
+            var manager1 = CreateLifetimeManager(server);
+            var manager2 = CreateLifetimeManager(server);
 
             using (var client = new TestClient())
             {
@@ -244,16 +247,10 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
         [Fact]
         public async Task InvokeGroupAsyncOnServerWithoutConnectionWritesOutputToGroupConnection()
         {
-            var manager1 = new RedisHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<RedisHubLifetimeManager<MyHub>>(),
-            Options.Create(new RedisOptions()
-            {
-                Factory = t => new TestConnectionMultiplexer()
-            }));
-            var manager2 = new RedisHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<RedisHubLifetimeManager<MyHub>>(),
-            Options.Create(new RedisOptions()
-            {
-                Factory = t => new TestConnectionMultiplexer()
-            }));
+            var server = new TestRedisServer();
+
+            var manager1 = CreateLifetimeManager(server);
+            var manager2 = CreateLifetimeManager(server);
 
             using (var client = new TestClient())
             {
@@ -272,11 +269,9 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
         [Fact]
         public async Task DisconnectConnectionRemovesConnectionFromGroup()
         {
-            var manager = new RedisHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<RedisHubLifetimeManager<MyHub>>(),
-            Options.Create(new RedisOptions()
-            {
-                Factory = t => new TestConnectionMultiplexer()
-            }));
+            var server = new TestRedisServer();
+
+            var manager = CreateLifetimeManager(server);
 
             using (var client = new TestClient())
             {
@@ -297,11 +292,9 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
         [Fact]
         public async Task RemoveGroupFromLocalConnectionNotInGroupDoesNothing()
         {
-            var manager = new RedisHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<RedisHubLifetimeManager<MyHub>>(),
-            Options.Create(new RedisOptions()
-            {
-                Factory = t => new TestConnectionMultiplexer()
-            }));
+            var server = new TestRedisServer();
+
+            var manager = CreateLifetimeManager(server);
 
             using (var client = new TestClient())
             {
@@ -316,16 +309,10 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
         [Fact]
         public async Task RemoveGroupFromConnectionOnDifferentServerNotInGroupDoesNothing()
         {
-            var manager1 = new RedisHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<RedisHubLifetimeManager<MyHub>>(),
-            Options.Create(new RedisOptions()
-            {
-                Factory = t => new TestConnectionMultiplexer()
-            }));
-            var manager2 = new RedisHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<RedisHubLifetimeManager<MyHub>>(),
-            Options.Create(new RedisOptions()
-            {
-                Factory = t => new TestConnectionMultiplexer()
-            }));
+            var server = new TestRedisServer();
+
+            var manager1 = CreateLifetimeManager(server);
+            var manager2 = CreateLifetimeManager(server);
 
             using (var client = new TestClient())
             {
@@ -340,14 +327,10 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
         [Fact]
         public async Task AddGroupAsyncForConnectionOnDifferentServerWorks()
         {
-            var manager1 = new RedisHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<RedisHubLifetimeManager<MyHub>>(), Options.Create(new RedisOptions()
-            {
-                Factory = t => new TestConnectionMultiplexer()
-            }));
-            var manager2 = new RedisHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<RedisHubLifetimeManager<MyHub>>(), Options.Create(new RedisOptions()
-            {
-                Factory = t => new TestConnectionMultiplexer()
-            }));
+            var server = new TestRedisServer();
+
+            var manager1 = CreateLifetimeManager(server);
+            var manager2 = CreateLifetimeManager(server);
 
             using (var client = new TestClient())
             {
@@ -366,10 +349,9 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
         [Fact]
         public async Task AddGroupAsyncForLocalConnectionAlreadyInGroupDoesNothing()
         {
-            var manager = new RedisHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<RedisHubLifetimeManager<MyHub>>(), Options.Create(new RedisOptions()
-            {
-                Factory = t => new TestConnectionMultiplexer()
-            }));
+            var server = new TestRedisServer();
+
+            var manager = CreateLifetimeManager(server);
 
             using (var client = new TestClient())
             {
@@ -382,7 +364,6 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
 
                 await manager.SendGroupAsync("name", "Hello", new object[] { "World" }).OrTimeout();
 
-
                 await AssertMessageAsync(client);
                 Assert.Null(client.TryRead());
             }
@@ -391,14 +372,10 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
         [Fact]
         public async Task AddGroupAsyncForConnectionOnDifferentServerAlreadyInGroupDoesNothing()
         {
-            var manager1 = new RedisHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<RedisHubLifetimeManager<MyHub>>(), Options.Create(new RedisOptions()
-            {
-                Factory = t => new TestConnectionMultiplexer()
-            }));
-            var manager2 = new RedisHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<RedisHubLifetimeManager<MyHub>>(), Options.Create(new RedisOptions()
-            {
-                Factory = t => new TestConnectionMultiplexer()
-            }));
+            var server = new TestRedisServer();
+
+            var manager1 = CreateLifetimeManager(server);
+            var manager2 = CreateLifetimeManager(server);
 
             using (var client = new TestClient())
             {
@@ -419,14 +396,10 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
         [Fact]
         public async Task RemoveGroupAsyncForConnectionOnDifferentServerWorks()
         {
-            var manager1 = new RedisHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<RedisHubLifetimeManager<MyHub>>(), Options.Create(new RedisOptions()
-            {
-                Factory = t => new TestConnectionMultiplexer()
-            }));
-            var manager2 = new RedisHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<RedisHubLifetimeManager<MyHub>>(), Options.Create(new RedisOptions()
-            {
-                Factory = t => new TestConnectionMultiplexer()
-            }));
+            var server = new TestRedisServer();
+
+            var manager1 = CreateLifetimeManager(server);
+            var manager2 = CreateLifetimeManager(server);
 
             using (var client = new TestClient())
             {
@@ -451,14 +424,10 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
         [Fact]
         public async Task InvokeConnectionAsyncForLocalConnectionDoesNotPublishToRedis()
         {
-            var manager1 = new RedisHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<RedisHubLifetimeManager<MyHub>>(), Options.Create(new RedisOptions()
-            {
-                Factory = t => new TestConnectionMultiplexer()
-            }));
-            var manager2 = new RedisHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<RedisHubLifetimeManager<MyHub>>(), Options.Create(new RedisOptions()
-            {
-                Factory = t => new TestConnectionMultiplexer()
-            }));
+            var server = new TestRedisServer();
+
+            var manager1 = CreateLifetimeManager(server);
+            var manager2 = CreateLifetimeManager(server);
 
             using (var client = new TestClient())
             {
@@ -478,14 +447,10 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
         [Fact]
         public async Task WritingToRemoteConnectionThatFailsDoesNotThrow()
         {
-            var manager1 = new RedisHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<RedisHubLifetimeManager<MyHub>>(), Options.Create(new RedisOptions()
-            {
-                Factory = t => new TestConnectionMultiplexer()
-            }));
-            var manager2 = new RedisHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<RedisHubLifetimeManager<MyHub>>(), Options.Create(new RedisOptions()
-            {
-                Factory = t => new TestConnectionMultiplexer()
-            }));
+            var server = new TestRedisServer();
+
+            var manager1 = CreateLifetimeManager(server);
+            var manager2 = CreateLifetimeManager(server);
 
             using (var client = new TestClient())
             {
@@ -505,10 +470,9 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
         [Fact]
         public async Task WritingToLocalConnectionThatFailsDoesNotThrowException()
         {
-            var manager = new RedisHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<RedisHubLifetimeManager<MyHub>>(), Options.Create(new RedisOptions()
-            {
-                Factory = t => new TestConnectionMultiplexer()
-            }));
+            var server = new TestRedisServer();
+
+            var manager = CreateLifetimeManager(server);
 
             using (var client = new TestClient())
             {
@@ -526,10 +490,9 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
         [Fact]
         public async Task WritingToGroupWithOneConnectionFailingSecondConnectionStillReceivesMessage()
         {
-            var manager = new RedisHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<RedisHubLifetimeManager<MyHub>>(), Options.Create(new RedisOptions()
-            {
-                Factory = t => new TestConnectionMultiplexer()
-            }));
+            var server = new TestRedisServer();
+
+            var manager = CreateLifetimeManager(server);
 
             using (var client1 = new TestClient())
             using (var client2 = new TestClient())
@@ -555,6 +518,72 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
                 await manager.SendGroupAsync("group", "Hello", new object[] { "World" }).OrTimeout();
                 await AssertMessageAsync(client2);
             }
+        }
+
+        [Fact]
+        public async Task CamelCasedJsonIsPreservedAcrossRedisBoundary()
+        {
+            var server = new TestRedisServer();
+
+            var messagePackOptions = new MessagePackHubProtocolOptions();
+            messagePackOptions.SerializationContext.DictionarySerlaizationOptions.KeyTransformer = DictionaryKeyTransformers.LowerCamel;
+
+            var jsonOptions = new JsonHubProtocolOptions();
+            jsonOptions.PayloadSerializerSettings.ContractResolver = new CamelCasePropertyNamesContractResolver();
+
+            using (var client1 = new TestClient())
+            using (var client2 = new TestClient())
+            {
+                // The sending manager has serializer settings
+                var manager1 = CreateLifetimeManager(server, messagePackOptions, jsonOptions);
+
+                // The receiving one doesn't matter because of how we serialize!
+                var manager2 = CreateLifetimeManager(server);
+
+                var connection1 = HubConnectionContextUtils.Create(client1.Connection);
+                var connection2 = HubConnectionContextUtils.Create(client2.Connection);
+
+                await manager1.OnConnectedAsync(connection1).OrTimeout();
+                await manager2.OnConnectedAsync(connection2).OrTimeout();
+
+                await manager1.SendAllAsync("Hello", new object[] { new TestObject { TestProperty = "Foo" } });
+
+                var message = Assert.IsType<InvocationMessage>(await client2.ReadAsync().OrTimeout());
+                Assert.Equal("Hello", message.Target);
+                Assert.Collection(
+                    message.Arguments,
+                    arg0 =>
+                    {
+                        var dict = Assert.IsType<JObject>(arg0);
+                        Assert.Collection(dict.Properties(),
+                            prop =>
+                            {
+                                Assert.Equal("testProperty", prop.Name);
+                                Assert.Equal("Foo", prop.Value.Value<string>());
+                            });
+                    });
+            }
+        }
+
+        public class TestObject
+        {
+            public string TestProperty { get; set; }
+        }
+
+        private RedisHubLifetimeManager<MyHub> CreateLifetimeManager(TestRedisServer server, MessagePackHubProtocolOptions messagePackOptions = null, JsonHubProtocolOptions jsonOptions = null)
+        {
+            var options = new RedisOptions() { Factory = t => new TestConnectionMultiplexer(server) };
+            messagePackOptions = messagePackOptions ?? new MessagePackHubProtocolOptions();
+            jsonOptions = jsonOptions ?? new JsonHubProtocolOptions();
+
+            return new RedisHubLifetimeManager<MyHub>(
+                NullLogger<RedisHubLifetimeManager<MyHub>>.Instance,
+                Options.Create(options),
+                new DefaultHubProtocolResolver(new IHubProtocol[]
+                {
+                    new JsonHubProtocol(Options.Create(jsonOptions)),
+                    new MessagePackHubProtocol(Options.Create(messagePackOptions)),
+                }, NullLogger<DefaultHubProtocolResolver>.Instance));
         }
 
         private async Task AssertMessageAsync(TestClient client)

--- a/test/Microsoft.AspNetCore.SignalR.Redis.Tests/RedisHubLifetimeManagerTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Redis.Tests/RedisHubLifetimeManagerTests.cs
@@ -468,26 +468,6 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
         }
 
         [Fact]
-        public async Task WritingToLocalConnectionThatFailsDoesNotThrowException()
-        {
-            var server = new TestRedisServer();
-
-            var manager = CreateLifetimeManager(server);
-
-            using (var client = new TestClient())
-            {
-                // Force an exception when writing to connection
-                var connectionMock = HubConnectionContextUtils.CreateMock(client.Connection);
-                connectionMock.Setup(m => m.WriteAsync(It.IsAny<HubMessage>())).Throws(new Exception("Message"));
-                var connection = connectionMock.Object;
-
-                await manager.OnConnectedAsync(connection).OrTimeout();
-
-                await manager.SendConnectionAsync(connection.ConnectionId, "Hello", new object[] { "World" }).OrTimeout();
-            }
-        }
-
-        [Fact]
         public async Task WritingToGroupWithOneConnectionFailingSecondConnectionStillReceivesMessage()
         {
             var server = new TestRedisServer();

--- a/test/Microsoft.AspNetCore.SignalR.Tests.Utils/HubConnectionContextUtils.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests.Utils/HubConnectionContextUtils.cs
@@ -11,11 +11,12 @@ namespace Microsoft.AspNetCore.SignalR.Tests
 {
     public static class HubConnectionContextUtils
     {
-        public static HubConnectionContext Create(ConnectionContext connection)
+        public static HubConnectionContext Create(ConnectionContext connection, IHubProtocol protocol = null, string userIdentifier = null)
         {
             return new HubConnectionContext(connection, TimeSpan.FromSeconds(15), NullLoggerFactory.Instance)
             {
-                Protocol = new JsonHubProtocol()
+                Protocol = protocol ?? new JsonHubProtocol(),
+                UserIdentifier = userIdentifier,
             };
         }
 

--- a/test/Microsoft.AspNetCore.SignalR.Tests.Utils/Microsoft.AspNetCore.SignalR.Tests.Utils.csproj
+++ b/test/Microsoft.AspNetCore.SignalR.Tests.Utils/Microsoft.AspNetCore.SignalR.Tests.Utils.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="Microsoft.Extensions.ValueStopwatch.Sources" Version="$(MicrosoftExtensionsValueStopwatchSourcesPackageVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="$(MicrosoftAspNetCoreHostingPackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="$(MicrosoftAspNetCoreServerKestrelPackageVersion)" />
+    <PackageReference Include="StackExchange.Redis.StrongName" Version="$(StackExchangeRedisStrongNamePackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes #1800 

I added a benchmark, the results from `dev` were questionable for some cases, but generally no major regressions. Significantly reduced allocations though ✨ 🍰 ✨ 

I'm not sure I believe the `SendGroups` numbers from dev. They're so far out of the from the others... The numbers match up with the numbers I was seeing when nobody was subscribed to the group, but SendGroup is passing. I'm also going to look at adding an expanded benchmark that times how long it takes for the client to receive messages.

Before (`dev`):

```
          Method |      Mean |     Error |    StdDev |    Median |     Op/s |  Gen 0 | Allocated |
---------------- |----------:|----------:|----------:|----------:|---------:|-------:|----------:|
         SendAll | 206.33 us | 5.8911 us |  5.511 us | 204.28 us |  4,846.7 | 0.2441 |   6.57 KB |
       SendGroup | 259.79 us | 3.4078 us |  3.021 us | 260.20 us |  3,849.3 | 0.2441 |   6.81 KB |
        SendUser | 285.43 us | 5.0913 us |  4.251 us | 286.66 us |  3,503.4 | 0.4883 |   6.86 KB |
  SendConnection |  99.85 us | 2.2469 us |  6.519 us |  97.91 us | 10,015.2 | 0.1221 |   6.93 KB |
 SendConnections | 183.91 us | 3.6726 us |  6.136 us | 182.82 us |  5,437.4 | 1.4648 |  67.66 KB |
   SendAllExcept | 239.39 us | 4.7761 us | 10.974 us | 238.84 us |  4,177.2 |      - |   7.21 KB |
 SendGroupExcept | 199.61 us | 3.1616 us |  3.514 us | 200.39 us |  5,009.7 | 0.2441 |   7.23 KB |
      SendGroups |  18.97 us | 0.4502 us |  1.247 us |  19.11 us | 52,704.6 | 0.1221 |  13.59 KB |
       SendUsers | 313.96 us | 5.9260 us | 10.063 us | 312.35 us |  3,185.1 | 0.9766 |  13.71 KB |
```

After (`anurse/1800-preserializer`):

```
          Method |      Mean |    Error |    StdDev |     Op/s |  Gen 0 | Allocated |
---------------- |----------:|---------:|----------:|---------:|-------:|----------:|
         SendAll | 187.27 us | 8.459 us | 24.941 us |  5,340.0 | 0.1221 |   2.81 KB |
       SendGroup | 136.25 us | 2.695 us |  3.597 us |  7,339.3 |      - |   3.05 KB |
        SendUser | 113.79 us | 2.135 us |  4.214 us |  8,787.7 |      - |   3.04 KB |
  SendConnection | 134.40 us | 2.628 us |  5.769 us |  7,440.5 |      - |   3.19 KB |
 SendConnections |  95.05 us | 2.055 us |  6.026 us | 10,520.3 | 0.2441 |  10.98 KB |
   SendAllExcept | 141.90 us | 2.924 us |  4.885 us |  7,047.4 |      - |   3.73 KB |
 SendGroupExcept | 135.66 us | 3.222 us |  3.581 us |  7,371.6 |      - |   3.97 KB |
      SendGroups | 133.16 us | 2.638 us |  5.789 us |  7,509.7 | 0.2441 |   4.04 KB |
       SendUsers | 142.44 us | 2.802 us |  4.757 us |  7,020.6 | 0.2441 |   4.04 KB |
```

