### PR TITLE
Don't throw from Observer's OnNext

### DIFF
--- a/src/Microsoft.AspNetCore.SignalR.Core/Internal/AsyncEnumeratorAdapters.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/Internal/AsyncEnumeratorAdapters.cs
@@ -62,8 +62,8 @@ namespace Microsoft.AspNetCore.SignalR.Internal
                     // Wait for a spot
                     if (!_output.WaitToWriteAsync(_cancellationToken).Result)
                     {
-                        // Channel was closed.
-                        throw new InvalidOperationException("Output channel was closed");
+                        // Channel was closed so we just no-op. The observer shouldn't throw.
+                        return;
                     }
                 }
             }

--- a/test/Microsoft.AspNetCore.SignalR.Tests/HubConnectionHandlerTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/HubConnectionHandlerTests.cs
@@ -184,9 +184,10 @@ namespace Microsoft.AspNetCore.SignalR.Tests
 
                 observable.Complete();
 
+                await subscribeTask.OrTimeout();
+                
                 // Disposing the client to complete the observer. Further calls to OnNext should no-op
                 client.Dispose();
-                await subscribeTask.OrTimeout();
 
                 // Calling OnNext after the client has disconnected shouldn't throw.
                 observable.OnNext(1);

--- a/test/Microsoft.AspNetCore.SignalR.Tests/HubConnectionHandlerTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/HubConnectionHandlerTests.cs
@@ -188,7 +188,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                 client.Dispose();
                 await subscribeTask.OrTimeout();
 
-                // Calling OnNext after the client has disconnected shouln't throw.
+                // Calling OnNext after the client has disconnected shouldn't throw.
                 observable.OnNext(1);
 
                 await waitForDispose.Task.OrTimeout();

--- a/test/Microsoft.AspNetCore.SignalR.Tests/HubConnectionHandlerTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/HubConnectionHandlerTests.cs
@@ -171,7 +171,6 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             {
                 var connectionHandlerTask = await client.ConnectAsync(connectionHandler);
 
-
                 var subscribeTask = client.StreamAsync(nameof(ObservableHub.Subscribe));
 
                 await waitForSubscribe.Task.OrTimeout();

--- a/test/Microsoft.AspNetCore.SignalR.Tests/HubConnectionHandlerTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/HubConnectionHandlerTests.cs
@@ -177,10 +177,10 @@ namespace Microsoft.AspNetCore.SignalR.Tests
 
                     var items = results.OfType<StreamItemMessage>().ToList();
 
+                    // Ensuring that only the call before OnCompleted actually did anything.
                     Assert.Single(items);
                     Assert.Equal(1, (long)items[0].Item);
                 }
-
 
                 var subscribeTask = Subscribe();
 

--- a/test/Microsoft.AspNetCore.SignalR.Tests/HubConnectionHandlerTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/HubConnectionHandlerTests.cs
@@ -171,21 +171,13 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             {
                 var connectionHandlerTask = await client.ConnectAsync(connectionHandler);
 
-                async Task Subscribe()
-                {
-                    var results = await client.StreamAsync(nameof(ObservableHub.Subscribe));
-                }
 
-                var subscribeTask = Subscribe();
+                var subscribeTask = client.StreamAsync(nameof(ObservableHub.Subscribe));
 
                 await waitForSubscribe.Task.OrTimeout();
 
                 Assert.Single(observable.Observers);
 
-                observable.Complete();
-
-                await subscribeTask.OrTimeout();
-                
                 // Disposing the client to complete the observer. Further calls to OnNext should no-op
                 client.Dispose();
 


### PR DESCRIPTION
We shouldn't be throwing from the Observer. If `OnNext` is called after the underlying channel is completed then it should just no-op.
Issue : https://github.com/aspnet/SignalR/issues/1032
