### PR TITLE
fix #1815 by disposing linked cts

### DIFF
--- a/clients/ts/FunctionalTests/ts/HubConnectionTests.ts
+++ b/clients/ts/FunctionalTests/ts/HubConnectionTests.ts
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 import { HubConnection, IHubConnectionOptions, JsonHubProtocol, LogLevel, TransportType } from "@aspnet/signalr";
@@ -166,7 +166,7 @@ describe("hubConnection", () => {
                         // exception expected but none thrown
                         fail();
                     }).catch((e) => {
-                        expect(e.message).toBe("The client attempted to invoke the streaming 'EmptyStream' method in a non-streaming fashion.");
+                        expect(e.message).toBe("The client attempted to invoke the streaming 'EmptyStream' method with a non-streaming invocation.");
                     }).then(() => {
                         return hubConnection.stop();
                     }).then(() => {
@@ -190,7 +190,7 @@ describe("hubConnection", () => {
                         // exception expected but none thrown
                         fail();
                     }).catch((e) => {
-                        expect(e.message).toBe("The client attempted to invoke the streaming 'Stream' method in a non-streaming fashion.");
+                        expect(e.message).toBe("The client attempted to invoke the streaming 'Stream' method with a non-streaming invocation.");
                     }).then(() => {
                         return hubConnection.stop();
                     }).then(() => {
@@ -246,7 +246,7 @@ describe("hubConnection", () => {
                             fail();
                         },
                         error: function error(err) {
-                            expect(err.message).toEqual("The client attempted to invoke the non-streaming 'Echo' method in a streaming fashion.");
+                            expect(err.message).toEqual("The client attempted to invoke the non-streaming 'Echo' method with a streaming invocation.");
                             hubConnection.stop();
                             done();
                         },

--- a/clients/ts/FunctionalTests/ts/HubConnectionTests.ts
+++ b/clients/ts/FunctionalTests/ts/HubConnectionTests.ts
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 import { HubConnection, IHubConnectionOptions, JsonHubProtocol, LogLevel, TransportType } from "@aspnet/signalr";

--- a/src/Microsoft.AspNetCore.SignalR.Core/Internal/DefaultHubDispatcher.Log.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/Internal/DefaultHubDispatcher.Log.cs
@@ -49,10 +49,10 @@ namespace Microsoft.AspNetCore.SignalR.Internal
                 LoggerMessage.Define<StreamInvocationMessage>(LogLevel.Debug, new EventId(12, "ReceivedStreamHubInvocation"), "Received stream hub invocation: {InvocationMessage}.");
 
             private static readonly Action<ILogger, HubMethodInvocationMessage, Exception> _streamingMethodCalledWithInvoke =
-                LoggerMessage.Define<HubMethodInvocationMessage>(LogLevel.Error, new EventId(13, "StreamingMethodCalledWithInvoke"), "A streaming method was invoked in the non-streaming fashion : {InvocationMessage}.");
+                LoggerMessage.Define<HubMethodInvocationMessage>(LogLevel.Error, new EventId(13, "StreamingMethodCalledWithInvoke"), "A streaming method was invoked with a non-streaming invocation : {InvocationMessage}.");
 
             private static readonly Action<ILogger, HubMethodInvocationMessage, Exception> _nonStreamingMethodCalledWithStream =
-                LoggerMessage.Define<HubMethodInvocationMessage>(LogLevel.Error, new EventId(14, "NonStreamingMethodCalledWithStream"), "A non-streaming method was invoked in the streaming fashion : {InvocationMessage}.");
+                LoggerMessage.Define<HubMethodInvocationMessage>(LogLevel.Error, new EventId(14, "NonStreamingMethodCalledWithStream"), "A non-streaming method was invoked with a streaming invocation : {InvocationMessage}.");
 
             private static readonly Action<ILogger, string, Exception> _invalidReturnValueFromStreamingMethod =
                 LoggerMessage.Define<string>(LogLevel.Error, new EventId(15, "InvalidReturnValueFromStreamingMethod"), "A streaming method returned a value that cannot be used to build enumerator {HubMethod}.");

--- a/src/Microsoft.AspNetCore.SignalR.Core/Internal/DefaultHubDispatcher.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/Internal/DefaultHubDispatcher.cs
@@ -193,7 +193,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal
 
                     if (isStreamedInvocation)
                     {
-                        if (!TryGetStreamingEnumerator(connection, hubMethodInvocationMessage.InvocationId, descriptor, result, out var enumerator, out var cts))
+                        if (!TryGetStreamingEnumerator(connection, hubMethodInvocationMessage.InvocationId, descriptor, result, out var enumerator, out var streamCts))
                         {
                             Log.InvalidReturnValueFromStreamingMethod(_logger, methodExecutor.MethodInfo.Name);
 
@@ -203,7 +203,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal
                         }
 
                         Log.StreamingResult(_logger, hubMethodInvocationMessage.InvocationId, methodExecutor);
-                        await StreamResultsAsync(hubMethodInvocationMessage.InvocationId, connection, enumerator, cts);
+                        await StreamResultsAsync(hubMethodInvocationMessage.InvocationId, connection, enumerator, streamCts);
                     }
                     // Non-empty/null InvocationId ==> Blocking invocation that needs a response
                     else if (!string.IsNullOrEmpty(hubMethodInvocationMessage.InvocationId))
@@ -358,35 +358,35 @@ namespace Microsoft.AspNetCore.SignalR.Internal
             return true;
         }
 
-        private bool TryGetStreamingEnumerator(HubConnectionContext connection, string invocationId, HubMethodDescriptor hubMethodDescriptor, object result, out IAsyncEnumerator<object> enumerator, out CancellationTokenSource cts)
+        private bool TryGetStreamingEnumerator(HubConnectionContext connection, string invocationId, HubMethodDescriptor hubMethodDescriptor, object result, out IAsyncEnumerator<object> enumerator, out CancellationTokenSource streamCts)
         {
             if (result != null)
             {
                 if (hubMethodDescriptor.IsObservable)
                 {
-                    cts = CreateCancellation();
-                    enumerator = hubMethodDescriptor.FromObservable(result, cts.Token);
+                    streamCts = CreateCancellation();
+                    enumerator = hubMethodDescriptor.FromObservable(result, streamCts.Token);
                     return true;
                 }
 
                 if (hubMethodDescriptor.IsChannel)
                 {
-                    cts = CreateCancellation();
-                    enumerator = hubMethodDescriptor.FromChannel(result, cts.Token);
+                    streamCts = CreateCancellation();
+                    enumerator = hubMethodDescriptor.FromChannel(result, streamCts.Token);
                     return true;
                 }
             }
 
-            cts = null;
+            streamCts = null;
             enumerator = null;
             return false;
 
             CancellationTokenSource CreateCancellation()
             {
-                var streamCts = new CancellationTokenSource();
-                connection.ActiveRequestCancellationSources.TryAdd(invocationId, streamCts);
+                var userCts = new CancellationTokenSource();
+                connection.ActiveRequestCancellationSources.TryAdd(invocationId, userCts);
 
-                return CancellationTokenSource.CreateLinkedTokenSource(connection.ConnectionAborted, streamCts.Token);
+                return CancellationTokenSource.CreateLinkedTokenSource(connection.ConnectionAborted, userCts.Token);
             }
         }
 

--- a/src/Microsoft.AspNetCore.SignalR.Core/Internal/DefaultHubDispatcher.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/Internal/DefaultHubDispatcher.cs
@@ -259,6 +259,8 @@ namespace Microsoft.AspNetCore.SignalR.Internal
             }
             finally
             {
+                (enumerator as IDisposable)?.Dispose();
+
                 // Dispose the linked CTS for the stream.
                 streamCts.Dispose();
 
@@ -340,7 +342,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal
                 {
                     Log.StreamingMethodCalledWithInvoke(_logger, hubMethodInvocationMessage);
                     await connection.WriteAsync(CompletionMessage.WithError(hubMethodInvocationMessage.InvocationId,
-                        $"The client attempted to invoke the streaming '{hubMethodInvocationMessage.Target}' with a non-streaming invocation."));
+                        $"The client attempted to invoke the streaming '{hubMethodInvocationMessage.Target}' method with a non-streaming invocation."));
                 }
 
                 return false;
@@ -350,7 +352,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal
             {
                 Log.NonStreamingMethodCalledWithStream(_logger, hubMethodInvocationMessage);
                 await connection.WriteAsync(CompletionMessage.WithError(hubMethodInvocationMessage.InvocationId,
-                    $"The client attempted to invoke the non-streaming '{hubMethodInvocationMessage.Target}' with a streaming invocation."));
+                    $"The client attempted to invoke the non-streaming '{hubMethodInvocationMessage.Target}' method with a streaming invocation."));
 
                 return false;
             }

--- a/src/Microsoft.AspNetCore.SignalR.Core/Internal/DefaultHubDispatcher.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/Internal/DefaultHubDispatcher.cs
@@ -264,7 +264,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal
                 // Dispose the linked CTS for the stream.
                 streamCts.Dispose();
 
-                await connection.WriteAsync(new CompletionMessage(invocationId, error: error, result: null, hasResult: false));
+                await connection.WriteAsync(CompletionMessage.WithError(invocationId, error));
 
                 if (connection.ActiveRequestCancellationSources.TryRemove(invocationId, out var cts))
                 {

--- a/src/Microsoft.AspNetCore.SignalR.Core/Internal/DefaultHubDispatcher.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/Internal/DefaultHubDispatcher.cs
@@ -340,7 +340,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal
                 {
                     Log.StreamingMethodCalledWithInvoke(_logger, hubMethodInvocationMessage);
                     await connection.WriteAsync(CompletionMessage.WithError(hubMethodInvocationMessage.InvocationId,
-                        $"The client attempted to invoke the streaming '{hubMethodInvocationMessage.Target}' using a non-streaming invocation."));
+                        $"The client attempted to invoke the streaming '{hubMethodInvocationMessage.Target}' with a non-streaming invocation."));
                 }
 
                 return false;
@@ -350,7 +350,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal
             {
                 Log.NonStreamingMethodCalledWithStream(_logger, hubMethodInvocationMessage);
                 await connection.WriteAsync(CompletionMessage.WithError(hubMethodInvocationMessage.InvocationId,
-                    $"The client attempted to invoke the non-streaming '{hubMethodInvocationMessage.Target}' using a streaming invocation."));
+                    $"The client attempted to invoke the non-streaming '{hubMethodInvocationMessage.Target}' with a streaming invocation."));
 
                 return false;
             }

--- a/src/Microsoft.AspNetCore.SignalR.Core/Internal/HubMethodDescriptor.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/Internal/HubMethodDescriptor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/Microsoft.AspNetCore.SignalR.Core/Internal/HubMethodDescriptor.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/Internal/HubMethodDescriptor.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/HubConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/HubConnectionTests.cs
@@ -618,7 +618,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
                     await connection.StartAsync().OrTimeout();
                     var channel = await connection.StreamAsChannelAsync<int>("HelloWorld").OrTimeout();
                     var ex = await Assert.ThrowsAsync<HubException>(() => channel.ReadAllAsync()).OrTimeout();
-                    Assert.Equal("The client attempted to invoke the non-streaming 'HelloWorld' method in a streaming fashion.", ex.Message);
+                    Assert.Equal("The client attempted to invoke the non-streaming 'HelloWorld' method with a streaming invocation.", ex.Message);
                 }
                 catch (Exception ex)
                 {
@@ -645,7 +645,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
                     await connection.StartAsync().OrTimeout();
 
                     var ex = await Assert.ThrowsAsync<HubException>(() => connection.InvokeAsync("Stream", 3)).OrTimeout();
-                    Assert.Equal("The client attempted to invoke the streaming 'Stream' method in a non-streaming fashion.", ex.Message);
+                    Assert.Equal("The client attempted to invoke the streaming 'Stream' method with a non-streaming invocation.", ex.Message);
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
Snapshots taken immediately before a streaming invocation, then immediate after it completes. Compared memory traffic between the snapshots.

Before:

![before](https://user-images.githubusercontent.com/7574/38328938-14a5e8bc-3801-11e8-9cfb-ff02c4908f5b.png)

After:

![after](https://user-images.githubusercontent.com/7574/38328947-1853c8b2-3801-11e8-972e-99ee7cdb8757.png)

Fixes #1815 