### PR TITLE
Fix #1927 by using Synchronous Callbacks everywhere.

### DIFF
--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.Protocol.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.Protocol.cs
@@ -403,7 +403,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
             [Fact]
             public async Task PartialHandshakeResponseWorks()
             {
-                var connection = new TestConnection(synchronousCallbacks: true, autoHandshake: false);
+                var connection = new TestConnection(autoHandshake: false);
                 var hubConnection = CreateHubConnection(connection);
                 try
                 {
@@ -432,7 +432,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
             public async Task HandshakeAndInvocationInSameBufferWorks()
             {
                 var payload = "{}\u001e{\"type\":1, \"target\": \"Echo\", \"arguments\":[\"hello\"]}\u001e";
-                var connection = new TestConnection(synchronousCallbacks: true, autoHandshake: false);
+                var connection = new TestConnection(autoHandshake: false);
                 var hubConnection = CreateHubConnection(connection);
                 try
                 {
@@ -459,7 +459,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
             [Fact]
             public async Task PartialInvocationWorks()
             {                
-                var connection = new TestConnection(synchronousCallbacks: true);
+                var connection = new TestConnection();
                 var hubConnection = CreateHubConnection(connection);
                 try
                 {

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/TestConnection.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/TestConnection.cs
@@ -42,14 +42,13 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
 
         public override IDictionary<object, object> Items { get; set; } = new ConnectionItems();
 
-        public TestConnection(Func<Task> onStart = null, Func<Task> onDispose = null, bool autoHandshake = true, bool synchronousCallbacks = false)
+        public TestConnection(Func<Task> onStart = null, Func<Task> onDispose = null, bool autoHandshake = true)
         {
             _autoHandshake = autoHandshake;
             _onStart = onStart ?? (() => Task.CompletedTask);
             _onDispose = onDispose ?? (() => Task.CompletedTask);
 
-            var scheduler = synchronousCallbacks ? PipeScheduler.Inline : null;
-            var options = new PipeOptions(readerScheduler: scheduler, writerScheduler: scheduler, useSynchronizationContext: false);
+            var options = new PipeOptions(readerScheduler: PipeScheduler.Inline, writerScheduler: PipeScheduler.Inline, useSynchronizationContext: false);
 
             var pair = DuplexPipe.CreateConnectionPair(options, options);
             Application = pair.Application;

--- a/test/Microsoft.AspNetCore.SignalR.Tests.Utils/TestClient.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests.Utils/TestClient.cs
@@ -32,9 +32,9 @@ namespace Microsoft.AspNetCore.SignalR.Tests
 
         public TransferFormat ActiveFormat { get; set; }
 
-        public TestClient(bool synchronousCallbacks = true, IHubProtocol protocol = null, IInvocationBinder invocationBinder = null, bool addClaimId = false)
+        public TestClient(IHubProtocol protocol = null, IInvocationBinder invocationBinder = null, bool addClaimId = false)
         {
-            var scheduler = synchronousCallbacks ? PipeScheduler.Inline : null;
+            var scheduler = PipeScheduler.Inline;
             var options = new PipeOptions(readerScheduler: scheduler, writerScheduler: scheduler, useSynchronizationContext: false);
             var pair = DuplexPipe.CreateConnectionPair(options, options);
             Connection = new DefaultConnectionContext(Guid.NewGuid().ToString(), pair.Transport, pair.Application);

--- a/test/Microsoft.AspNetCore.SignalR.Tests.Utils/TestClient.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests.Utils/TestClient.cs
@@ -34,8 +34,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
 
         public TestClient(IHubProtocol protocol = null, IInvocationBinder invocationBinder = null, bool addClaimId = false)
         {
-            var scheduler = PipeScheduler.Inline;
-            var options = new PipeOptions(readerScheduler: scheduler, writerScheduler: scheduler, useSynchronizationContext: false);
+            var options = new PipeOptions(readerScheduler: PipeScheduler.Inline, writerScheduler: PipeScheduler.Inline, useSynchronizationContext: false);
             var pair = DuplexPipe.CreateConnectionPair(options, options);
             Connection = new DefaultConnectionContext(Guid.NewGuid().ToString(), pair.Transport, pair.Application);
 

--- a/test/Microsoft.AspNetCore.SignalR.Tests.Utils/TestClient.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests.Utils/TestClient.cs
@@ -32,7 +32,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
 
         public TransferFormat ActiveFormat { get; set; }
 
-        public TestClient(bool synchronousCallbacks = false, IHubProtocol protocol = null, IInvocationBinder invocationBinder = null, bool addClaimId = false)
+        public TestClient(bool synchronousCallbacks = true, IHubProtocol protocol = null, IInvocationBinder invocationBinder = null, bool addClaimId = false)
         {
             var scheduler = synchronousCallbacks ? PipeScheduler.Inline : null;
             var options = new PipeOptions(readerScheduler: scheduler, writerScheduler: scheduler, useSynchronizationContext: false);

--- a/test/Microsoft.AspNetCore.SignalR.Tests/HubConnectionHandlerTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/HubConnectionHandlerTests.cs
@@ -194,7 +194,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             var part2 = Encoding.UTF8.GetBytes(",\"version\": 1}");
             var part3 = Encoding.UTF8.GetBytes("\u001e");
 
-            using (var client = new TestClient(synchronousCallbacks: true))
+            using (var client = new TestClient())
             {
                 client.SupportedFormats = TransferFormat.Text;
 
@@ -234,7 +234,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             var part2 = Encoding.UTF8.GetBytes("\"target\": \"Echo\", \"arguments\"");
             var part3 = Encoding.UTF8.GetBytes(":[\"hello\"]}\u001e");
 
-            using (var client = new TestClient(synchronousCallbacks: true))
+            using (var client = new TestClient())
             {
                 client.SupportedFormats = TransferFormat.Text;
 
@@ -272,7 +272,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             var connectionHandler = HubConnectionHandlerTestUtils.GetHubConnectionHandler(typeof(HubT));
             var payload = Encoding.UTF8.GetBytes("{\"protocol\": \"json\",\"version\": 1}\u001e{\"type\":1, \"invocationId\":\"1\", \"target\": \"Echo\", \"arguments\":[\"hello\"]}\u001e");
 
-            using (var client = new TestClient(synchronousCallbacks: true))
+            using (var client = new TestClient())
             {
                 client.SupportedFormats = TransferFormat.Text;
 
@@ -616,7 +616,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
 
             var connectionHandler = serviceProvider.GetService<HubConnectionHandler<MethodHub>>();
 
-            using (var client = new TestClient(synchronousCallbacks: true))
+            using (var client = new TestClient())
             {
                 var connectionHandlerTask = await client.ConnectAsync(connectionHandler);
 
@@ -1195,7 +1195,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
 
                 await Task.WhenAll(firstClient.Connected, secondClient.Connected).OrTimeout();
 
-                var result = (await firstClient.InvokeAsync("GroupSendMethod", "testGroup", "test").OrTimeout()).Result;
+                var result = (await firstClient.InvokeAsync("GroupSendMethod", "testGroup", "test").OrTimeout(10)).Result;
 
                 // check that 'firstConnection' hasn't received the group send
                 Assert.Null(firstClient.TryRead());

--- a/test/Microsoft.AspNetCore.SignalR.Tests/HubConnectionHandlerTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/HubConnectionHandlerTests.cs
@@ -1195,7 +1195,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
 
                 await Task.WhenAll(firstClient.Connected, secondClient.Connected).OrTimeout();
 
-                var result = (await firstClient.InvokeAsync("GroupSendMethod", "testGroup", "test").OrTimeout(10)).Result;
+                var result = (await firstClient.InvokeAsync("GroupSendMethod", "testGroup", "test").OrTimeout()).Result;
 
                 // check that 'firstConnection' hasn't received the group send
                 Assert.Null(firstClient.TryRead());

--- a/test/Microsoft.AspNetCore.SignalR.Tests/HubConnectionHandlerTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/HubConnectionHandlerTests.cs
@@ -1392,7 +1392,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             var invocationBinder = new Mock<IInvocationBinder>();
             invocationBinder.Setup(b => b.GetReturnType(It.IsAny<string>())).Returns(typeof(string));
 
-            using (var client = new TestClient(synchronousCallbacks: false, protocol: protocol, invocationBinder: invocationBinder.Object))
+            using (var client = new TestClient(protocol: protocol, invocationBinder: invocationBinder.Object))
             {
                 client.SupportedFormats = protocol.TransferFormat;
 
@@ -1684,7 +1684,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             var connectionHandler = serviceProvider.GetService<HubConnectionHandler<MethodHub>>();
 
             var msgPackOptions = serviceProvider.GetRequiredService<IOptions<MessagePackHubProtocolOptions>>();
-            using (var client = new TestClient(synchronousCallbacks: false, protocol: new MessagePackHubProtocol(msgPackOptions)))
+            using (var client = new TestClient(protocol: new MessagePackHubProtocol(msgPackOptions)))
             {
                 client.SupportedFormats = TransferFormat.Binary;
                 var connectionHandlerTask = await client.ConnectAsync(connectionHandler);
@@ -1805,7 +1805,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider();
             var connectionHandler = serviceProvider.GetService<HubConnectionHandler<MethodHub>>();
 
-            using (var client = new TestClient(false, new JsonHubProtocol()))
+            using (var client = new TestClient(new JsonHubProtocol()))
             {
                 var connectionHandlerTask = await client.ConnectAsync(connectionHandler);
                 await client.Connected.OrTimeout();
@@ -1831,7 +1831,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                     options.KeepAliveInterval = TimeSpan.FromMilliseconds(100)));
             var connectionHandler = serviceProvider.GetService<HubConnectionHandler<MethodHub>>();
 
-            using (var client = new TestClient(false, new JsonHubProtocol()))
+            using (var client = new TestClient(new JsonHubProtocol()))
             {
                 var connectionHandlerTask = await client.ConnectAsync(connectionHandler);
 
@@ -1872,7 +1872,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                     options.KeepAliveInterval = TimeSpan.FromMilliseconds(100)));
             var connectionHandler = serviceProvider.GetService<HubConnectionHandler<MethodHub>>();
 
-            using (var client = new TestClient(false, new JsonHubProtocol()))
+            using (var client = new TestClient(new JsonHubProtocol()))
             {
                 var connectionHandlerTask = await client.ConnectAsync(connectionHandler);
                 await client.Connected.OrTimeout();
@@ -1928,7 +1928,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider();
             var connectionHandler = serviceProvider.GetService<HubConnectionHandler<MethodHub>>();
 
-            using (var client = new TestClient(false, new JsonHubProtocol()))
+            using (var client = new TestClient(new JsonHubProtocol()))
             {
                 var connectionHandlerTask = await client.ConnectAsync(connectionHandler);
 
@@ -1962,7 +1962,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             });
             var connectionHandler = serviceProvider.GetService<HubConnectionHandler<OnConnectedThrowsHub>>();
 
-            using (var client = new TestClient(false, new JsonHubProtocol()))
+            using (var client = new TestClient(new JsonHubProtocol()))
             {
                 var connectionHandlerTask = await client.ConnectAsync(connectionHandler);
 


### PR DESCRIPTION
Fix flakiness in test client by using synchronous callbacks everywere. This resolved some flakiness I saw in the test referenced by #1927 when running it multiple times in parallel.