### PR TITLE
Get off the event loop before dispatch

### DIFF
--- a/src/Common/AwaitableThreadPool.cs
+++ b/src/Common/AwaitableThreadPool.cs
@@ -7,7 +7,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
-namespace Microsoft.AspNetCore.Http.Connections.Internal
+namespace Microsoft.AspNetCore.Internal
 {
     public static class AwaitableThreadPool
     {

--- a/src/Microsoft.AspNetCore.Http.Connections/Microsoft.AspNetCore.Http.Connections.csproj
+++ b/src/Microsoft.AspNetCore.Http.Connections/Microsoft.AspNetCore.Http.Connections.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\Common\AwaitableThreadPool.cs" Link="AwaitableThreadPool.cs" />
     <Compile Include="..\Common\MemoryBufferWriter.cs" Link="MemoryBufferWriter.cs" />
     <Compile Include="..\Common\PipeWriterStream.cs" Link="PipeWriterStream.cs" />
     <Compile Include="..\Common\WebSocketExtensions.cs" Link="WebSocketExtensions.cs" />

--- a/src/Microsoft.AspNetCore.SignalR.Client.Core/Microsoft.AspNetCore.SignalR.Client.Core.csproj
+++ b/src/Microsoft.AspNetCore.SignalR.Client.Core/Microsoft.AspNetCore.SignalR.Client.Core.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\Common\AwaitableThreadPool.cs" Link="AwaitableThreadPool.cs" />
     <Compile Include="..\Common\ForceAsyncAwaiter.cs" Link="ForceAsyncAwaiter.cs" />
     <Compile Include="..\Common\PipeWriterStream.cs" Link="PipeWriterStream.cs" />
   </ItemGroup>

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.Protocol.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.Protocol.cs
@@ -485,9 +485,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
 
                     await connection.ReceiveTextAsync(":[\"hello\"]}\u001e");
 
-                    Assert.True(tcs.Task.IsCompleted);
-
-                    var response = await tcs.Task;
+                    var response = await tcs.Task.OrTimeout();
 
                     Assert.Equal("hello", response);
                 }


### PR DESCRIPTION
Get off the event loop when dispatching On* callbacks. This is a double edged sword. 

The upside:
- The user can't block their own events.
- The user code won't interleave with our own event loop processing logic.
- User callbacks will fire in parallel. Since we're not waiting on their callback to complete it's easy to fire more events that come in before waiting on their code to run.
- Less chance of a deadlock.

The downside:
- The single callback at a time simplifies the programming model somewhat. Running events in parallel means users will have to synchronize.
- The "natural" back pressure is gone, if a user blocks their own events then they won't get more data on any other events.

PS: We already do this for close.

Related to https://github.com/aspnet/SignalR/issues/1950