### PR TITLE
Increase timeout of test

### DIFF
--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.Helpers.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.Helpers.cs
@@ -1,12 +1,13 @@
 using Microsoft.AspNetCore.SignalR.Protocol;
 using Microsoft.AspNetCore.SignalR.Tests;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.SignalR.Client.Tests
 {
     public partial class HubConnectionTests
     {
-        private static HubConnection CreateHubConnection(TestConnection connection, IHubProtocol protocol = null)
+        private static HubConnection CreateHubConnection(TestConnection connection, IHubProtocol protocol = null, ILoggerFactory loggerFactory = null)
         {
             var builder = new HubConnectionBuilder();
 
@@ -15,6 +16,11 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                 c => ((TestConnection)c).DisposeAsync());
 
             builder.Services.AddSingleton<IConnectionFactory>(delegateConnectionFactory);
+
+            if (loggerFactory != null)
+            {
+                builder.WithLoggerFactory(loggerFactory);
+            }
 
             if (protocol != null)
             {


### PR DESCRIPTION
- Seems like it was possible for the server timeout to happen *before* the invocation happened.
- Added logging to the test