### PR TITLE
API review changes

### DIFF
--- a/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/DefaultHubDispatcherBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/DefaultHubDispatcherBenchmark.cs
@@ -70,7 +70,7 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
             {
             }
 
-            public byte[] GetMessageBytes(HubMessage message)
+            public ReadOnlyMemory<byte> GetMessageBytes(HubMessage message)
             {
                 return HubProtocolExtensions.GetMessageBytes(this, message);
             }

--- a/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/HubProtocolBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/HubProtocolBenchmark.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
     public class HubProtocolBenchmark
     {
         private IHubProtocol _hubProtocol;
-        private byte[] _binaryInput;
+        private ReadOnlyMemory<byte> _binaryInput;
         private TestBinder _binder;
         private HubMessage _hubMessage;
 

--- a/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/RedisHubLifetimeManagerBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/RedisHubLifetimeManagerBenchmark.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.Linq;
@@ -195,7 +196,7 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
                 _innerProtocol.WriteMessage(message, output);
             }
 
-            public byte[] GetMessageBytes(HubMessage message)
+            public ReadOnlyMemory<byte> GetMessageBytes(HubMessage message)
             {
                 return HubProtocolExtensions.GetMessageBytes(this, message);
             }

--- a/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/RedisProtocolBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/RedisProtocolBenchmark.cs
@@ -144,7 +144,7 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
                 output.Write(_fixedOutput);
             }
 
-            public byte[] GetMessageBytes(HubMessage message)
+            public ReadOnlyMemory<byte> GetMessageBytes(HubMessage message)
             {
                 return HubProtocolExtensions.GetMessageBytes(this, message);
             }

--- a/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/HandshakeProtocol.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/HandshakeProtocol.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
         private const string ErrorPropertyName = "error";
         private const string TypePropertyName = "type";
 
-        public static ReadOnlyMemory<byte> SuccessHandshakeData { get; }
+        public static ReadOnlyMemory<byte> SuccessHandshakeData;
 
         static HandshakeProtocol()
         {

--- a/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/IHubProtocol.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Common/Internal/Protocol/IHubProtocol.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Buffers;
 using Microsoft.AspNetCore.Connections;
 
@@ -18,7 +19,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
 
         void WriteMessage(HubMessage message, IBufferWriter<byte> output);
 
-        byte[] GetMessageBytes(HubMessage message);
+        ReadOnlyMemory<byte> GetMessageBytes(HubMessage message);
 
         bool IsVersionSupported(int version);
     }

--- a/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionContext.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionContext.cs
@@ -34,7 +34,7 @@ namespace Microsoft.AspNetCore.SignalR
         private readonly SemaphoreSlim _writeLock = new SemaphoreSlim(1);
 
         private long _lastSendTimestamp = Stopwatch.GetTimestamp();
-        private byte[] _cachedPingMessage;
+        private ReadOnlyMemory<byte> _cachedPingMessage;
 
         public HubConnectionContext(ConnectionContext connectionContext, TimeSpan keepAliveInterval, ILoggerFactory loggerFactory)
         {
@@ -223,11 +223,7 @@ namespace Microsoft.AspNetCore.SignalR
         {
             try
             {
-                Debug.Assert(_cachedPingMessage != null);
-
-                _connectionContext.Transport.Output.Write(_cachedPingMessage);
-
-                await _connectionContext.Transport.Output.FlushAsync();
+                await _connectionContext.Transport.Output.WriteAsync(_cachedPingMessage);
 
                 Log.SentPing(_logger);
             }

--- a/src/Microsoft.AspNetCore.SignalR.Core/Internal/SerializedHubMessage.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/Internal/SerializedHubMessage.cs
@@ -50,7 +50,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal
             return serialized;
         }
 
-        private void SetCache(string protocolName, byte[] serialized)
+        private void SetCache(string protocolName, ReadOnlyMemory<byte> serialized)
         {
             if (_cachedItem1.ProtocolName == null)
             {
@@ -80,7 +80,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal
             }
         }
 
-        private bool TryGetCached(string protocolName, out byte[] result)
+        private bool TryGetCached(string protocolName, out ReadOnlyMemory<byte> result)
         {
             if (string.Equals(_cachedItem1.ProtocolName, protocolName, StringComparison.Ordinal))
             {

--- a/src/Microsoft.AspNetCore.SignalR.Core/Internal/SerializedMessage.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/Internal/SerializedMessage.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 
 namespace Microsoft.AspNetCore.SignalR.Internal

--- a/src/Microsoft.AspNetCore.SignalR.Core/Internal/SerializedMessage.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/Internal/SerializedMessage.cs
@@ -1,11 +1,13 @@
+using System;
+
 namespace Microsoft.AspNetCore.SignalR.Internal
 {
     public readonly struct SerializedMessage
     {
         public string ProtocolName { get; }
-        public byte[] Serialized { get; }
+        public ReadOnlyMemory<byte> Serialized { get; }
 
-        public SerializedMessage(string protocolName, byte[] serialized)
+        public SerializedMessage(string protocolName, ReadOnlyMemory<byte> serialized)
         {
             ProtocolName = protocolName;
             Serialized = serialized;

--- a/src/Microsoft.AspNetCore.SignalR.Protocols.Json/Internal/Protocol/JsonHubProtocol.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Protocols.Json/Internal/Protocol/JsonHubProtocol.cs
@@ -82,7 +82,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
             TextMessageFormatter.WriteRecordSeparator(output);
         }
 
-        public byte[] GetMessageBytes(HubMessage message)
+        public ReadOnlyMemory<byte> GetMessageBytes(HubMessage message)
         {
             return HubProtocolExtensions.GetMessageBytes(this, message);
         }

--- a/src/Microsoft.AspNetCore.SignalR.Protocols.MsgPack/Internal/Protocol/MessagePackHubProtocol.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Protocols.MsgPack/Internal/Protocol/MessagePackHubProtocol.cs
@@ -303,7 +303,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal.Protocol
             }
         }
 
-        public byte[] GetMessageBytes(HubMessage message)
+        public ReadOnlyMemory<byte> GetMessageBytes(HubMessage message)
         {
             var writer = MemoryBufferWriter.Get();
 

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.cs
@@ -168,7 +168,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                 }
             }
 
-            public byte[] GetMessageBytes(HubMessage message)
+            public ReadOnlyMemory<byte> GetMessageBytes(HubMessage message)
             {
                 return HubProtocolExtensions.GetMessageBytes(this, message);
             }

--- a/test/Microsoft.AspNetCore.SignalR.Redis.Tests/RedisProtocolTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Redis.Tests/RedisProtocolTests.cs
@@ -202,10 +202,10 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
 
             public void WriteMessage(HubMessage message, IBufferWriter<byte> output)
             {
-                output.Write(GetMessageBytes(message));
+                output.Write(GetMessageBytes(message).Span);
             }
 
-            public byte[] GetMessageBytes(HubMessage message)
+            public ReadOnlyMemory<byte> GetMessageBytes(HubMessage message)
             {
                 SerializationCount += 1;
 


### PR DESCRIPTION
- Changed GetMessageBytes to return ReadOnlyMemory
- Make HandshakeProtocol.SuccessHandshakeData a readonly field

## Before

```
             Method |       Input | HubProtocol |       Mean |     Error |    StdDev |        Op/s |  Gen 0 | Allocated |
------------------- |------------ |------------ |-----------:|----------:|----------:|------------:|-------:|----------:|
 WriteSingleMessage | NoArguments |        Json | 1,074.8 ns | 11.669 ns | 10.915 ns |   930,399.5 | 0.0114 |     392 B |
 WriteSingleMessage | NoArguments |     MsgPack |   344.3 ns |  7.487 ns |  6.637 ns | 2,904,147.3 | 0.0010 |      40 B |
```

## After

```
              Method |       Input | HubProtocol |       Mean |     Error |    StdDev |        Op/s |  Gen 0 | Allocated |
------------------- |------------ |------------ |-----------:|----------:|----------:|------------:|-------:|----------:|
 WriteSingleMessage | NoArguments |        Json | 1,112.9 ns | 12.325 ns | 11.529 ns |   898,513.8 | 0.0114 |     392 B |
 WriteSingleMessage | NoArguments |     MsgPack |   366.7 ns |  7.010 ns |  7.791 ns | 2,726,694.7 | 0.0010 |      40 B |
```

There's a performance hit here, but it might still be worth it?