### PR TITLE
Dont always copy handlers

### DIFF
--- a/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.cs
@@ -791,10 +791,7 @@ namespace Microsoft.AspNetCore.SignalR.Client
 
             public void Dispose()
             {
-                lock (_handlerList)
-                {
-                    _handlerList.Remove(_handler);
-                }
+                 _handlerList.Remove(_handler);
             }
         }
 


### PR DESCRIPTION
Issue: https://github.com/aspnet/SignalR/issues/1862
Previously we were always making copies of the the invocation handler list in preparation for dispatching an invocation. Now we only make a new copy if there have been updates to the set of handlers.

https://github.com/aspnet/SignalR/blob/80f87e7730e04e6979ee934126be7d608fc43724/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.cs#L440-L447