### PR TITLE
Send delete request after poll ends

### DIFF
--- a/src/Microsoft.AspNetCore.Http.Connections.Client/Internal/LongPollingTransport.cs
+++ b/src/Microsoft.AspNetCore.Http.Connections.Client/Internal/LongPollingTransport.cs
@@ -95,9 +95,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Client.Internal
                 _application.Output.CancelPendingFlush();
 
                 await receiving;
-                
+
                 // Send the DELETE request to clean-up the connection on the server.
-                // This will also cause the poll to return.
                 await SendDeleteRequest(url);
             }
         }

--- a/src/Microsoft.AspNetCore.Http.Connections.Client/Internal/LongPollingTransport.cs
+++ b/src/Microsoft.AspNetCore.Http.Connections.Client/Internal/LongPollingTransport.cs
@@ -88,16 +88,17 @@ namespace Microsoft.AspNetCore.Http.Connections.Client.Internal
                 // Set the sending error so we communicate that to the application
                 _error = sending.IsFaulted ? sending.Exception.InnerException : null;
 
-                // Send the DELETE request to clean-up the connection on the server.
-                // This will also cause the poll to return.
-                await SendDeleteRequest(url);
-
+                // Cancel the poll request
                 _transportCts.Cancel();
 
                 // Cancel any pending flush so that we can quit
                 _application.Output.CancelPendingFlush();
 
                 await receiving;
+                
+                // Send the DELETE request to clean-up the connection on the server.
+                // This will also cause the poll to return.
+                await SendDeleteRequest(url);
             }
         }
 


### PR DESCRIPTION
Should fix the 404s in https://github.com/aspnet/SignalR/pull/1972#issuecomment-381314296. The idea is to unwind the client side loop before sending the delete request.