### PR TITLE
Internalize classes in Http.Connections

### DIFF
--- a/src/Microsoft.AspNetCore.Http.Connections.Client/Internal/ConnectionLogScope.cs
+++ b/src/Microsoft.AspNetCore.Http.Connections.Client/Internal/ConnectionLogScope.cs
@@ -8,7 +8,7 @@ using System.Globalization;
 
 namespace Microsoft.AspNetCore.Http.Connections.Client.Internal
 {
-    public class ConnectionLogScope : IReadOnlyList<KeyValuePair<string, object>>
+    internal class ConnectionLogScope : IReadOnlyList<KeyValuePair<string, object>>
     {
         private string _cachedToString;
         private string _connectionId;

--- a/src/Microsoft.AspNetCore.Http.Connections.Common/Internal/NegotiateProtocol.cs
+++ b/src/Microsoft.AspNetCore.Http.Connections.Common/Internal/NegotiateProtocol.cs
@@ -5,7 +5,6 @@ using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
-using System.Text;
 using Microsoft.AspNetCore.Internal;
 using Newtonsoft.Json;
 

--- a/src/Microsoft.AspNetCore.Http.Connections/Internal/AuthorizeHelper.cs
+++ b/src/Microsoft.AspNetCore.Http.Connections/Internal/AuthorizeHelper.cs
@@ -6,12 +6,11 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Authorization.Policy;
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNetCore.Http.Connections.Internal
 {
-    public static class AuthorizeHelper
+    internal static class AuthorizeHelper
     {
         public static async Task<bool> AuthorizeAsync(HttpContext context, IList<IAuthorizeData> policies)
         {

--- a/src/Microsoft.AspNetCore.Http.Connections/Internal/ConnectionLogScope.cs
+++ b/src/Microsoft.AspNetCore.Http.Connections/Internal/ConnectionLogScope.cs
@@ -8,7 +8,7 @@ using System.Globalization;
 
 namespace Microsoft.AspNetCore.Http.Connections.Internal
 {
-    public class ConnectionLogScope : IReadOnlyList<KeyValuePair<string, object>>
+    internal class ConnectionLogScope : IReadOnlyList<KeyValuePair<string, object>>
     {
         private string _cachedToString;
 

--- a/src/Microsoft.AspNetCore.Http.Connections/Internal/Transports/ServerSentEventsMessageFormatter.cs
+++ b/src/Microsoft.AspNetCore.Http.Connections/Internal/Transports/ServerSentEventsMessageFormatter.cs
@@ -3,9 +3,7 @@
 
 using System;
 using System.Buffers;
-using System.Diagnostics;
 using System.IO;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 
 namespace Microsoft.AspNetCore.Http.Connections.Internal


### PR DESCRIPTION
https://github.com/aspnet/SignalR/issues/1976
Kept `AvailableTransport` and `ServerSentEventsMessageFormatter` as pubternal
`AvailableTransport` is used in `NegotiationResponse` which is used across multiple packages
`ServerSentEventsMessageFormatter` is used by micro-benchmarks and because of crazy internal dependencies can't have internals visible to on Http.Connections