### PR TITLE
fix #1874 by adding RedisProtocolBenchmark

### DIFF
--- a/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/RedisProtocolBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/RedisProtocolBenchmark.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.SignalR.Internal;
+using Microsoft.AspNetCore.SignalR.Internal.Protocol;
+using Microsoft.AspNetCore.SignalR.Redis.Internal;
+
+namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
+{
+    public class RedisProtocolBenchmark
+    {
+        private RedisProtocol _protocol;
+        private RedisGroupCommand _groupCommand;
+        private object[] _args;
+        private string _methodName;
+        private IReadOnlyList<string> _excludedIdsSmall;
+        private IReadOnlyList<string> _excludedIdsLarge;
+        private byte[] _writtenAck;
+        private byte[] _writtenGroupCommand;
+        private byte[] _writtenInvocationNoExclusions;
+        private byte[] _writtenInvocationSmallExclusions;
+        private byte[] _writtenInvocationLargeExclusions;
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            _protocol = new RedisProtocol(new [] {
+                new DummyProtocol("protocol1"),
+                new DummyProtocol("protocol2")
+            });
+
+            _groupCommand = new RedisGroupCommand(id: 42, serverName: "Server", GroupAction.Add, groupName: "group", connectionId: "connection");
+
+            // Because of the DummyProtocol, the args don't really matter
+            _args = Array.Empty<object>();
+            _methodName = "Method";
+
+            _excludedIdsSmall = GenerateIds(2);
+            _excludedIdsLarge = GenerateIds(20);
+
+            _writtenAck = _protocol.WriteAck(42);
+            _writtenGroupCommand = _protocol.WriteGroupCommand(_groupCommand);
+            _writtenInvocationNoExclusions = _protocol.WriteInvocation(_methodName, _args, null);
+            _writtenInvocationSmallExclusions = _protocol.WriteInvocation(_methodName, _args, _excludedIdsSmall);
+            _writtenInvocationLargeExclusions = _protocol.WriteInvocation(_methodName, _args, _excludedIdsLarge);
+        }
+
+        [Benchmark]
+        public void WriteAck()
+        {
+            _protocol.WriteAck(42);
+        }
+
+        [Benchmark]
+        public void WriteGroupCommand()
+        {
+            _protocol.WriteGroupCommand(_groupCommand);
+        }
+
+        [Benchmark]
+        public void WriteInvocationNoExclusions()
+        {
+            _protocol.WriteInvocation(_methodName, _args);
+        }
+
+        [Benchmark]
+        public void WriteInvocationSmallExclusions()
+        {
+            _protocol.WriteInvocation(_methodName, _args, _excludedIdsSmall);
+        }
+
+        [Benchmark]
+        public void WriteInvocationLargeExclusions()
+        {
+            _protocol.WriteInvocation(_methodName, _args, _excludedIdsLarge);
+        }
+
+        [Benchmark]
+        public void ReadAck()
+        {
+            _protocol.ReadAck(_writtenAck);
+        }
+
+        [Benchmark]
+        public void ReadGroupCommand()
+        {
+            _protocol.ReadGroupCommand(_writtenGroupCommand);
+        }
+
+        [Benchmark]
+        public void ReadInvocationNoExclusions()
+        {
+            _protocol.ReadInvocation(_writtenInvocationNoExclusions);
+        }
+
+        [Benchmark]
+        public void ReadInvocationSmallExclusions()
+        {
+            _protocol.ReadInvocation(_writtenInvocationSmallExclusions);
+        }
+
+        [Benchmark]
+        public void ReadInvocationLargeExclusions()
+        {
+            _protocol.ReadInvocation(_writtenInvocationLargeExclusions);
+        }
+
+        private static IReadOnlyList<string> GenerateIds(int count)
+        {
+            var ids = new string[count];
+            for(var i = 0; i < count; i++)
+            {
+                ids[i] = Guid.NewGuid().ToString("N");
+            }
+            return ids;
+        }
+
+        private class DummyProtocol: IHubProtocol
+        {
+            private static byte[] _fixedOutput = new byte[] { 0x68, 0x68, 0x6C, 0x6C, 0x6F };
+
+            public string Name { get; }
+
+            public int Version => 1;
+
+            public TransferFormat TransferFormat => TransferFormat.Text;
+
+            public DummyProtocol(string name)
+            {
+                Name = name;
+            }
+
+            public bool IsVersionSupported(int version) => true;
+
+            public bool TryParseMessage(ref ReadOnlySequence<byte> input, IInvocationBinder binder, out HubMessage message)
+            {
+                throw new NotSupportedException();
+            }
+
+            public void WriteMessage(HubMessage message, IBufferWriter<byte> output)
+            {
+                output.Write(_fixedOutput);
+            }
+        }
+    }
+}


### PR DESCRIPTION
```
                         Method |        Mean |     Error |     StdDev |         Op/s |  Gen 0 | Allocated |
------------------------------- |------------:|----------:|-----------:|-------------:|-------:|----------:|
                       WriteAck |   147.86 ns |  2.982 ns |   8.214 ns |  6,763,261.9 | 0.0024 |     544 B |
              WriteGroupCommand |   381.90 ns |  7.421 ns |   9.907 ns |  2,618,511.5 | 0.0038 |     848 B |
    WriteInvocationNoExclusions |   870.29 ns | 17.913 ns |  44.610 ns |  1,149,048.1 | 0.0048 |    1008 B |
 WriteInvocationSmallExclusions | 1,052.07 ns | 20.938 ns |  47.685 ns |    950,508.3 | 0.0038 |    1112 B |
 WriteInvocationLargeExclusions | 2,958.82 ns | 58.909 ns | 110.646 ns |    337,972.3 | 0.0153 |    3288 B |
                        ReadAck |    83.82 ns |  1.707 ns |   4.757 ns | 11,930,872.5 | 0.0011 |     240 B |
               ReadGroupCommand |   377.62 ns |  7.532 ns |  16.690 ns |  2,648,140.3 | 0.0038 |     808 B |
     ReadInvocationNoExclusions |   414.16 ns |  8.299 ns |  17.138 ns |  2,414,552.5 | 0.0043 |     904 B |
  ReadInvocationSmallExclusions |   598.69 ns | 11.996 ns |  18.677 ns |  1,670,301.0 | 0.0048 |    1136 B |
  ReadInvocationLargeExclusions | 2,116.26 ns | 41.075 ns |  53.410 ns |    472,530.8 | 0.0114 |    3008 B |
```