### PR TITLE
JsonHubProtocol and MessagePackHubProtocol version fields now private

### DIFF
--- a/src/Microsoft.AspNetCore.SignalR.Protocols.Json/Protocol/JsonHubProtocol.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Protocols.Json/Protocol/JsonHubProtocol.cs
@@ -28,8 +28,8 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
         private const string ArgumentsPropertyName = "arguments";
         private const string HeadersPropertyName = "headers";
 
-        public static readonly string ProtocolName = "json";
-        public static readonly int ProtocolVersion = 1;
+        private static readonly string ProtocolName = "json";
+        private static readonly int ProtocolVersion = 1;
 
         // ONLY to be used for application payloads (args, return values, etc.)
         public JsonSerializer PayloadSerializer { get; }

--- a/src/Microsoft.AspNetCore.SignalR.Protocols.MessagePack/Protocol/MessagePackHubProtocol.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Protocols.MessagePack/Protocol/MessagePackHubProtocol.cs
@@ -25,8 +25,8 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
 
         private IFormatterResolver _resolver;
 
-        public static readonly string ProtocolName = "messagepack";
-        public static readonly int ProtocolVersion = 1;
+        private static readonly string ProtocolName = "messagepack";
+        private static readonly int ProtocolVersion = 1;
 
         public string Name => ProtocolName;
 

--- a/test/Microsoft.AspNetCore.SignalR.Redis.Tests/RedisEndToEnd.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Redis.Tests/RedisEndToEnd.cs
@@ -117,11 +117,11 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
             {
                 foreach (var transport in TransportTypes())
                 {
-                    yield return new object[] { transport, JsonHubProtocol.ProtocolName };
+                    yield return new object[] { transport, "json" };
 
                     if (transport != HttpTransportType.ServerSentEvents)
                     {
-                        yield return new object[] { transport, MessagePackHubProtocol.ProtocolName };
+                        yield return new object[] { transport, "messagepack" };
                     }
                 }
             }

--- a/test/Microsoft.AspNetCore.SignalR.Tests/Internal/DefaultHubProtocolResolverTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/Internal/DefaultHubProtocolResolverTests.cs
@@ -77,7 +77,7 @@ namespace Microsoft.AspNetCore.SignalR.Common.Protocol.Tests
                 new JsonHubProtocol()
             }, NullLogger<DefaultHubProtocolResolver>.Instance));
 
-            Assert.Equal($"Multiple Hub Protocols with the name '{JsonHubProtocol.ProtocolName}' were registered.", exception.Message);
+            Assert.Equal($"Multiple Hub Protocols with the name 'json' were registered.", exception.Message);
         }
 
         public static IEnumerable<object[]> HubProtocolNames => HubProtocolHelpers.AllProtocols.Select(p => new object[] {p.Name});


### PR DESCRIPTION
Make private
- JsonHubProtocol.ProtocolVersion
- JsonHubProtocol.ProtocolName
- JsonHubProtocol.PayloadSerializer
- MessagePackHubProtocol.ProtocolVersion
- MessagePackHubProtocol.ProtocolName