### PR TITLE
Add GetMessageBytes to IHubProtocol

### DIFF
--- a/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/DefaultHubDispatcherBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/DefaultHubDispatcherBenchmark.cs
@@ -69,6 +69,11 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
             public void WriteMessage(HubMessage message, IBufferWriter<byte> output)
             {
             }
+
+            public byte[] GetBytes(HubMessage message)
+            {
+                return HubProtocolExtensions.GetBytes(this, message);
+            }
         }
 
         public class NoErrorHubConnectionContext : HubConnectionContext

--- a/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/DefaultHubDispatcherBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/DefaultHubDispatcherBenchmark.cs
@@ -70,9 +70,9 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
             {
             }
 
-            public byte[] GetBytes(HubMessage message)
+            public byte[] GetMessageBytes(HubMessage message)
             {
-                return HubProtocolExtensions.GetBytes(this, message);
+                return HubProtocolExtensions.GetMessageBytes(this, message);
             }
         }
 

--- a/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/HubProtocolBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/HubProtocolBenchmark.cs
@@ -50,7 +50,7 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
                     break;
             }
 
-            _binaryInput = _hubProtocol.GetBytes(_hubMessage);
+            _binaryInput = _hubProtocol.GetMessageBytes(_hubMessage);
             _binder = new TestBinder(_hubMessage);
         }
 
@@ -67,7 +67,7 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
         [Benchmark]
         public void WriteSingleMessage()
         {
-            var bytes = _hubProtocol.GetBytes(_hubMessage);
+            var bytes = _hubProtocol.GetMessageBytes(_hubMessage);
             if (bytes.Length != _binaryInput.Length)
             {
                 throw new InvalidOperationException("Failed to write message");

--- a/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/HubProtocolBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/HubProtocolBenchmark.cs
@@ -50,7 +50,7 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
                     break;
             }
 
-            _binaryInput = _hubProtocol.WriteToArray(_hubMessage);
+            _binaryInput = _hubProtocol.GetBytes(_hubMessage);
             _binder = new TestBinder(_hubMessage);
         }
 
@@ -67,7 +67,7 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
         [Benchmark]
         public void WriteSingleMessage()
         {
-            var bytes = _hubProtocol.WriteToArray(_hubMessage);
+            var bytes = _hubProtocol.GetBytes(_hubMessage);
             if (bytes.Length != _binaryInput.Length)
             {
                 throw new InvalidOperationException("Failed to write message");

--- a/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/RedisHubLifetimeManagerBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/RedisHubLifetimeManagerBenchmark.cs
@@ -194,9 +194,9 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
                 _innerProtocol.WriteMessage(message, output);
             }
 
-            public byte[] GetBytes(HubMessage message)
+            public byte[] GetMessageBytes(HubMessage message)
             {
-                return HubProtocolExtensions.GetBytes(this, message);
+                return HubProtocolExtensions.GetMessageBytes(this, message);
             }
 
             public bool IsVersionSupported(int version)

--- a/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/RedisHubLifetimeManagerBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/RedisHubLifetimeManagerBenchmark.cs
@@ -194,6 +194,11 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
                 _innerProtocol.WriteMessage(message, output);
             }
 
+            public byte[] GetBytes(HubMessage message)
+            {
+                return HubProtocolExtensions.GetBytes(this, message);
+            }
+
             public bool IsVersionSupported(int version)
             {
                 return _innerProtocol.IsVersionSupported(version);

--- a/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/RedisProtocolBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/RedisProtocolBenchmark.cs
@@ -144,9 +144,9 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
                 output.Write(_fixedOutput);
             }
 
-            public byte[] GetBytes(HubMessage message)
+            public byte[] GetMessageBytes(HubMessage message)
             {
-                return HubProtocolExtensions.GetBytes(this, message);
+                return HubProtocolExtensions.GetMessageBytes(this, message);
             }
         }
     }

--- a/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/RedisProtocolBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/RedisProtocolBenchmark.cs
@@ -143,6 +143,11 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
             {
                 output.Write(_fixedOutput);
             }
+
+            public byte[] GetBytes(HubMessage message)
+            {
+                return HubProtocolExtensions.GetBytes(this, message);
+            }
         }
     }
 }

--- a/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/ServerSentEventsBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/ServerSentEventsBenchmark.cs
@@ -39,7 +39,7 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
             }
 
             _parser = new ServerSentEventsMessageParser();
-            _rawData = hubProtocol.GetBytes(hubMessage);
+            _rawData = hubProtocol.GetMessageBytes(hubMessage);
             var ms = new MemoryStream();
             ServerSentEventsMessageFormatter.WriteMessage(_rawData, ms);
             _sseFormattedData = ms.ToArray();

--- a/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/ServerSentEventsBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/ServerSentEventsBenchmark.cs
@@ -39,7 +39,7 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
             }
 
             _parser = new ServerSentEventsMessageParser();
-            _rawData = hubProtocol.WriteToArray(hubMessage);
+            _rawData = hubProtocol.GetBytes(hubMessage);
             var ms = new MemoryStream();
             ServerSentEventsMessageFormatter.WriteMessage(_rawData, ms);
             _sseFormattedData = ms.ToArray();

--- a/src/Common/MemoryBufferWriter.cs
+++ b/src/Common/MemoryBufferWriter.cs
@@ -218,13 +218,13 @@ namespace Microsoft.AspNetCore.Internal
             return result;
         }
 
-        public int CopyTo(Span<byte> span)
+        public void CopyTo(Span<byte> span)
         {
             Debug.Assert(span.Length >= _bytesWritten);
 
             if (_currentSegment == null)
             {
-                return 0;
+                return;
             }
 
             var totalWritten = 0;
@@ -245,7 +245,6 @@ namespace Microsoft.AspNetCore.Internal
             _currentSegment.AsSpan(0, _position).CopyTo(span.Slice(totalWritten));
 
             Debug.Assert(_bytesWritten == totalWritten + _position);
-            return _bytesWritten;
         }
 
         public override void Flush() { }

--- a/src/Common/MemoryBufferWriter.cs
+++ b/src/Common/MemoryBufferWriter.cs
@@ -244,7 +244,8 @@ namespace Microsoft.AspNetCore.Internal
             // Copy current incomplete segment
             _currentSegment.AsSpan(0, _position).CopyTo(span.Slice(totalWritten));
 
-            return totalWritten;
+            Debug.Assert(_bytesWritten == totalWritten + _position);
+            return _bytesWritten;
         }
 
         public override void Flush() { }

--- a/src/Common/MemoryBufferWriter.cs
+++ b/src/Common/MemoryBufferWriter.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Buffers;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -215,6 +216,35 @@ namespace Microsoft.AspNetCore.Internal
             _currentSegment.AsSpan(0, _position).CopyTo(result.AsSpan(totalWritten));
 
             return result;
+        }
+
+        public int CopyTo(Span<byte> span)
+        {
+            Debug.Assert(span.Length >= _bytesWritten);
+
+            if (_currentSegment == null)
+            {
+                return 0;
+            }
+
+            var totalWritten = 0;
+
+            if (_fullSegments != null)
+            {
+                // Copy full segments
+                var count = _fullSegments.Count;
+                for (var i = 0; i < count; i++)
+                {
+                    var segment = _fullSegments[i];
+                    segment.AsSpan().CopyTo(span.Slice(totalWritten));
+                    totalWritten += segment.Length;
+                }
+            }
+
+            // Copy current incomplete segment
+            _currentSegment.AsSpan(0, _position).CopyTo(span.Slice(totalWritten));
+
+            return totalWritten;
         }
 
         public override void Flush() { }

--- a/src/Microsoft.AspNetCore.SignalR.Common/Internal/Formatters/BinaryMessageFormatter.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Common/Internal/Formatters/BinaryMessageFormatter.cs
@@ -10,24 +10,9 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Formatters
     {
         public static void WriteLengthPrefix(long length, IBufferWriter<byte> output)
         {
-            // This code writes length prefix of the message as a VarInt. Read the comment in
-            // the BinaryMessageParser.TryParseMessage for details.
-
             Span<byte> lenBuffer = stackalloc byte[5];
 
-            var lenNumBytes = 0;
-            do
-            {
-                ref var current = ref lenBuffer[lenNumBytes];
-                current = (byte)(length & 0x7f);
-                length >>= 7;
-                if (length > 0)
-                {
-                    current |= 0x80;
-                }
-                lenNumBytes++;
-            }
-            while (length > 0);
+            var lenNumBytes = WriteLengthPrefix(length, lenBuffer);
 
             output.Write(lenBuffer.Slice(0, lenNumBytes));
         }
@@ -36,13 +21,10 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Formatters
         {
             // This code writes length prefix of the message as a VarInt. Read the comment in
             // the BinaryMessageParser.TryParseMessage for details.
-
-            Span<byte> lenBuffer = stackalloc byte[5];
-
             var lenNumBytes = 0;
             do
             {
-                ref var current = ref lenBuffer[lenNumBytes];
+                ref var current = ref output[lenNumBytes];
                 current = (byte)(length & 0x7f);
                 length >>= 7;
                 if (length > 0)
@@ -52,8 +34,6 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Formatters
                 lenNumBytes++;
             }
             while (length > 0);
-
-            lenBuffer.Slice(0, lenNumBytes).CopyTo(output);
 
             return lenNumBytes;
         }

--- a/src/Microsoft.AspNetCore.SignalR.Common/Internal/Formatters/BinaryMessageFormatter.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Common/Internal/Formatters/BinaryMessageFormatter.cs
@@ -31,5 +31,44 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Formatters
 
             output.Write(lenBuffer.Slice(0, lenNumBytes));
         }
+
+        public static int WriteLengthPrefix(long length, Span<byte> output)
+        {
+            // This code writes length prefix of the message as a VarInt. Read the comment in
+            // the BinaryMessageParser.TryParseMessage for details.
+
+            Span<byte> lenBuffer = stackalloc byte[5];
+
+            var lenNumBytes = 0;
+            do
+            {
+                ref var current = ref lenBuffer[lenNumBytes];
+                current = (byte)(length & 0x7f);
+                length >>= 7;
+                if (length > 0)
+                {
+                    current |= 0x80;
+                }
+                lenNumBytes++;
+            }
+            while (length > 0);
+
+            lenBuffer.Slice(0, lenNumBytes).CopyTo(output);
+
+            return lenNumBytes;
+        }
+
+        public static int LengthPrefixLength(long length)
+        {
+            var lenNumBytes = 0;
+            do
+            {
+                length >>= 7;
+                lenNumBytes++;
+            }
+            while (length > 0);
+
+            return lenNumBytes;
+        }
     }
 }

--- a/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/HubProtocolExtensions.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/HubProtocolExtensions.cs
@@ -7,11 +7,6 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
 {
     public static class HubProtocolExtensions
     {
-        public static byte[] WriteToArray(this IHubProtocol hubProtocol, HubMessage message)
-        {
-            return hubProtocol.GetBytes(message);
-        }
-
         // Would work as default interface impl
         public static byte[] GetBytes(this IHubProtocol hubProtocol, HubMessage message)
         {

--- a/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/HubProtocolExtensions.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/HubProtocolExtensions.cs
@@ -9,6 +9,12 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
     {
         public static byte[] WriteToArray(this IHubProtocol hubProtocol, HubMessage message)
         {
+            return hubProtocol.GetBytes(message);
+        }
+
+        // Would work as default interface impl
+        public static byte[] GetBytes(this IHubProtocol hubProtocol, HubMessage message)
+        {
             var writer = MemoryBufferWriter.Get();
             try
             {

--- a/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/HubProtocolExtensions.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/HubProtocolExtensions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
     public static class HubProtocolExtensions
     {
         // Would work as default interface impl
-        public static byte[] GetBytes(this IHubProtocol hubProtocol, HubMessage message)
+        public static byte[] GetMessageBytes(this IHubProtocol hubProtocol, HubMessage message)
         {
             var writer = MemoryBufferWriter.Get();
             try

--- a/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/IHubProtocol.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/IHubProtocol.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Buffers;
-using System.IO;
 using Microsoft.AspNetCore.Connections;
 
 namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
@@ -19,7 +18,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
 
         void WriteMessage(HubMessage message, IBufferWriter<byte> output);
 
-        byte[] GetBytes(HubMessage message);
+        byte[] GetMessageBytes(HubMessage message);
 
         bool IsVersionSupported(int version);
     }

--- a/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/IHubProtocol.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/IHubProtocol.cs
@@ -19,6 +19,8 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
 
         void WriteMessage(HubMessage message, IBufferWriter<byte> output);
 
+        byte[] GetBytes(HubMessage message);
+
         bool IsVersionSupported(int version);
     }
 }

--- a/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionContext.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionContext.cs
@@ -340,7 +340,7 @@ namespace Microsoft.AspNetCore.SignalR
                                         transferFormatFeature.ActiveFormat = Protocol.TransferFormat;
                                     }
 
-                                    _cachedPingMessage = Protocol.GetBytes(PingMessage.Instance);
+                                    _cachedPingMessage = Protocol.GetMessageBytes(PingMessage.Instance);
 
                                     UserIdentifier = userIdProvider.GetUserId(this);
 

--- a/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionContext.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionContext.cs
@@ -340,7 +340,7 @@ namespace Microsoft.AspNetCore.SignalR
                                         transferFormatFeature.ActiveFormat = Protocol.TransferFormat;
                                     }
 
-                                    _cachedPingMessage = Protocol.WriteToArray(PingMessage.Instance);
+                                    _cachedPingMessage = Protocol.GetBytes(PingMessage.Instance);
 
                                     UserIdentifier = userIdProvider.GetUserId(this);
 

--- a/src/Microsoft.AspNetCore.SignalR.Core/Internal/SerializedHubMessage.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/Internal/SerializedHubMessage.cs
@@ -39,7 +39,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal
                         "This message was received from another server that did not have the requested protocol available.");
                 }
 
-                serialized = protocol.WriteToArray(Message);
+                serialized = protocol.GetBytes(Message);
                 SetCache(protocol.Name, serialized);
             }
 
@@ -65,7 +65,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal
             {
                 writer.Write(protocol.Name);
 
-                var buffer = protocol.WriteToArray(message);
+                var buffer = protocol.GetBytes(message);
                 writer.Write(buffer.Length);
                 writer.Write(buffer);
             }

--- a/src/Microsoft.AspNetCore.SignalR.Core/Internal/SerializedHubMessage.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/Internal/SerializedHubMessage.cs
@@ -39,7 +39,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal
                         "This message was received from another server that did not have the requested protocol available.");
                 }
 
-                serialized = protocol.GetBytes(Message);
+                serialized = protocol.GetMessageBytes(Message);
                 SetCache(protocol.Name, serialized);
             }
 
@@ -65,7 +65,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal
             {
                 writer.Write(protocol.Name);
 
-                var buffer = protocol.GetBytes(message);
+                var buffer = protocol.GetMessageBytes(message);
                 writer.Write(buffer.Length);
                 writer.Write(buffer);
             }

--- a/src/Microsoft.AspNetCore.SignalR.Protocols.Json/Internal/Protocol/JsonHubProtocol.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Protocols.Json/Internal/Protocol/JsonHubProtocol.cs
@@ -82,9 +82,9 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
             TextMessageFormatter.WriteRecordSeparator(output);
         }
 
-        public byte[] GetBytes(HubMessage message)
+        public byte[] GetMessageBytes(HubMessage message)
         {
-            return HubProtocolExtensions.GetBytes(this, message);
+            return HubProtocolExtensions.GetMessageBytes(this, message);
         }
 
         private HubMessage ParseMessage(Utf8BufferTextReader textReader, IInvocationBinder binder)

--- a/src/Microsoft.AspNetCore.SignalR.Protocols.Json/Internal/Protocol/JsonHubProtocol.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Protocols.Json/Internal/Protocol/JsonHubProtocol.cs
@@ -82,6 +82,11 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
             TextMessageFormatter.WriteRecordSeparator(output);
         }
 
+        public byte[] GetBytes(HubMessage message)
+        {
+            return HubProtocolExtensions.GetBytes(this, message);
+        }
+
         private HubMessage ParseMessage(Utf8BufferTextReader textReader, IInvocationBinder binder)
         {
             try

--- a/src/Microsoft.AspNetCore.SignalR.Protocols.MsgPack/Internal/Protocol/MessagePackHubProtocol.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Protocols.MsgPack/Internal/Protocol/MessagePackHubProtocol.cs
@@ -303,7 +303,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
             }
         }
 
-        public byte[] GetBytes(HubMessage message)
+        public byte[] GetMessageBytes(HubMessage message)
         {
             var writer = MemoryBufferWriter.Get();
 

--- a/src/Microsoft.AspNetCore.SignalR.Protocols.MsgPack/Internal/Protocol/MessagePackHubProtocol.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Protocols.MsgPack/Internal/Protocol/MessagePackHubProtocol.cs
@@ -321,8 +321,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
                 // Write length then message to output
                 var written = BinaryMessageFormatter.WriteLengthPrefix(writer.Length, span);
                 Debug.Assert(written == prefixLength);
-                written = writer.CopyTo(span.Slice(prefixLength));
-                Debug.Assert(written == dataLength);
+                writer.CopyTo(span.Slice(prefixLength));
 
                 return array;
             }

--- a/src/Microsoft.AspNetCore.SignalR.Protocols.MsgPack/Internal/Protocol/MessagePackHubProtocol.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Protocols.MsgPack/Internal/Protocol/MessagePackHubProtocol.cs
@@ -303,6 +303,35 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
             }
         }
 
+        public byte[] GetBytes(HubMessage message)
+        {
+            var writer = MemoryBufferWriter.Get();
+
+            try
+            {
+                // Write message to a buffer so we can get its length
+                WriteMessageCore(message, writer);
+
+                var dataLength = writer.Length;
+                var prefixLength = BinaryMessageFormatter.LengthPrefixLength(writer.Length);
+
+                var array = new byte[dataLength + prefixLength];
+                var span = array.AsSpan();
+
+                // Write length then message to output
+                var written = BinaryMessageFormatter.WriteLengthPrefix(writer.Length, span);
+                Debug.Assert(written == prefixLength);
+                written = writer.CopyTo(span.Slice(prefixLength));
+                Debug.Assert(written == dataLength);
+
+                return array;
+            }
+            finally
+            {
+                MemoryBufferWriter.Return(writer);
+            }
+        }
+
         private void WriteMessageCore(HubMessage message, Stream packer)
         {
             switch (message)

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.cs
@@ -168,9 +168,9 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                 }
             }
 
-            public byte[] GetBytes(HubMessage message)
+            public byte[] GetMessageBytes(HubMessage message)
             {
-                return HubProtocolExtensions.GetBytes(this, message);
+                return HubProtocolExtensions.GetMessageBytes(this, message);
             }
         }
     }

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.cs
@@ -167,6 +167,11 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                     throw _error;
                 }
             }
+
+            public byte[] GetBytes(HubMessage message)
+            {
+                return HubProtocolExtensions.GetBytes(this, message);
+            }
         }
     }
 }

--- a/test/Microsoft.AspNetCore.SignalR.Common.Tests/Internal/Protocol/MemoryBufferWriterTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Common.Tests/Internal/Protocol/MemoryBufferWriterTests.cs
@@ -31,6 +31,8 @@ namespace Microsoft.AspNetCore.SignalR.Common.Tests.Internal.Protocol
                 Assert.Equal(0, bufferWriter.Length);
                 var data = bufferWriter.ToArray();
                 Assert.Empty(data);
+                bufferWriter.CopyTo(data);
+                Assert.Empty(data);
             }
         }
 
@@ -44,6 +46,11 @@ namespace Microsoft.AspNetCore.SignalR.Common.Tests.Internal.Protocol
 
                 Assert.Equal(1, bufferWriter.Length);
                 Assert.Single(data);
+                Assert.Equal(234, data[0]);
+
+                Array.Clear(data, 0, data.Length);
+
+                bufferWriter.CopyTo(data);
                 Assert.Equal(234, data[0]);
             }
         }
@@ -62,6 +69,12 @@ namespace Microsoft.AspNetCore.SignalR.Common.Tests.Internal.Protocol
                 Assert.Equal(17, bufferWriter.Length);
 
                 var data = bufferWriter.ToArray();
+                Assert.Equal(input, data.Take(16));
+                Assert.Equal(16, data[16]);
+
+                Array.Clear(data, 0, data.Length);
+
+                bufferWriter.CopyTo(data);
                 Assert.Equal(input, data.Take(16));
                 Assert.Equal(16, data[16]);
             }
@@ -85,6 +98,14 @@ namespace Microsoft.AspNetCore.SignalR.Common.Tests.Internal.Protocol
                 Assert.Equal(12, data[1]);
                 Assert.Equal(13, data[2]);
                 Assert.Equal(14, data[3]);
+
+                Array.Clear(data, 0, data.Length);
+
+                bufferWriter.CopyTo(data);
+                Assert.Equal(11, data[0]);
+                Assert.Equal(12, data[1]);
+                Assert.Equal(13, data[2]);
+                Assert.Equal(14, data[3]);
             }
         }
 
@@ -101,6 +122,11 @@ namespace Microsoft.AspNetCore.SignalR.Common.Tests.Internal.Protocol
 
                 var data = bufferWriter.ToArray();
                 Assert.Equal(input, data);
+
+                Array.Clear(data, 0, data.Length);
+
+                bufferWriter.CopyTo(data);
+                Assert.Equal(input, data);
             }
         }
 
@@ -116,6 +142,11 @@ namespace Microsoft.AspNetCore.SignalR.Common.Tests.Internal.Protocol
                 Assert.Equal(input.Length, bufferWriter.Length);
 
                 var data = bufferWriter.ToArray();
+                Assert.Equal(input, data);
+
+                Array.Clear(data, 0, data.Length);
+
+                bufferWriter.CopyTo(data);
                 Assert.Equal(input, data);
             }
         }
@@ -173,6 +204,16 @@ namespace Microsoft.AspNetCore.SignalR.Common.Tests.Internal.Protocol
                     bufferWriter.CopyTo(destination);
                     var data = destination.ToArray();
                     Assert.Equal(input, data);
+
+                    Array.Clear(data, 0, data.Length);
+
+                    bufferWriter.CopyTo(data);
+                    Assert.Equal(input, data);
+
+                    Array.Clear(data, 0, data.Length);
+
+                    destination.CopyTo(data);
+                    Assert.Equal(input, data);
                 }
             }
         }
@@ -193,6 +234,16 @@ namespace Microsoft.AspNetCore.SignalR.Common.Tests.Internal.Protocol
                     bufferWriter.CopyTo(destination);
                     var data = destination.ToArray();
                     Assert.Equal(input, data);
+
+                    Array.Clear(data, 0, data.Length);
+
+                    bufferWriter.CopyTo(data);
+                    Assert.Equal(input, data);
+
+                    Array.Clear(data, 0, data.Length);
+
+                    destination.CopyTo(data);
+                    Assert.Equal(input, data);
                 }
             }
         }
@@ -210,6 +261,14 @@ namespace Microsoft.AspNetCore.SignalR.Common.Tests.Internal.Protocol
 
                 var data = bufferWriter.ToArray();
                 Assert.Equal(4, data.Length);
+                Assert.Equal(1, data[0]);
+                Assert.Equal(2, data[1]);
+                Assert.Equal(3, data[2]);
+                Assert.Equal(4, data[3]);
+
+                Array.Clear(data, 0, data.Length);
+
+                bufferWriter.CopyTo(data);
                 Assert.Equal(1, data[0]);
                 Assert.Equal(2, data[1]);
                 Assert.Equal(3, data[2]);

--- a/test/Microsoft.AspNetCore.SignalR.Tests.Utils/TestClient.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests.Utils/TestClient.cs
@@ -179,7 +179,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
 
         public async Task<string> SendHubMessageAsync(HubMessage message)
         {
-            var payload = _protocol.GetBytes(message);
+            var payload = _protocol.GetMessageBytes(message);
 
             await Connection.Application.Output.WriteAsync(payload);
             return message is HubInvocationMessage hubMessage ? hubMessage.InvocationId : null;

--- a/test/Microsoft.AspNetCore.SignalR.Tests.Utils/TestClient.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests.Utils/TestClient.cs
@@ -179,7 +179,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
 
         public async Task<string> SendHubMessageAsync(HubMessage message)
         {
-            var payload = _protocol.WriteToArray(message);
+            var payload = _protocol.GetBytes(message);
 
             await Connection.Application.Output.WriteAsync(payload);
             return message is HubInvocationMessage hubMessage ? hubMessage.InvocationId : null;


### PR DESCRIPTION
Though don't know if `HubProtocolExtensions.WriteToArray` is only used for testing?

Before
```
             Method |          Input | HubProtocol |        Mean |        Op/s | Allocated |
------------------- |--------------- |------------ |------------:|------------:|----------:|
 WriteSingleMessage |   FewArguments |     MsgPack |  1,055.5 ns |   947,400.1 |     472 B |
 WriteSingleMessage | LargeArguments |     MsgPack | 15,514.6 ns |    64,455.3 |   61848 B |
 WriteSingleMessage |  ManyArguments |     MsgPack |  1,956.2 ns |   511,200.9 |     744 B |
 WriteSingleMessage |    NoArguments |     MsgPack |    421.6 ns | 2,371,764.3 |     224 B |
```
After
```
             Method |          Input | HubProtocol |        Mean |        Op/s | Allocated |
------------------- |--------------- |------------ |------------:|------------:|----------:|
 WriteSingleMessage |   FewArguments |     MsgPack |    874.5 ns | 1,143,494.3 |     472 B |
 WriteSingleMessage | LargeArguments |     MsgPack | 13,153.3 ns |    76,026.5 |   61848 B |
 WriteSingleMessage |  ManyArguments |     MsgPack |  1,811.3 ns |   552,096.4 |     744 B |
 WriteSingleMessage |    NoArguments |     MsgPack |    261.2 ns | 3,828,386.2 |     224 B |
```
Newest
```
             Method |          Input | HubProtocol |        Mean |        Op/s | Allocated |
------------------- |--------------- |------------ |------------:|------------:|----------:|
 WriteSingleMessage |   FewArguments |     MsgPack |    865.8 ns | 1,154,991.2 |     472 B |
 WriteSingleMessage | LargeArguments |     MsgPack | 13,159.9 ns |    75,988.7 |   61848 B |
 WriteSingleMessage |  ManyArguments |     MsgPack |  1,772.2 ns |   564,261.0 |     744 B |
 WriteSingleMessage |    NoArguments |     MsgPack |    246.1 ns | 4,063,672.2 |     224 B |
```
Rebased (with "MessagePack-CSharp returns" https://github.com/aspnet/SignalR/pull/1879)
```
             Method |          Input | HubProtocol |        Mean |        Op/s | Allocated |
------------------- |--------------- |------------ |------------:|------------:|----------:|
 WriteSingleMessage |   FewArguments |     MsgPack |    511.1 ns | 1,956,414.1 |      48 B |
 WriteSingleMessage | LargeArguments |     MsgPack |  8,030.1 ns |   124,531.9 |   20528 B |
 WriteSingleMessage |  ManyArguments |     MsgPack |    939.3 ns | 1,064,590.2 |      72 B |
 WriteSingleMessage |    NoArguments |     MsgPack |    290.3 ns | 3,444,304.9 |      40 B |
```

/cc @davidfowl @JamesNK 