### PR TITLE
Use in for ReadOnlySequence

### DIFF
--- a/samples/ClientSample/Tcp/SocketSender.cs
+++ b/samples/ClientSample/Tcp/SocketSender.cs
@@ -25,7 +25,7 @@ namespace ClientSample
             _eventArgs.Completed += (_, e) => ((SocketAwaitable)e.UserToken).Complete(e.BytesTransferred, e.SocketError);
         }
 
-        public SocketAwaitable SendAsync(ReadOnlySequence<byte> buffers)
+        public SocketAwaitable SendAsync(in ReadOnlySequence<byte> buffers)
         {
             if (buffers.IsSingleSegment)
             {
@@ -74,7 +74,7 @@ namespace ClientSample
             return _awaitable;
         }
 
-        private List<ArraySegment<byte>> GetBufferList(ReadOnlySequence<byte> buffer)
+        private List<ArraySegment<byte>> GetBufferList(in ReadOnlySequence<byte> buffer)
         {
             Debug.Assert(!buffer.IsEmpty);
             Debug.Assert(!buffer.IsSingleSegment);

--- a/src/Microsoft.AspNetCore.Http.Connections.Client/Internal/ServerSentEventsMessageParser.cs
+++ b/src/Microsoft.AspNetCore.Http.Connections.Client/Internal/ServerSentEventsMessageParser.cs
@@ -146,7 +146,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Client.Internal
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private ReadOnlySpan<byte> ConvertBufferToSpan(ReadOnlySequence<byte> buffer)
+        private ReadOnlySpan<byte> ConvertBufferToSpan(in ReadOnlySequence<byte> buffer)
         {
             if (buffer.IsSingleSegment)
             {

--- a/src/Microsoft.AspNetCore.Http.Connections.Client/SendUtils.cs
+++ b/src/Microsoft.AspNetCore.Http.Connections.Client/SendUtils.cs
@@ -92,7 +92,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
         {
             private readonly ReadOnlySequence<byte> _buffer;
 
-            public ReadOnlySequenceContent(ReadOnlySequence<byte> buffer)
+            public ReadOnlySequenceContent(in ReadOnlySequence<byte> buffer)
             {
                 _buffer = buffer;
             }

--- a/src/Microsoft.AspNetCore.Http.Connections/Internal/Transports/ServerSentEventsMessageFormatter.cs
+++ b/src/Microsoft.AspNetCore.Http.Connections/Internal/Transports/ServerSentEventsMessageFormatter.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
 
         private const byte LineFeed = (byte)'\n';
 
-        public static async Task WriteMessageAsync(ReadOnlySequence<byte> payload, Stream output)
+        public static Task WriteMessageAsync(in ReadOnlySequence<byte> payload, Stream output)
         {
             var ms = new MemoryStream();
 
@@ -38,7 +38,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
 
             ms.Position = 0;
 
-            await ms.CopyToAsync(output);
+            return ms.CopyToAsync(output);
         }
 
         public static void WriteMessage(ReadOnlyMemory<byte> payload, Stream output)

--- a/src/Microsoft.AspNetCore.SignalR.Protocols.MsgPack/Internal/Protocol/MessagePackHubProtocol.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Protocols.MsgPack/Internal/Protocol/MessagePackHubProtocol.cs
@@ -62,7 +62,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
             return message != null;
         }
 
-        private static ArraySegment<byte> GetArraySegment(ReadOnlySequence<byte> input)
+        private static ArraySegment<byte> GetArraySegment(in ReadOnlySequence<byte> input)
         {
             if (input.IsSingleSegment)
             {


### PR DESCRIPTION
It's a big enough struct that there *could* be a benefit (I didn't run any perf tests though...)