### PR TITLE
Found these while looking at a flaky test

### DIFF
--- a/src/Microsoft.AspNetCore.Http.Connections.Client/Internal/WebSocketsTransport.cs
+++ b/src/Microsoft.AspNetCore.Http.Connections.Client/Internal/WebSocketsTransport.cs
@@ -354,6 +354,10 @@ namespace Microsoft.AspNetCore.Http.Connections.Client.Internal
                 // exceptions have been handled in the Running task continuation by closing the channel with the exception
                 return;
             }
+            finally
+            {
+                _webSocket.Dispose();
+            }
 
             Log.TransportStopped(_logger, null);
         }

--- a/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/HubConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/HubConnectionTests.cs
@@ -182,9 +182,9 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
                     }
                     catch (Exception ex)
                     {
-                            // It's important to try catch here since this happens
-                            // on a thread pool thread
-                            restartTcs.TrySetException(ex);
+                        // It's important to try catch here since this happens
+                        // on a thread pool thread
+                        restartTcs.TrySetException(ex);
                     }
                 };
 

--- a/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/HubConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.FunctionalTests/HubConnectionTests.cs
@@ -169,13 +169,22 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
                 var restartTcs = new TaskCompletionSource<object>();
                 connection.Closed += async e =>
                 {
-                    logger.LogInformation("Closed event triggered");
-                    if (!restartTcs.Task.IsCompleted)
+                    try
                     {
-                        logger.LogInformation("Restarting connection");
-                        await connection.StartAsync().OrTimeout();
-                        logger.LogInformation("Restarted connection");
-                        restartTcs.SetResult(null);
+                        logger.LogInformation("Closed event triggered");
+                        if (!restartTcs.Task.IsCompleted)
+                        {
+                            logger.LogInformation("Restarting connection");
+                            await connection.StartAsync().OrTimeout();
+                            logger.LogInformation("Restarted connection");
+                            restartTcs.SetResult(null);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                            // It's important to try catch here since this happens
+                            // on a thread pool thread
+                            restartTcs.TrySetException(ex);
                     }
                 };
 


### PR DESCRIPTION
- Stop test from crashing when errors happen on a thread pool thread (we Task.Run the closed event), so this is async void
- Dispose the ClientWebSocket