### PR TITLE
MsgPack perf

### DIFF
--- a/src/Microsoft.AspNetCore.SignalR.Protocols.MsgPack/Internal/Protocol/MessagePackHubProtocol.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Protocols.MsgPack/Internal/Protocol/MessagePackHubProtocol.cs
@@ -322,7 +322,9 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
                 packer.PackString(message.InvocationId);
             }
             packer.PackString(message.Target);
-            packer.PackObject(message.Arguments, SerializationContext);
+            packer.PackArrayHeader(message.Arguments.Length);
+            foreach (var arg in message.Arguments)
+                packer.PackObject(arg, SerializationContext);
         }
 
         private void WriteStreamInvocationMessage(StreamInvocationMessage message, Packer packer)

--- a/src/Microsoft.AspNetCore.SignalR.Protocols.MsgPack/Internal/Protocol/MessagePackHubProtocol.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Protocols.MsgPack/Internal/Protocol/MessagePackHubProtocol.cs
@@ -324,7 +324,9 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
             packer.PackString(message.Target);
             packer.PackArrayHeader(message.Arguments.Length);
             foreach (var arg in message.Arguments)
+            {
                 packer.PackObject(arg, SerializationContext);
+            }
         }
 
         private void WriteStreamInvocationMessage(StreamInvocationMessage message, Packer packer)
@@ -334,7 +336,11 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
             PackHeaders(packer, message.Headers);
             packer.PackString(message.InvocationId);
             packer.PackString(message.Target);
-            packer.PackObject(message.Arguments, SerializationContext);
+            packer.PackArrayHeader(message.Arguments.Length);
+            foreach (var arg in message.Arguments)
+            {
+                packer.PackObject(arg, SerializationContext);
+            }
         }
 
         private void WriteStreamingItemMessage(StreamItemMessage message, Packer packer)


### PR DESCRIPTION
Before
```
             Method |          Input | HubProtocol |        Mean |     Error |      StdDev |      Median |        Op/s |  Gen 0 | Allocated |
------------------- |--------------- |------------ |------------:|----------:|------------:|------------:|------------:|-------:|----------:|
 WriteSingleMessage |   FewArguments |     MsgPack |  1,803.6 ns |  34.42 ns |    32.20 ns |  1,810.2 ns |   554,435.6 | 0.0038 |     568 B |
 WriteSingleMessage | LargeArguments |     MsgPack | 20,765.8 ns | 502.79 ns | 1,418.12 ns | 20,320.4 ns |    48,156.0 | 0.7324 |   61944 B |
 WriteSingleMessage |  ManyArguments |     MsgPack |  3,344.6 ns |  66.26 ns |   112.52 ns |  3,331.5 ns |   298,990.4 | 0.0076 |     840 B |
 WriteSingleMessage |    NoArguments |     MsgPack |    994.9 ns |  21.17 ns |    46.91 ns |    995.7 ns | 1,005,150.6 | 0.0019 |     320 B |
```

After
``` 
             Method |          Input | HubProtocol |        Mean |     Error |    StdDev |        Op/s |  Gen 0 | Allocated |
------------------- |--------------- |------------ |------------:|----------:|----------:|------------:|-------:|----------:|
 WriteSingleMessage |   FewArguments |     MsgPack |  1,630.4 ns |  32.49 ns |  83.86 ns |   613,359.9 | 0.0038 |     520 B |
 WriteSingleMessage | LargeArguments |     MsgPack | 20,307.1 ns | 405.71 ns | 721.14 ns |    49,243.9 | 0.7019 |   61896 B |
 WriteSingleMessage |  ManyArguments |     MsgPack |  3,013.0 ns |  59.57 ns | 102.75 ns |   331,900.1 | 0.0076 |     792 B |
 WriteSingleMessage |    NoArguments |     MsgPack |    687.4 ns |  13.54 ns |  25.43 ns | 1,454,798.5 | 0.0029 |     272 B |
```