### PR TITLE
Use invariant culture and ordinal comparisons

### DIFF
--- a/samples/JwtClientSample/Program.cs
+++ b/samples/JwtClientSample/Program.cs
@@ -23,7 +23,7 @@ namespace JwtClientSample
 
         private const string ServerUrl = "http://localhost:54543";
 
-        private readonly ConcurrentDictionary<string, string> _tokens = new ConcurrentDictionary<string, string>();
+        private readonly ConcurrentDictionary<string, string> _tokens = new ConcurrentDictionary<string, string>(StringComparer.Ordinal);
         private readonly Random _random = new Random();
 
         private async Task RunConnection(HttpTransportType transportType)

--- a/samples/SignalRSamples/ConnectionList.cs
+++ b/samples/SignalRSamples/ConnectionList.cs
@@ -11,7 +11,7 @@ namespace SignalRSamples
 {
     internal class ConnectionList : IReadOnlyCollection<ConnectionContext>
     {
-        private readonly ConcurrentDictionary<string, ConnectionContext> _connections = new ConcurrentDictionary<string, ConnectionContext>();
+        private readonly ConcurrentDictionary<string, ConnectionContext> _connections = new ConcurrentDictionary<string, ConnectionContext>(StringComparer.Ordinal);
 
         public ConnectionContext this[string connectionId]
         {

--- a/samples/SocialWeather/ConnectionList.cs
+++ b/samples/SocialWeather/ConnectionList.cs
@@ -11,7 +11,8 @@ namespace SocialWeather
 {
     internal class ConnectionList : IReadOnlyCollection<ConnectionContext>
     {
-        private readonly ConcurrentDictionary<string, ConnectionContext> _connections = new ConcurrentDictionary<string, ConnectionContext>();
+        private readonly ConcurrentDictionary<string, ConnectionContext> _connections =
+            new ConcurrentDictionary<string, ConnectionContext>(StringComparer.Ordinal);
 
         public ConnectionContext this[string connectionId]
         {

--- a/src/Common/JsonUtils.cs
+++ b/src/Common/JsonUtils.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Buffers;
+using System.Globalization;
 using System.IO;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -127,7 +128,7 @@ namespace Microsoft.AspNetCore.Internal
                 return null;
             }
 
-            return Convert.ToInt32(reader.Value);
+            return Convert.ToInt32(reader.Value, CultureInfo.InvariantCulture);
         }
 
         public static string ReadAsString(JsonTextReader reader, string propertyName)

--- a/src/Microsoft.AspNetCore.Http.Connections/HttpConnectionDispatcher.cs
+++ b/src/Microsoft.AspNetCore.Http.Connections/HttpConnectionDispatcher.cs
@@ -567,7 +567,7 @@ namespace Microsoft.AspNetCore.Http.Connections
             requestFeature.PathBase = existingRequestFeature.PathBase;
             requestFeature.QueryString = existingRequestFeature.QueryString;
             requestFeature.RawTarget = existingRequestFeature.RawTarget;
-            var requestHeaders = new Dictionary<string, StringValues>(existingRequestFeature.Headers.Count);
+            var requestHeaders = new Dictionary<string, StringValues>(existingRequestFeature.Headers.Count, StringComparer.Ordinal);
             foreach (var header in existingRequestFeature.Headers)
             {
                 requestHeaders[header.Key] = header.Value;

--- a/src/Microsoft.AspNetCore.Http.Connections/HttpConnectionManager.cs
+++ b/src/Microsoft.AspNetCore.Http.Connections/HttpConnectionManager.cs
@@ -26,7 +26,8 @@ namespace Microsoft.AspNetCore.Http.Connections
 
         private static readonly RNGCryptoServiceProvider _keyGenerator = new RNGCryptoServiceProvider();
 
-        private readonly ConcurrentDictionary<string, (HttpConnectionContext Connection, ValueStopwatch Timer)> _connections = new ConcurrentDictionary<string, (HttpConnectionContext Connection, ValueStopwatch Timer)>();
+        private readonly ConcurrentDictionary<string, (HttpConnectionContext Connection, ValueStopwatch Timer)> _connections =
+            new ConcurrentDictionary<string, (HttpConnectionContext Connection, ValueStopwatch Timer)>(StringComparer.Ordinal);
         private Timer _timer;
         private readonly ILogger<HttpConnectionManager> _logger;
         private readonly ILogger<HttpConnectionContext> _connectionLogger;

--- a/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Channels;
@@ -33,7 +34,7 @@ namespace Microsoft.AspNetCore.SignalR.Client
         private readonly IHubProtocol _protocol;
         private readonly IServiceProvider _serviceProvider;
         private readonly IConnectionFactory _connectionFactory;
-        private readonly ConcurrentDictionary<string, List<InvocationHandler>> _handlers = new ConcurrentDictionary<string, List<InvocationHandler>>();
+        private readonly ConcurrentDictionary<string, List<InvocationHandler>> _handlers = new ConcurrentDictionary<string, List<InvocationHandler>>(StringComparer.Ordinal);
         private bool _disposed;
 
         // Transient state to a connection
@@ -835,7 +836,7 @@ namespace Microsoft.AspNetCore.SignalR.Client
 
             private TaskCompletionSource<object> _stopTcs;
             private readonly object _lock = new object();
-            private readonly Dictionary<string, InvocationRequest> _pendingCalls = new Dictionary<string, InvocationRequest>();
+            private readonly Dictionary<string, InvocationRequest> _pendingCalls = new Dictionary<string, InvocationRequest>(StringComparer.Ordinal);
             private int _nextId;
 
             public ConnectionContext Connection { get; }
@@ -854,7 +855,7 @@ namespace Microsoft.AspNetCore.SignalR.Client
                 Connection = connection;
             }
 
-            public string GetNextId() => Interlocked.Increment(ref _nextId).ToString();
+            public string GetNextId() => Interlocked.Increment(ref _nextId).ToString(CultureInfo.InvariantCulture);
 
             public void AddInvocation(InvocationRequest irq)
             {

--- a/src/Microsoft.AspNetCore.SignalR.Client/HttpConnectionOptions.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client/HttpConnectionOptions.cs
@@ -64,7 +64,7 @@ namespace Microsoft.AspNetCore.SignalR.Client
             {
                 if (_headers == null)
                 {
-                    _headers = new Dictionary<string, string>();
+                    _headers = new Dictionary<string, string>(StringComparer.Ordinal);
                 }
 
                 return _headers;

--- a/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionContext.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionContext.cs
@@ -63,7 +63,7 @@ namespace Microsoft.AspNetCore.SignalR
         internal ExceptionDispatchInfo AbortException { get; private set; }
 
         // Currently used only for streaming methods
-        internal ConcurrentDictionary<string, CancellationTokenSource> ActiveRequestCancellationSources { get; } = new ConcurrentDictionary<string, CancellationTokenSource>();
+        internal ConcurrentDictionary<string, CancellationTokenSource> ActiveRequestCancellationSources { get; } = new ConcurrentDictionary<string, CancellationTokenSource>(StringComparer.Ordinal);
 
         public virtual ValueTask WriteAsync(HubMessage message)
         {

--- a/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionStore.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionStore.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -9,7 +10,8 @@ namespace Microsoft.AspNetCore.SignalR
 {
     public class HubConnectionStore
     {
-        private readonly ConcurrentDictionary<string, HubConnectionContext> _connections = new ConcurrentDictionary<string, HubConnectionContext>();
+        private readonly ConcurrentDictionary<string, HubConnectionContext> _connections =
+            new ConcurrentDictionary<string, HubConnectionContext>(StringComparer.Ordinal);
 
         public HubConnectionContext this[string connectionId]
         {

--- a/src/Microsoft.AspNetCore.SignalR.Core/HubGroupList.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/HubGroupList.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -11,7 +12,7 @@ namespace Microsoft.AspNetCore.SignalR
     public class HubGroupList : IReadOnlyCollection<ConcurrentDictionary<string, HubConnectionContext>>
     {
         private readonly ConcurrentDictionary<string, GroupConnectionList> _groups =
-            new ConcurrentDictionary<string, GroupConnectionList>();
+            new ConcurrentDictionary<string, GroupConnectionList>(StringComparer.Ordinal);
 
         private static readonly GroupConnectionList EmptyGroupConnectionList = new GroupConnectionList();
 

--- a/src/Microsoft.AspNetCore.SignalR.Protocols.Json/Internal/Protocol/JsonHubProtocol.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Protocols.Json/Internal/Protocol/JsonHubProtocol.cs
@@ -307,7 +307,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
 
         private Dictionary<string, string> ReadHeaders(JsonTextReader reader)
         {
-            var headers = new Dictionary<string, string>();
+            var headers = new Dictionary<string, string>(StringComparer.Ordinal);
 
             if (reader.TokenType != JsonToken.StartObject)
             {

--- a/src/Microsoft.AspNetCore.SignalR.Protocols.MsgPack/Internal/Protocol/MessagePackHubProtocol.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Protocols.MsgPack/Internal/Protocol/MessagePackHubProtocol.cs
@@ -232,7 +232,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
             if (headerCount > 0)
             {
                 // If headerCount is larger than int.MaxValue, things are going to go horribly wrong anyway :)
-                var headers = new Dictionary<string, string>((int)headerCount);
+                var headers = new Dictionary<string, string>((int)headerCount, StringComparer.Ordinal);
 
                 for (var i = 0; i < headerCount; i++)
                 {

--- a/src/Microsoft.AspNetCore.SignalR.Redis/RedisHubLifetimeManager.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Redis/RedisHubLifetimeManager.cs
@@ -23,7 +23,7 @@ namespace Microsoft.AspNetCore.SignalR.Redis
     {
         private readonly HubConnectionStore _connections = new HubConnectionStore();
         // TODO: Investigate "memory leak" entries never get removed
-        private readonly ConcurrentDictionary<string, GroupData> _groups = new ConcurrentDictionary<string, GroupData>();
+        private readonly ConcurrentDictionary<string, GroupData> _groups = new ConcurrentDictionary<string, GroupData>(StringComparer.Ordinal);
         private readonly IConnectionMultiplexer _redisServerConnection;
         private readonly ISubscriber _bus;
         private readonly ILogger _logger;


### PR DESCRIPTION
- Ordinal comparison on group names, connection IDs, invocation IDs and headers
- A couple of other minor culture fixes