### PR TITLE
Cache property access

### DIFF
--- a/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionHandler.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionHandler.cs
@@ -169,16 +169,18 @@ namespace Microsoft.AspNetCore.SignalR
 
             try
             {
+                var input = connection.Input;
+                var protocol = connection.Protocol;
                 while (true)
                 {
-                    var result = await connection.Input.ReadAsync(connection.ConnectionAborted);
+                    var result = await input.ReadAsync(connection.ConnectionAborted);
                     var buffer = result.Buffer;
 
                     try
                     {
                         if (!buffer.IsEmpty)
                         {
-                            while (connection.Protocol.TryParseMessage(ref buffer, _dispatcher, out var message))
+                            while (protocol.TryParseMessage(ref buffer, _dispatcher, out var message))
                             {
                                 // Don't wait on the result of execution, continue processing other
                                 // incoming messages on this connection.
@@ -195,7 +197,7 @@ namespace Microsoft.AspNetCore.SignalR
                         // The buffer was sliced up to where it was consumed, so we can just advance to the start.
                         // We mark examined as buffer.End so that if we didn't receive a full frame, we'll wait for more data
                         // before yielding the read again.
-                        connection.Input.AdvanceTo(buffer.Start, buffer.End);
+                        input.AdvanceTo(buffer.Start, buffer.End);
                     }
                 }
             }


### PR DESCRIPTION
Before:
```
       Method | Connections | Protocol |         Mean |      Error |     StdDev |      Op/s |  Gen 0 | Allocated |
------------- |------------ |--------- |-------------:|-----------:|-----------:|----------:|-------:|----------:|
 SendAsyncAll |           1 |  msgpack |     3.525 us |  0.0705 us |  0.1857 us | 283,695.9 | 0.0038 |     285 B |
 SendAsyncAll |          10 |  msgpack |    28.724 us |  0.5728 us |  0.9086 us |  34,814.7 |      - |     880 B |
 SendAsyncAll |        1000 |  msgpack | 2,581.824 us | 36.6386 us | 34.2718 us |     387.3 |      - |   64240 B |
```

After:
```
       Method | Connections | Protocol |         Mean |      Error |     StdDev |      Op/s |  Gen 0 | Allocated |
------------- |------------ |--------- |-------------:|-----------:|-----------:|----------:|-------:|----------:|
 SendAsyncAll |           1 |  msgpack |     3.410 us |  0.0701 us |  0.2068 us | 293,256.5 | 0.0038 |     284 B |
 SendAsyncAll |          10 |  msgpack |    26.992 us |  0.2720 us |  0.2272 us |  37,048.2 |      - |     880 B |
 SendAsyncAll |        1000 |  msgpack | 2,495.333 us | 45.5888 us | 42.6438 us |     400.7 |      - |   64240 B |
```