### PR TITLE
Fix graceful closing of pipes

### DIFF
--- a/src/Microsoft.AspNetCore.Http.Connections/HttpConnectionManager.cs
+++ b/src/Microsoft.AspNetCore.Http.Connections/HttpConnectionManager.cs
@@ -135,7 +135,7 @@ namespace Microsoft.AspNetCore.Http.Connections
                 }
 
                 // Pause the timer while we're running
-                _timer.Change(Timeout.Infinite, Timeout.Infinite);
+                _timer?.Change(Timeout.Infinite, Timeout.Infinite);
 
                 // Time the scan so we know if it gets slower than 1sec
                 var timer = ValueStopwatch.StartNew();
@@ -169,7 +169,11 @@ namespace Microsoft.AspNetCore.Http.Connections
                     {
                         Log.ConnectionTimedOut(_logger, connection.ConnectionId);
                         HttpConnectionsEventSource.Log.ConnectionTimedOut(connection.ConnectionId);
-                        var ignore = DisposeAndRemoveAsync(connection);
+
+                        // This is most likely a long polling connection. The transport here ends because
+                        // a poll completed and has been inactive for > 5 seconds so we wait for the 
+                        // application to finish gracefully
+                        _ = DisposeAndRemoveAsync(connection, closeGracefully: true);
                     }
                     else
                     {
@@ -184,7 +188,7 @@ namespace Microsoft.AspNetCore.Http.Connections
                 Log.ScannedConnections(_logger, elapsed);
 
                 // Resume once we finished processing all connections
-                _timer.Change(_heartbeatTickRate, _heartbeatTickRate);
+                _timer?.Change(_heartbeatTickRate, _heartbeatTickRate);
             }
             finally
             {
@@ -209,20 +213,23 @@ namespace Microsoft.AspNetCore.Http.Connections
 
                 var tasks = new List<Task>();
 
+                // REVIEW: In the future we can consider a hybrid where we first try to wait for shutdown
+                // for a certain time frame then after some grace period we shutdown more aggressively
                 foreach (var c in _connections)
                 {
-                    tasks.Add(DisposeAndRemoveAsync(c.Value.Connection));
+                    // We're shutting down so don't wait for closing the application
+                    tasks.Add(DisposeAndRemoveAsync(c.Value.Connection, closeGracefully: false));
                 }
 
                 Task.WaitAll(tasks.ToArray(), TimeSpan.FromSeconds(5));
             }
         }
 
-        public async Task DisposeAndRemoveAsync(HttpConnectionContext connection)
+        public async Task DisposeAndRemoveAsync(HttpConnectionContext connection, bool closeGracefully)
         {
             try
             {
-                await connection.DisposeAsync();
+                await connection.DisposeAsync(closeGracefully);
             }
             catch (IOException ex)
             {

--- a/src/Microsoft.AspNetCore.Http.Connections/HttpConnectionManager.cs
+++ b/src/Microsoft.AspNetCore.Http.Connections/HttpConnectionManager.cs
@@ -84,7 +84,7 @@ namespace Microsoft.AspNetCore.Http.Connections
 
             Log.CreatedNewConnection(_logger, id);
             var connectionTimer = HttpConnectionsEventSource.Log.ConnectionStart(id);
-            var connection = new HttpConnectionContext(id);
+            var connection = new HttpConnectionContext(id, _connectionLogger);
             var pair = DuplexPipe.CreateConnectionPair(transportPipeOptions, appPipeOptions);
             connection.Transport = pair.Application;
             connection.Application = pair.Transport;
@@ -231,7 +231,7 @@ namespace Microsoft.AspNetCore.Http.Connections
         {
             try
             {
-                await connection.DisposeAsync(closeGracefully, _connectionLogger);
+                await connection.DisposeAsync(closeGracefully);
             }
             catch (IOException ex)
             {

--- a/test/Microsoft.AspNetCore.Http.Connections.Tests/HttpConnectionDispatcherTests.cs
+++ b/test/Microsoft.AspNetCore.Http.Connections.Tests/HttpConnectionDispatcherTests.cs
@@ -106,6 +106,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                 var dispatcher = new HttpConnectionDispatcher(manager, loggerFactory);
                 var pipeOptions = new PipeOptions(pauseWriterThreshold: 8, resumeWriterThreshold: 4);
                 var connection = manager.CreateConnection(pipeOptions, pipeOptions);
+                connection.TransportType = transportType;
                 connection.Items[ConnectionMetadataNames.Transport] = transportType;
 
                 using (var requestBody = new MemoryStream())
@@ -263,6 +264,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                 var manager = CreateConnectionManager(loggerFactory);
                 var dispatcher = new HttpConnectionDispatcher(manager, loggerFactory);
                 var connection = manager.CreateConnection();
+                connection.TransportType = HttpTransportType.WebSockets;
                 connection.Items[ConnectionMetadataNames.Transport] = HttpTransportType.WebSockets;
 
                 using (var strm = new MemoryStream())
@@ -300,6 +302,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                 var manager = CreateConnectionManager(loggerFactory);
                 var dispatcher = new HttpConnectionDispatcher(manager, loggerFactory);
                 var connection = manager.CreateConnection();
+                connection.TransportType = HttpTransportType.LongPolling;
                 connection.Items[ConnectionMetadataNames.Transport] = HttpTransportType.LongPolling;
                 await connection.DisposeAsync(closeGracefully: false);
 
@@ -338,6 +341,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                 var manager = CreateConnectionManager(loggerFactory);
                 var dispatcher = new HttpConnectionDispatcher(manager, loggerFactory);
                 var connection = manager.CreateConnection();
+                connection.TransportType = transportType;
+                connection.Items[ConnectionMetadataNames.Transport] = transportType;
 
                 using (var strm = new MemoryStream())
                 {
@@ -398,6 +403,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                 var manager = CreateConnectionManager(loggerFactory);
                 var dispatcher = new HttpConnectionDispatcher(manager, loggerFactory);
                 var connection = manager.CreateConnection();
+                connection.TransportType = HttpTransportType.LongPolling;
+                connection.Items[ConnectionMetadataNames.Transport] = HttpTransportType.LongPolling;
 
                 using (var strm = new MemoryStream())
                 {
@@ -460,6 +467,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                 var manager = CreateConnectionManager(loggerFactory);
                 var dispatcher = new HttpConnectionDispatcher(manager, loggerFactory);
                 var connection = manager.CreateConnection();
+                connection.TransportType = transportType;
                 connection.Items[ConnectionMetadataNames.Transport] = transportType;
 
                 using (var requestBody = new MemoryStream())
@@ -506,6 +514,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                 var manager = CreateConnectionManager(loggerFactory);
                 var dispatcher = new HttpConnectionDispatcher(manager, loggerFactory);
                 var connection = manager.CreateConnection();
+                connection.TransportType = transportType;
                 connection.Items[ConnectionMetadataNames.Transport] = transportType;
 
                 // Allow a maximum of one caller to use code at one time
@@ -591,6 +600,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                 var manager = CreateConnectionManager(loggerFactory);
                 var dispatcher = new HttpConnectionDispatcher(manager, loggerFactory);
                 var connection = manager.CreateConnection();
+                connection.TransportType = HttpTransportType.LongPolling;
+                connection.Items[ConnectionMetadataNames.Transport] = HttpTransportType.LongPolling;
 
                 using (var requestBody = new MemoryStream())
                 using (var responseBody = new MemoryStream())
@@ -789,6 +800,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
             {
                 var manager = CreateConnectionManager(loggerFactory);
                 var connection = manager.CreateConnection();
+                connection.TransportType = HttpTransportType.ServerSentEvents;
+                connection.Items[ConnectionMetadataNames.Transport] = HttpTransportType.ServerSentEvents;
 
                 var dispatcher = new HttpConnectionDispatcher(manager, loggerFactory);
 
@@ -816,6 +829,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
             {
                 var manager = CreateConnectionManager(loggerFactory);
                 var connection = manager.CreateConnection();
+                connection.TransportType = HttpTransportType.ServerSentEvents;
+                connection.Items[ConnectionMetadataNames.Transport] = HttpTransportType.ServerSentEvents;
 
                 var dispatcher = new HttpConnectionDispatcher(manager, loggerFactory);
                 var context = MakeRequest("/foo", connection);
@@ -842,6 +857,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
             {
                 var manager = CreateConnectionManager(loggerFactory);
                 var connection = manager.CreateConnection();
+                connection.TransportType = HttpTransportType.LongPolling;
+                connection.Items[ConnectionMetadataNames.Transport] = HttpTransportType.LongPolling;
 
                 var dispatcher = new HttpConnectionDispatcher(manager, loggerFactory);
 
@@ -868,6 +885,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
             {
                 var manager = CreateConnectionManager(loggerFactory);
                 var connection = manager.CreateConnection();
+                connection.TransportType = HttpTransportType.LongPolling;
+                connection.Items[ConnectionMetadataNames.Transport] = HttpTransportType.LongPolling;
 
                 var dispatcher = new HttpConnectionDispatcher(manager, loggerFactory);
 
@@ -893,6 +912,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
             {
                 var manager = CreateConnectionManager(loggerFactory);
                 var connection = manager.CreateConnection();
+                connection.TransportType = HttpTransportType.WebSockets;
+                connection.Items[ConnectionMetadataNames.Transport] = HttpTransportType.WebSockets;
 
                 var dispatcher = new HttpConnectionDispatcher(manager, loggerFactory);
 
@@ -922,6 +943,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
             {
                 var manager = CreateConnectionManager(loggerFactory);
                 var connection = manager.CreateConnection();
+                connection.TransportType = transportType;
+                connection.Items[ConnectionMetadataNames.Transport] = transportType;
 
                 var dispatcher = new HttpConnectionDispatcher(manager, loggerFactory);
 
@@ -964,6 +987,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
             {
                 var manager = CreateConnectionManager(loggerFactory);
                 var connection = manager.CreateConnection();
+                connection.TransportType = HttpTransportType.LongPolling;
+                connection.Items[ConnectionMetadataNames.Transport] = HttpTransportType.LongPolling;
 
                 var dispatcher = new HttpConnectionDispatcher(manager, loggerFactory);
 
@@ -1001,6 +1026,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
             {
                 var manager = CreateConnectionManager(loggerFactory);
                 var connection = manager.CreateConnection();
+                connection.TransportType = transportType;
+                connection.Items[ConnectionMetadataNames.Transport] = transportType;
                 connection.Status = HttpConnectionContext.ConnectionStatus.Disposed;
 
                 var dispatcher = new HttpConnectionDispatcher(manager, loggerFactory);
@@ -1028,6 +1055,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
             {
                 var manager = CreateConnectionManager(loggerFactory);
                 var connection = manager.CreateConnection();
+                connection.TransportType = HttpTransportType.LongPolling;
+                connection.Items[ConnectionMetadataNames.Transport] = HttpTransportType.LongPolling;
 
                 var dispatcher = new HttpConnectionDispatcher(manager, loggerFactory);
 
@@ -1062,6 +1091,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
             {
                 var manager = CreateConnectionManager(loggerFactory);
                 var connection = manager.CreateConnection();
+                connection.TransportType = HttpTransportType.ServerSentEvents;
+                connection.Items[ConnectionMetadataNames.Transport] = HttpTransportType.ServerSentEvents;
 
                 var dispatcher = new HttpConnectionDispatcher(manager, loggerFactory);
 
@@ -1096,6 +1127,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
             {
                 var manager = CreateConnectionManager(loggerFactory);
                 var connection = manager.CreateConnection();
+                connection.TransportType = HttpTransportType.LongPolling;
+                connection.Items[ConnectionMetadataNames.Transport] = HttpTransportType.LongPolling;
 
                 var dispatcher = new HttpConnectionDispatcher(manager, loggerFactory);
 
@@ -1129,6 +1162,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
             {
                 var manager = CreateConnectionManager(loggerFactory);
                 var connection = manager.CreateConnection();
+                connection.TransportType = HttpTransportType.LongPolling;
+                connection.Items[ConnectionMetadataNames.Transport] = HttpTransportType.LongPolling;
 
                 var dispatcher = new HttpConnectionDispatcher(manager, loggerFactory);
 
@@ -1170,6 +1205,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
             {
                 var manager = CreateConnectionManager(loggerFactory);
                 var connection = manager.CreateConnection();
+                connection.TransportType = transportType;
+                connection.Items[ConnectionMetadataNames.Transport] = transportType;
 
                 var dispatcher = new HttpConnectionDispatcher(manager, loggerFactory);
 
@@ -1201,6 +1238,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
             {
                 var manager = CreateConnectionManager(loggerFactory);
                 var connection = manager.CreateConnection();
+                connection.TransportType = HttpTransportType.LongPolling;
+                connection.Items[ConnectionMetadataNames.Transport] = HttpTransportType.LongPolling;
                 var dispatcher = new HttpConnectionDispatcher(manager, loggerFactory);
                 var context = new DefaultHttpContext();
                 var services = new ServiceCollection();
@@ -1246,6 +1285,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
             {
                 var manager = CreateConnectionManager(loggerFactory);
                 var connection = manager.CreateConnection();
+                connection.TransportType = HttpTransportType.LongPolling;
+                connection.Items[ConnectionMetadataNames.Transport] = HttpTransportType.LongPolling;
                 var dispatcher = new HttpConnectionDispatcher(manager, loggerFactory);
                 var context = new DefaultHttpContext();
                 var services = new ServiceCollection();
@@ -1293,6 +1334,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
             {
                 var manager = CreateConnectionManager(loggerFactory);
                 var connection = manager.CreateConnection();
+                connection.TransportType = HttpTransportType.LongPolling;
+                connection.Items[ConnectionMetadataNames.Transport] = HttpTransportType.LongPolling;
                 var dispatcher = new HttpConnectionDispatcher(manager, loggerFactory);
                 var context = new DefaultHttpContext();
                 context.Features.Set<IHttpResponseFeature>(new ResponseFeature());
@@ -1349,6 +1392,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
             {
                 var manager = CreateConnectionManager(loggerFactory);
                 var connection = manager.CreateConnection();
+                connection.TransportType = HttpTransportType.LongPolling;
+                connection.Items[ConnectionMetadataNames.Transport] = HttpTransportType.LongPolling;
                 var dispatcher = new HttpConnectionDispatcher(manager, loggerFactory);
                 var context = new DefaultHttpContext();
                 context.Features.Set<IHttpResponseFeature>(new ResponseFeature());
@@ -1430,6 +1475,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
             {
                 var manager = CreateConnectionManager(loggerFactory);
                 var connection = manager.CreateConnection();
+                connection.TransportType = HttpTransportType.LongPolling;
+                connection.Items[ConnectionMetadataNames.Transport] = HttpTransportType.LongPolling;
                 var dispatcher = new HttpConnectionDispatcher(manager, loggerFactory);
                 var context = new DefaultHttpContext();
                 context.Features.Set<IHttpResponseFeature>(new ResponseFeature());
@@ -1487,6 +1534,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
             {
                 var manager = CreateConnectionManager(loggerFactory);
                 var connection = manager.CreateConnection();
+                connection.TransportType = HttpTransportType.LongPolling;
+                connection.Items[ConnectionMetadataNames.Transport] = HttpTransportType.LongPolling;
                 var dispatcher = new HttpConnectionDispatcher(manager, loggerFactory);
                 var context = new DefaultHttpContext();
                 var services = new ServiceCollection();
@@ -1540,6 +1589,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
             {
                 var manager = CreateConnectionManager(loggerFactory);
                 var connection = manager.CreateConnection();
+                connection.TransportType = HttpTransportType.LongPolling;
+                connection.Items[ConnectionMetadataNames.Transport] = HttpTransportType.LongPolling;
 
                 var dispatcher = new HttpConnectionDispatcher(manager, loggerFactory);
 
@@ -1635,6 +1686,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
         {
             var manager = CreateConnectionManager(loggerFactory);
             var connection = manager.CreateConnection();
+            connection.TransportType = transportType;
+            connection.Items[ConnectionMetadataNames.Transport] = transportType;
             var dispatcher = new HttpConnectionDispatcher(manager, loggerFactory);
             using (var strm = new MemoryStream())
             {
@@ -1705,7 +1758,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
 
         private static HttpConnectionManager CreateConnectionManager(ILoggerFactory loggerFactory)
         {
-            return new HttpConnectionManager(new Logger<HttpConnectionManager>(loggerFactory ?? new LoggerFactory()), new EmptyApplicationLifetime());
+            return new HttpConnectionManager(loggerFactory ?? new LoggerFactory(), new EmptyApplicationLifetime());
         }
 
         private string GetContentAsString(Stream body)

--- a/test/Microsoft.AspNetCore.Http.Connections.Tests/HttpConnectionManagerTests.cs
+++ b/test/Microsoft.AspNetCore.Http.Connections.Tests/HttpConnectionManagerTests.cs
@@ -61,7 +61,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
             }
             catch
             {
-                // Ignore the exception that bubbles out of the failing ta
+                // Ignore the exception that bubbles out of the failing task
             }
 
             await Task.WhenAll(applicationInputTcs.Task, applicationOutputTcs.Task, transportInputTcs.Task, transportOutputTcs.Task).OrTimeout();

--- a/test/Microsoft.AspNetCore.Http.Connections.Tests/HttpConnectionManagerTests.cs
+++ b/test/Microsoft.AspNetCore.Http.Connections.Tests/HttpConnectionManagerTests.cs
@@ -281,7 +281,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
         private static HttpConnectionManager CreateConnectionManager(IApplicationLifetime lifetime = null)
         {
             lifetime = lifetime ?? new EmptyApplicationLifetime();
-            return new HttpConnectionManager(new Logger<HttpConnectionManager>(new LoggerFactory()), lifetime);
+            return new HttpConnectionManager(new LoggerFactory(), lifetime);
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Http.Connections.Tests/HttpConnectionManagerTests.cs
+++ b/test/Microsoft.AspNetCore.Http.Connections.Tests/HttpConnectionManagerTests.cs
@@ -75,11 +75,6 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                     // Wait for the application to end
                     var result = await connection.Transport.Input.ReadAsync();
                     connection.Transport.Input.AdvanceTo(result.Buffer.End);
-
-                    if (applicationFaulted)
-                    {
-                        throw new Exception("Transport failed");
-                    }
                 });
             }
             else


### PR DESCRIPTION
- Closing pipes gracefully in most cases. The only case where we forcefull close the pipes is during application shutdown
- Return 404 if sending to connection after disposal
- Added tests

Fixes #1758

Also ran the functional tests before and after and got logs:

https://gist.github.com/davidfowl/3792407c9015611848cdaad9575e41ef#file-before-log-L89-L109