### PR TITLE
Make baseUrl work again

### DIFF
--- a/samples/ClientSample/HubSample.cs
+++ b/samples/ClientSample/HubSample.cs
@@ -28,16 +28,25 @@ namespace ClientSample
 
         public static async Task<int> ExecuteAsync(string baseUrl)
         {
-            var endpoint = new IPEndPoint(IPAddress.Loopback, 9001);
-            Console.WriteLine("Connecting to {0}", endpoint);
-            var connection = new HubConnectionBuilder()
-                .WithEndPoint(endpoint)
+            var uri = baseUrl == null ? new Uri("net.tcp://127.0.0.1:9001") : new Uri(baseUrl);
+            Console.WriteLine("Connecting to {0}", uri);
+            var connectionBuilder = new HubConnectionBuilder()
                 .WithLogging(logging =>
                 {
                     logging.AddConsole();
                     logging.SetMinimumLevel(LogLevel.Trace);
-                })
-                .Build();
+                });
+
+            if (uri.Scheme == "net.tcp")
+            {
+                connectionBuilder.WithEndPoint(uri);
+            }
+            else
+            {
+                connectionBuilder.WithUrl(uri);
+            }
+
+            var connection = connectionBuilder.Build();
 
             try
             {
@@ -48,7 +57,7 @@ namespace ClientSample
 
                 await ConnectAsync(connection);
 
-                Console.WriteLine("Connected to {0}", endpoint);
+                Console.WriteLine("Connected to {0}", uri);
 
                 var sendCts = new CancellationTokenSource();
 

--- a/samples/ClientSample/Tcp/TcpHubConnectionBuilderExtensions.cs
+++ b/samples/ClientSample/Tcp/TcpHubConnectionBuilderExtensions.cs
@@ -9,7 +9,27 @@ namespace Microsoft.AspNetCore.SignalR.Client
 {
     public static class TcpHubConnectionBuilderExtensions
     {
-        public static IHubConnectionBuilder WithEndPoint(this IHubConnectionBuilder builder, IPEndPoint endPoint)
+        public static IHubConnectionBuilder WithEndPoint(this IHubConnectionBuilder builder, Uri uri)
+        {
+            if (!string.Equals(uri.Scheme, "net.tcp", StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException($"URI Scheme {uri.Scheme} not supported.");
+            }
+
+            IPEndPoint endPoint;
+            if (string.Equals(uri.Host, "localhost"))
+            {
+                endPoint = new IPEndPoint(IPAddress.Loopback, uri.Port);
+            }
+            else
+            {
+                endPoint = new IPEndPoint(IPAddress.Parse(uri.Host), uri.Port);
+            }
+
+            return builder.WithEndPoint(endPoint);
+        }
+
+        public static IHubConnectionBuilder WithEndPoint(this IHubConnectionBuilder builder, EndPoint endPoint)
         {
             builder.WithConnectionFactory(() => new TcpConnection(endPoint));
 


### PR DESCRIPTION
- The client sample can now switch between TCP and HTTP connection layer by URI scheme
- Support net.tcp URI scheme for the TCP connection

@BrennanConroy this is for you bro