### PR TITLE
fix #1923 by avoiding extra build step

### DIFF
--- a/build/repo.targets
+++ b/build/repo.targets
@@ -33,6 +33,7 @@
 
   <Target Name="RunBrowserTests">
     <Message Text="Running TypeScript client Browser tests" Importance="high" />
+    <Exec Command="npm run build" WorkingDirectory="$(RepositoryRoot)clients/ts/FunctionalTests" IgnoreStandardErrorWarningFormat="true" />
     <Exec Command="npm run ci-test -- --configuration $(Configuration)" WorkingDirectory="$(RepositoryRoot)clients/ts/FunctionalTests" IgnoreStandardErrorWarningFormat="true" />
   </Target>
 

--- a/clients/ts/FunctionalTests/package.json
+++ b/clients/ts/FunctionalTests/package.json
@@ -21,7 +21,8 @@
     "build:tsc": "node ../node_modules/typescript/bin/tsc --project ./tsconfig.json",
     "build:rollup": "node ../node_modules/rollup/bin/rollup -c",
     "pretest": "npm run build",
-    "test": "dotnet build && ts-node --project ./selenium/tsconfig.json ./selenium/run-tests.ts",
+    "test": "dotnet build && npm run test-only",
+    "test-only": "ts-node --project ./selenium/tsconfig.json ./selenium/run-tests.ts",
     "ci-test": "ts-node --project ./selenium/tsconfig.json ./selenium/run-ci-tests.ts"
   },
   "author": "",

--- a/clients/ts/FunctionalTests/selenium/run-ci-tests.ts
+++ b/clients/ts/FunctionalTests/selenium/run-ci-tests.ts
@@ -80,9 +80,9 @@ if (configuration) {
     args.push("--configuration");
     args.push(configuration);
 }
-if (verbose) {
+
     args.push("--verbose");
-}
+
 
 let command = "npm";
 

--- a/clients/ts/FunctionalTests/selenium/run-ci-tests.ts
+++ b/clients/ts/FunctionalTests/selenium/run-ci-tests.ts
@@ -74,8 +74,8 @@ if (!existsSync(chromeBinary)) {
     console.log(`Using Google Chrome Browser from '${chromeBinary}`);
 }
 
-// Launch the tests
-const args = ["test", "--", "--raw", "--chrome", chromeBinary];
+// Launch the tests (we know the CI already built, so run the 'test-only' script)
+const args = ["run", "test-only", "--", "--raw", "--chrome", chromeBinary];
 if (configuration) {
     args.push("--configuration");
     args.push(configuration);


### PR DESCRIPTION
Assuming this passes Travis/Appveyor, it should resolve #1923. The problem was that our default `test` script does `dotnet build` but doesn't pass through dependency information from Universe. The thing is, during a full build, the FunctionalTests project has already been built, so we don't need to build it again. The `ci-test` script can assume this is the case, so it will just run the tests with no `dotnet build` step.

cc @natemcmaster @ryanbrandenburg 