### PR TITLE
API review changes for Microsoft.AspNetCore.SignalR

### DIFF
--- a/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/BroadcastBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/BroadcastBenchmark.cs
@@ -49,7 +49,7 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
                 var hubConnection = new HubConnectionContext(connection, Timeout.InfiniteTimeSpan, NullLoggerFactory.Instance);
                 hubConnection.Protocol = protocol;
                 _hubLifetimeManager.OnConnectedAsync(hubConnection).GetAwaiter().GetResult();
-                _hubLifetimeManager.AddGroupAsync(connection.ConnectionId, TestGroupName).GetAwaiter().GetResult();
+                _hubLifetimeManager.AddGroupAsync(TestGroupName, connection.ConnectionId).GetAwaiter().GetResult();
 
                 _ = ConsumeAsync(connection.Application);
             }

--- a/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/BroadcastBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/BroadcastBenchmark.cs
@@ -49,7 +49,7 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
                 var hubConnection = new HubConnectionContext(connection, Timeout.InfiniteTimeSpan, NullLoggerFactory.Instance);
                 hubConnection.Protocol = protocol;
                 _hubLifetimeManager.OnConnectedAsync(hubConnection).GetAwaiter().GetResult();
-                _hubLifetimeManager.AddGroupAsync(TestGroupName, connection.ConnectionId).GetAwaiter().GetResult();
+                _hubLifetimeManager.AddToGroupAsync(connection.ConnectionId, TestGroupName).GetAwaiter().GetResult();
 
                 _ = ConsumeAsync(connection.Application);
             }

--- a/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/DefaultHubActivatorBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/DefaultHubActivatorBenchmark.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using BenchmarkDotNet.Attributes;
+using Microsoft.AspNetCore.SignalR.Internal;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNetCore.SignalR.Microbenchmarks

--- a/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/DefaultHubLifetimeManagerBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/DefaultHubLifetimeManagerBenchmark.cs
@@ -56,7 +56,7 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
                 hubConnectionContext.Protocol = jsonHubProtocol;
 
                 _hubLifetimeManager.OnConnectedAsync(hubConnectionContext).GetAwaiter().GetResult();
-                _hubLifetimeManager.AddGroupAsync(groupName, connectionId);
+                _hubLifetimeManager.AddToGroupAsync(connectionId, groupName);
             }
         }
 

--- a/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/DefaultHubLifetimeManagerBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/DefaultHubLifetimeManagerBenchmark.cs
@@ -56,7 +56,7 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
                 hubConnectionContext.Protocol = jsonHubProtocol;
 
                 _hubLifetimeManager.OnConnectedAsync(hubConnectionContext).GetAwaiter().GetResult();
-                _hubLifetimeManager.AddGroupAsync(connectionId, groupName);
+                _hubLifetimeManager.AddGroupAsync(groupName, connectionId);
             }
         }
 

--- a/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/RedisHubLifetimeManagerBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/RedisHubLifetimeManagerBenchmark.cs
@@ -52,8 +52,8 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
             async Task ConnectClient(TestClient client, IHubProtocol protocol, string userId, string groupName)
             {
                 await _manager2.OnConnectedAsync(HubConnectionContextUtils.Create(client.Connection, protocol, userId));
-                await _manager2.AddGroupAsync("Everyone", client.Connection.ConnectionId);
-                await _manager2.AddGroupAsync(groupName, client.Connection.ConnectionId);
+                await _manager2.AddToGroupAsync(client.Connection.ConnectionId, "Everyone");
+                await _manager2.AddToGroupAsync(client.Connection.ConnectionId, groupName);
             }
 
             // Connect clients

--- a/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/RedisHubLifetimeManagerBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/RedisHubLifetimeManagerBenchmark.cs
@@ -49,11 +49,11 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
             _manager1 = new RedisHubLifetimeManager<TestHub>(logger, options, resolver);
             _manager2 = new RedisHubLifetimeManager<TestHub>(logger, options, resolver);
 
-            async Task ConnectClient(TestClient client, IHubProtocol protocol, string userId, string group)
+            async Task ConnectClient(TestClient client, IHubProtocol protocol, string userId, string groupName)
             {
                 await _manager2.OnConnectedAsync(HubConnectionContextUtils.Create(client.Connection, protocol, userId));
-                await _manager2.AddGroupAsync(client.Connection.ConnectionId, "Everyone");
-                await _manager2.AddGroupAsync(client.Connection.ConnectionId, group);
+                await _manager2.AddGroupAsync("Everyone", client.Connection.ConnectionId);
+                await _manager2.AddGroupAsync(groupName, client.Connection.ConnectionId);
             }
 
             // Connect clients

--- a/samples/ChatSample/PresenceHubLifetimeManager.cs
+++ b/samples/ChatSample/PresenceHubLifetimeManager.cs
@@ -173,9 +173,9 @@ namespace ChatSample
             return _wrappedHubLifetimeManager.SendUserAsync(userId, methodName, args);
         }
 
-        public override Task AddGroupAsync(string connectionId, string groupName)
+        public override Task AddGroupAsync(string groupName, string connectionId)
         {
-            return _wrappedHubLifetimeManager.AddGroupAsync(connectionId, groupName);
+            return _wrappedHubLifetimeManager.AddGroupAsync(groupName, connectionId);
         }
 
         public override Task RemoveGroupAsync(string connectionId, string groupName)

--- a/samples/ChatSample/PresenceHubLifetimeManager.cs
+++ b/samples/ChatSample/PresenceHubLifetimeManager.cs
@@ -173,14 +173,14 @@ namespace ChatSample
             return _wrappedHubLifetimeManager.SendUserAsync(userId, methodName, args);
         }
 
-        public override Task AddGroupAsync(string groupName, string connectionId)
+        public override Task AddToGroupAsync(string connectionId, string groupName)
         {
-            return _wrappedHubLifetimeManager.AddGroupAsync(groupName, connectionId);
+            return _wrappedHubLifetimeManager.AddToGroupAsync(connectionId, groupName);
         }
 
-        public override Task RemoveGroupAsync(string connectionId, string groupName)
+        public override Task RemoveFromGroupAsync(string connectionId, string groupName)
         {
-            return _wrappedHubLifetimeManager.RemoveGroupAsync(connectionId, groupName);
+            return _wrappedHubLifetimeManager.RemoveFromGroupAsync(connectionId, groupName);
         }
 
         public override Task SendGroupExceptAsync(string groupName, string methodName, object[] args, IReadOnlyList<string> excludedIds)

--- a/samples/SignalRSamples/Hubs/Chat.cs
+++ b/samples/SignalRSamples/Hubs/Chat.cs
@@ -46,7 +46,7 @@ namespace SignalRSamples.Hubs
 
         public async Task JoinGroup(string groupName)
         {
-            await Groups.AddAsync(Context.ConnectionId, groupName);
+            await Groups.AddAsync(groupName, Context.ConnectionId);
 
             await Clients.Group(groupName).SendAsync("Send", $"{Context.ConnectionId} joined {groupName}");
         }
@@ -55,7 +55,7 @@ namespace SignalRSamples.Hubs
         {
             await Clients.Group(groupName).SendAsync("Send", $"{Context.ConnectionId} left {groupName}");
 
-            await Groups.RemoveAsync(Context.ConnectionId, groupName);
+            await Groups.RemoveAsync(groupName, Context.ConnectionId);
         }
 
         public Task Echo(string message)

--- a/samples/SignalRSamples/Hubs/Chat.cs
+++ b/samples/SignalRSamples/Hubs/Chat.cs
@@ -46,7 +46,7 @@ namespace SignalRSamples.Hubs
 
         public async Task JoinGroup(string groupName)
         {
-            await Groups.AddAsync(groupName, Context.ConnectionId);
+            await Groups.AddToGroupAsync(groupName, Context.ConnectionId);
 
             await Clients.Group(groupName).SendAsync("Send", $"{Context.ConnectionId} joined {groupName}");
         }
@@ -55,7 +55,7 @@ namespace SignalRSamples.Hubs
         {
             await Clients.Group(groupName).SendAsync("Send", $"{Context.ConnectionId} left {groupName}");
 
-            await Groups.RemoveAsync(groupName, Context.ConnectionId);
+            await Groups.RemoveFromGroupAsync(groupName, Context.ConnectionId);
         }
 
         public Task Echo(string message)

--- a/samples/SignalRSamples/Hubs/Chat.cs
+++ b/samples/SignalRSamples/Hubs/Chat.cs
@@ -46,7 +46,7 @@ namespace SignalRSamples.Hubs
 
         public async Task JoinGroup(string groupName)
         {
-            await Groups.AddToGroupAsync(groupName, Context.ConnectionId);
+            await Groups.AddToGroupAsync(Context.ConnectionId, groupName);
 
             await Clients.Group(groupName).SendAsync("Send", $"{Context.ConnectionId} joined {groupName}");
         }
@@ -55,7 +55,7 @@ namespace SignalRSamples.Hubs
         {
             await Clients.Group(groupName).SendAsync("Send", $"{Context.ConnectionId} left {groupName}");
 
-            await Groups.RemoveFromGroupAsync(groupName, Context.ConnectionId);
+            await Groups.RemoveFromGroupAsync(Context.ConnectionId, groupName);
         }
 
         public Task Echo(string message)

--- a/samples/SignalRSamples/Hubs/DynamicChat.cs
+++ b/samples/SignalRSamples/Hubs/DynamicChat.cs
@@ -41,7 +41,7 @@ namespace SignalRSamples.Hubs
 
         public async Task JoinGroup(string groupName)
         {
-            await Groups.AddToGroupAsync(groupName, Context.ConnectionId);
+            await Groups.AddToGroupAsync(Context.ConnectionId, groupName);
 
             await Clients.Group(groupName).Send($"{Context.ConnectionId} joined {groupName}");
         }
@@ -50,7 +50,7 @@ namespace SignalRSamples.Hubs
         {
             await Clients.Group(groupName).Send($"{Context.ConnectionId} left {groupName}");
 
-            await Groups.RemoveFromGroupAsync(groupName, Context.ConnectionId);
+            await Groups.RemoveFromGroupAsync(Context.ConnectionId, groupName);
         }
 
         public Task Echo(string message)

--- a/samples/SignalRSamples/Hubs/DynamicChat.cs
+++ b/samples/SignalRSamples/Hubs/DynamicChat.cs
@@ -41,7 +41,7 @@ namespace SignalRSamples.Hubs
 
         public async Task JoinGroup(string groupName)
         {
-            await Groups.AddAsync(groupName, Context.ConnectionId);
+            await Groups.AddToGroupAsync(groupName, Context.ConnectionId);
 
             await Clients.Group(groupName).Send($"{Context.ConnectionId} joined {groupName}");
         }
@@ -50,7 +50,7 @@ namespace SignalRSamples.Hubs
         {
             await Clients.Group(groupName).Send($"{Context.ConnectionId} left {groupName}");
 
-            await Groups.RemoveAsync(groupName, Context.ConnectionId);
+            await Groups.RemoveFromGroupAsync(groupName, Context.ConnectionId);
         }
 
         public Task Echo(string message)

--- a/samples/SignalRSamples/Hubs/DynamicChat.cs
+++ b/samples/SignalRSamples/Hubs/DynamicChat.cs
@@ -41,7 +41,7 @@ namespace SignalRSamples.Hubs
 
         public async Task JoinGroup(string groupName)
         {
-            await Groups.AddAsync(Context.ConnectionId, groupName);
+            await Groups.AddAsync(groupName, Context.ConnectionId);
 
             await Clients.Group(groupName).Send($"{Context.ConnectionId} joined {groupName}");
         }
@@ -50,7 +50,7 @@ namespace SignalRSamples.Hubs
         {
             await Clients.Group(groupName).Send($"{Context.ConnectionId} left {groupName}");
 
-            await Groups.RemoveAsync(Context.ConnectionId, groupName);
+            await Groups.RemoveAsync(groupName, Context.ConnectionId);
         }
 
         public Task Echo(string message)

--- a/samples/SignalRSamples/Hubs/HubTChat.cs
+++ b/samples/SignalRSamples/Hubs/HubTChat.cs
@@ -41,7 +41,7 @@ namespace SignalRSamples.Hubs
 
         public async Task JoinGroup(string groupName)
         {
-            await Groups.AddToGroupAsync(groupName, Context.ConnectionId);
+            await Groups.AddToGroupAsync(Context.ConnectionId, groupName);
 
             await Clients.Group(groupName).Send($"{Context.ConnectionId} joined {groupName}");
         }
@@ -50,7 +50,7 @@ namespace SignalRSamples.Hubs
         {
             await Clients.Group(groupName).Send($"{Context.ConnectionId} left {groupName}");
 
-            await Groups.RemoveFromGroupAsync(groupName, Context.ConnectionId);
+            await Groups.RemoveFromGroupAsync(Context.ConnectionId, groupName);
         }
 
         public Task Echo(string message)

--- a/samples/SignalRSamples/Hubs/HubTChat.cs
+++ b/samples/SignalRSamples/Hubs/HubTChat.cs
@@ -41,7 +41,7 @@ namespace SignalRSamples.Hubs
 
         public async Task JoinGroup(string groupName)
         {
-            await Groups.AddAsync(groupName, Context.ConnectionId);
+            await Groups.AddToGroupAsync(groupName, Context.ConnectionId);
 
             await Clients.Group(groupName).Send($"{Context.ConnectionId} joined {groupName}");
         }
@@ -50,7 +50,7 @@ namespace SignalRSamples.Hubs
         {
             await Clients.Group(groupName).Send($"{Context.ConnectionId} left {groupName}");
 
-            await Groups.RemoveAsync(groupName, Context.ConnectionId);
+            await Groups.RemoveFromGroupAsync(groupName, Context.ConnectionId);
         }
 
         public Task Echo(string message)

--- a/samples/SignalRSamples/Hubs/HubTChat.cs
+++ b/samples/SignalRSamples/Hubs/HubTChat.cs
@@ -41,7 +41,7 @@ namespace SignalRSamples.Hubs
 
         public async Task JoinGroup(string groupName)
         {
-            await Groups.AddAsync(Context.ConnectionId, groupName);
+            await Groups.AddAsync(groupName, Context.ConnectionId);
 
             await Clients.Group(groupName).Send($"{Context.ConnectionId} joined {groupName}");
         }
@@ -50,7 +50,7 @@ namespace SignalRSamples.Hubs
         {
             await Clients.Group(groupName).Send($"{Context.ConnectionId} left {groupName}");
 
-            await Groups.RemoveAsync(Context.ConnectionId, groupName);
+            await Groups.RemoveAsync(groupName, Context.ConnectionId);
         }
 
         public Task Echo(string message)

--- a/src/Microsoft.AspNetCore.SignalR.Core/ClientProxyExtensions.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/ClientProxyExtensions.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.AspNetCore.SignalR
 {
-    public static class IClientProxyExtensions
+    public static class ClientProxyExtensions
     {
         /// <summary>
         /// Invokes a method on the connection(s) represented by the <see cref="IClientProxy"/> instance.

--- a/src/Microsoft.AspNetCore.SignalR.Core/DefaultHubLifetimeManager.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/DefaultHubLifetimeManager.cs
@@ -23,7 +23,7 @@ namespace Microsoft.AspNetCore.SignalR
             _logger = logger;
         }
 
-        public override Task AddGroupAsync(string connectionId, string groupName)
+        public override Task AddGroupAsync(string groupName, string connectionId)
         {
             if (connectionId == null)
             {

--- a/src/Microsoft.AspNetCore.SignalR.Core/DefaultHubLifetimeManager.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/DefaultHubLifetimeManager.cs
@@ -23,7 +23,7 @@ namespace Microsoft.AspNetCore.SignalR
             _logger = logger;
         }
 
-        public override Task AddGroupAsync(string groupName, string connectionId)
+        public override Task AddToGroupAsync(string connectionId, string groupName)
         {
             if (connectionId == null)
             {
@@ -46,7 +46,7 @@ namespace Microsoft.AspNetCore.SignalR
             return Task.CompletedTask;
         }
 
-        public override Task RemoveGroupAsync(string connectionId, string groupName)
+        public override Task RemoveFromGroupAsync(string connectionId, string groupName)
         {
             if (connectionId == null)
             {

--- a/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionContext.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionContext.cs
@@ -52,7 +52,8 @@ namespace Microsoft.AspNetCore.SignalR
 
         public virtual IDictionary<object, object> Items => _connectionContext.Items;
 
-        public virtual PipeReader Input => _connectionContext.Transport.Input;
+        // Used by HubConnectionHandler
+        internal PipeReader Input => _connectionContext.Transport.Input;
 
         public string UserIdentifier { get; set; }
 

--- a/src/Microsoft.AspNetCore.SignalR.Core/HubLifetimeManager.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/HubLifetimeManager.cs
@@ -30,7 +30,7 @@ namespace Microsoft.AspNetCore.SignalR
 
         public abstract Task SendUsersAsync(IReadOnlyList<string> userIds, string methodName, object[] args);
 
-        public abstract Task AddGroupAsync(string connectionId, string groupName);
+        public abstract Task AddGroupAsync(string groupName, string connectionId);
 
         public abstract Task RemoveGroupAsync(string connectionId, string groupName);
     }

--- a/src/Microsoft.AspNetCore.SignalR.Core/HubLifetimeManager.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/HubLifetimeManager.cs
@@ -30,9 +30,9 @@ namespace Microsoft.AspNetCore.SignalR
 
         public abstract Task SendUsersAsync(IReadOnlyList<string> userIds, string methodName, object[] args);
 
-        public abstract Task AddGroupAsync(string groupName, string connectionId);
+        public abstract Task AddToGroupAsync(string connectionId, string groupName);
 
-        public abstract Task RemoveGroupAsync(string connectionId, string groupName);
+        public abstract Task RemoveFromGroupAsync(string connectionId, string groupName);
     }
 
 }

--- a/src/Microsoft.AspNetCore.SignalR.Core/IGroupManager.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/IGroupManager.cs
@@ -7,7 +7,7 @@ namespace Microsoft.AspNetCore.SignalR
 {
     public interface IGroupManager
     {
-        Task AddAsync(string connectionId, string groupName);
-        Task RemoveAsync(string connectionId, string groupName);
+        Task AddAsync(string groupName, string connectionId);
+        Task RemoveAsync(string groupName, string connectionId);
     }
 }

--- a/src/Microsoft.AspNetCore.SignalR.Core/IGroupManager.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/IGroupManager.cs
@@ -7,7 +7,7 @@ namespace Microsoft.AspNetCore.SignalR
 {
     public interface IGroupManager
     {
-        Task AddToGroupAsync(string groupName, string connectionId);
-        Task RemoveFromGroupAsync(string groupName, string connectionId);
+        Task AddToGroupAsync(string connectionId, string groupName);
+        Task RemoveFromGroupAsync(string connectionId, string groupName);
     }
 }

--- a/src/Microsoft.AspNetCore.SignalR.Core/IGroupManager.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/IGroupManager.cs
@@ -7,7 +7,7 @@ namespace Microsoft.AspNetCore.SignalR
 {
     public interface IGroupManager
     {
-        Task AddAsync(string groupName, string connectionId);
-        Task RemoveAsync(string groupName, string connectionId);
+        Task AddToGroupAsync(string groupName, string connectionId);
+        Task RemoveFromGroupAsync(string groupName, string connectionId);
     }
 }

--- a/src/Microsoft.AspNetCore.SignalR.Core/IHubClients`T.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/IHubClients`T.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNetCore.SignalR
     {
         T All { get; }
 
-        T AllExcept(IReadOnlyList<string> excludedIds);
+        T AllExcept(IReadOnlyList<string> excludedConnectionIds);
 
         T Client(string connectionId);
 
@@ -19,7 +19,7 @@ namespace Microsoft.AspNetCore.SignalR
 
         T Groups(IReadOnlyList<string> groupNames);
 
-        T GroupExcept(string groupName, IReadOnlyList<string> excludeIds);
+        T GroupExcept(string groupName, IReadOnlyList<string> excludedConnectionIds);
 
         T User(string userId);
 

--- a/src/Microsoft.AspNetCore.SignalR.Core/Internal/DefaultHubActivator.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/Internal/DefaultHubActivator.cs
@@ -5,7 +5,7 @@ using System;
 using System.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace Microsoft.AspNetCore.SignalR
+namespace Microsoft.AspNetCore.SignalR.Internal
 {
     public class DefaultHubActivator<THub> : IHubActivator<THub> where THub: Hub
     {
@@ -19,7 +19,7 @@ namespace Microsoft.AspNetCore.SignalR
             _serviceProvider = serviceProvider;
         }
 
-        public THub Create()
+        public virtual THub Create()
         {
             Debug.Assert(!_created.HasValue, "hub activators must not be reused.");
 
@@ -34,7 +34,7 @@ namespace Microsoft.AspNetCore.SignalR
             return hub;
         }
 
-        public void Release(THub hub)
+        public virtual void Release(THub hub)
         {
             if (hub == null)
             {

--- a/src/Microsoft.AspNetCore.SignalR.Core/Internal/DefaultHubCallerContext.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/Internal/DefaultHubCallerContext.cs
@@ -8,7 +8,7 @@ using System.Security.Claims;
 using System.Threading;
 using Microsoft.AspNetCore.Http.Features;
 
-namespace Microsoft.AspNetCore.SignalR
+namespace Microsoft.AspNetCore.SignalR.Internal
 {
     public class DefaultHubCallerContext : HubCallerContext
     {

--- a/src/Microsoft.AspNetCore.SignalR.Core/Internal/HubCallerClients.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/Internal/HubCallerClients.cs
@@ -24,9 +24,9 @@ namespace Microsoft.AspNetCore.SignalR.Internal
 
         public IClientProxy All => _hubClients.All;
 
-        public IClientProxy AllExcept(IReadOnlyList<string> excludedIds)
+        public IClientProxy AllExcept(IReadOnlyList<string> excludedConnectionIds)
         {
-            return _hubClients.AllExcept(excludedIds);
+            return _hubClients.AllExcept(excludedConnectionIds);
         }
 
         public IClientProxy Client(string connectionId)
@@ -49,9 +49,9 @@ namespace Microsoft.AspNetCore.SignalR.Internal
             return _hubClients.GroupExcept(groupName, _currentConnectionId);
         }
 
-        public IClientProxy GroupExcept(string groupName, IReadOnlyList<string> excludeIds)
+        public IClientProxy GroupExcept(string groupName, IReadOnlyList<string> excludedConnectionIds)
         {
-            return _hubClients.GroupExcept(groupName, excludeIds);
+            return _hubClients.GroupExcept(groupName, excludedConnectionIds);
         }
 
         public IClientProxy User(string userId)

--- a/src/Microsoft.AspNetCore.SignalR.Core/Internal/HubClients.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/Internal/HubClients.cs
@@ -17,9 +17,9 @@ namespace Microsoft.AspNetCore.SignalR.Internal
 
         public IClientProxy All { get; }
 
-        public IClientProxy AllExcept(IReadOnlyList<string> excludedIds)
+        public IClientProxy AllExcept(IReadOnlyList<string> excludedConnectionIds)
         {
-            return new AllClientsExceptProxy<THub>(_lifetimeManager, excludedIds);
+            return new AllClientsExceptProxy<THub>(_lifetimeManager, excludedConnectionIds);
         }
 
         public IClientProxy Client(string connectionId)
@@ -32,9 +32,9 @@ namespace Microsoft.AspNetCore.SignalR.Internal
             return new GroupProxy<THub>(_lifetimeManager, groupName);
         }
 
-        public IClientProxy GroupExcept(string groupName, IReadOnlyList<string> excludeIds)
+        public IClientProxy GroupExcept(string groupName, IReadOnlyList<string> excludedConnectionIds)
         {
-            return new GroupExceptProxy<THub>(_lifetimeManager, groupName, excludeIds);
+            return new GroupExceptProxy<THub>(_lifetimeManager, groupName, excludedConnectionIds);
         }
 
         public IClientProxy Clients(IReadOnlyList<string> connectionIds)

--- a/src/Microsoft.AspNetCore.SignalR.Core/Internal/HubClients`T.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/Internal/HubClients`T.cs
@@ -17,9 +17,9 @@ namespace Microsoft.AspNetCore.SignalR.Internal
 
         public T All { get; }
 
-        public T AllExcept(IReadOnlyList<string> excludedIds)
+        public T AllExcept(IReadOnlyList<string> excludedConnectionIds)
         {
-            return TypedClientBuilder<T>.Build(new AllClientsExceptProxy<THub>(_lifetimeManager, excludedIds));
+            return TypedClientBuilder<T>.Build(new AllClientsExceptProxy<THub>(_lifetimeManager, excludedConnectionIds));
         }
 
         public virtual T Client(string connectionId)
@@ -37,9 +37,9 @@ namespace Microsoft.AspNetCore.SignalR.Internal
             return TypedClientBuilder<T>.Build(new GroupProxy<THub>(_lifetimeManager, groupName));
         }
 
-        public T GroupExcept(string groupName, IReadOnlyList<string> excludeIds)
+        public T GroupExcept(string groupName, IReadOnlyList<string> excludedConnectionIds)
         {
-            return TypedClientBuilder<T>.Build(new GroupExceptProxy<THub>(_lifetimeManager, groupName, excludeIds));
+            return TypedClientBuilder<T>.Build(new GroupExceptProxy<THub>(_lifetimeManager, groupName, excludedConnectionIds));
         }
 
         public T Groups(IReadOnlyList<string> groupNames)

--- a/src/Microsoft.AspNetCore.SignalR.Core/Internal/HubConnectionStore.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/Internal/HubConnectionStore.cs
@@ -6,7 +6,7 @@ using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 
-namespace Microsoft.AspNetCore.SignalR
+namespace Microsoft.AspNetCore.SignalR.Internal
 {
     public class HubConnectionStore
     {

--- a/src/Microsoft.AspNetCore.SignalR.Core/Internal/Proxies.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/Internal/Proxies.cs
@@ -168,14 +168,14 @@ namespace Microsoft.AspNetCore.SignalR.Internal
             _lifetimeManager = lifetimeManager;
         }
 
-        public Task AddToGroupAsync(string groupName, string connectionId)
+        public Task AddToGroupAsync(string connectionId, string groupName)
         {
-            return _lifetimeManager.AddGroupAsync(groupName, connectionId);
+            return _lifetimeManager.AddToGroupAsync(connectionId, groupName);
         }
 
-        public Task RemoveFromGroupAsync(string groupName, string connectionId)
+        public Task RemoveFromGroupAsync(string connectionId, string groupName)
         {
-            return _lifetimeManager.RemoveGroupAsync(connectionId, groupName);
+            return _lifetimeManager.RemoveFromGroupAsync(connectionId, groupName);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.SignalR.Core/Internal/Proxies.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/Internal/Proxies.cs
@@ -168,12 +168,12 @@ namespace Microsoft.AspNetCore.SignalR.Internal
             _lifetimeManager = lifetimeManager;
         }
 
-        public Task AddAsync(string connectionId, string groupName)
+        public Task AddAsync(string groupName, string connectionId)
         {
-            return _lifetimeManager.AddGroupAsync(connectionId, groupName);
+            return _lifetimeManager.AddGroupAsync(groupName, connectionId);
         }
 
-        public Task RemoveAsync(string connectionId, string groupName)
+        public Task RemoveAsync(string groupName, string connectionId)
         {
             return _lifetimeManager.RemoveGroupAsync(connectionId, groupName);
         }

--- a/src/Microsoft.AspNetCore.SignalR.Core/Internal/Proxies.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/Internal/Proxies.cs
@@ -168,12 +168,12 @@ namespace Microsoft.AspNetCore.SignalR.Internal
             _lifetimeManager = lifetimeManager;
         }
 
-        public Task AddAsync(string groupName, string connectionId)
+        public Task AddToGroupAsync(string groupName, string connectionId)
         {
             return _lifetimeManager.AddGroupAsync(groupName, connectionId);
         }
 
-        public Task RemoveAsync(string groupName, string connectionId)
+        public Task RemoveFromGroupAsync(string groupName, string connectionId)
         {
             return _lifetimeManager.RemoveGroupAsync(connectionId, groupName);
         }

--- a/src/Microsoft.AspNetCore.SignalR.Core/TypedHubClients.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/TypedHubClients.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNetCore.SignalR
 
         public T Others => TypedClientBuilder<T>.Build(_hubClients.Others);
 
-        public T AllExcept(IReadOnlyList<string> excludedIds) => TypedClientBuilder<T>.Build(_hubClients.AllExcept(excludedIds));
+        public T AllExcept(IReadOnlyList<string> excludedConnectionIds) => TypedClientBuilder<T>.Build(_hubClients.AllExcept(excludedConnectionIds));
 
         public T Client(string connectionId)
         {
@@ -32,9 +32,9 @@ namespace Microsoft.AspNetCore.SignalR
             return TypedClientBuilder<T>.Build(_hubClients.Group(groupName));
         }
 
-        public T GroupExcept(string groupName, IReadOnlyList<string> excludeIds)
+        public T GroupExcept(string groupName, IReadOnlyList<string> excludedConnectionIds)
         {
-            return TypedClientBuilder<T>.Build(_hubClients.GroupExcept(groupName, excludeIds));
+            return TypedClientBuilder<T>.Build(_hubClients.GroupExcept(groupName, excludedConnectionIds));
         }
 
         public T Clients(IReadOnlyList<string> connectionIds)

--- a/src/Microsoft.AspNetCore.SignalR.Redis/RedisHubLifetimeManager.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Redis/RedisHubLifetimeManager.cs
@@ -165,7 +165,7 @@ namespace Microsoft.AspNetCore.SignalR.Redis
             return PublishAsync(_channels.User(userId), message);
         }
 
-        public override async Task AddGroupAsync(string connectionId, string groupName)
+        public override async Task AddGroupAsync(string groupName, string connectionId)
         {
             if (connectionId == null)
             {

--- a/src/Microsoft.AspNetCore.SignalR.Redis/RedisHubLifetimeManager.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Redis/RedisHubLifetimeManager.cs
@@ -94,7 +94,7 @@ namespace Microsoft.AspNetCore.SignalR.Redis
             if (groupNames != null)
             {
                 // Copy the groups to an array here because they get removed from this collection
-                // in RemoveGroupAsync
+                // in RemoveFromGroupAsync
                 foreach (var group in groupNames.ToArray())
                 {
                     // Use RemoveGroupAsyncCore because the connection is local and we don't want to
@@ -165,7 +165,7 @@ namespace Microsoft.AspNetCore.SignalR.Redis
             return PublishAsync(_channels.User(userId), message);
         }
 
-        public override async Task AddGroupAsync(string groupName, string connectionId)
+        public override async Task AddToGroupAsync(string connectionId, string groupName)
         {
             if (connectionId == null)
             {
@@ -188,7 +188,7 @@ namespace Microsoft.AspNetCore.SignalR.Redis
             await SendGroupActionAndWaitForAck(connectionId, groupName, GroupAction.Add);
         }
 
-        public override async Task RemoveGroupAsync(string connectionId, string groupName)
+        public override async Task RemoveFromGroupAsync(string connectionId, string groupName)
         {
             if (connectionId == null)
             {

--- a/src/Microsoft.AspNetCore.SignalR/HubRouteBuilder.cs
+++ b/src/Microsoft.AspNetCore.SignalR/HubRouteBuilder.cs
@@ -18,11 +18,6 @@ namespace Microsoft.AspNetCore.SignalR
             _routes = routes;
         }
 
-        public void MapHub<THub>(string path) where THub : Hub
-        {
-            MapHub<THub>(new PathString(path), configureOptions: null);
-        }
-
         public void MapHub<THub>(PathString path) where THub : Hub
         {
             MapHub<THub>(path, configureOptions: null);

--- a/test/Microsoft.AspNetCore.SignalR.Redis.Tests/EchoHub.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Redis.Tests/EchoHub.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
 
         public Task AddSelfToGroup(string groupName)
         {
-            return Groups.AddToGroupAsync(groupName, Context.ConnectionId);
+            return Groups.AddToGroupAsync(Context.ConnectionId, groupName);
         }
     }
 }

--- a/test/Microsoft.AspNetCore.SignalR.Redis.Tests/EchoHub.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Redis.Tests/EchoHub.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
 
         public Task AddSelfToGroup(string groupName)
         {
-            return Groups.AddAsync(groupName, Context.ConnectionId);
+            return Groups.AddToGroupAsync(groupName, Context.ConnectionId);
         }
     }
 }

--- a/test/Microsoft.AspNetCore.SignalR.Redis.Tests/EchoHub.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Redis.Tests/EchoHub.cs
@@ -13,14 +13,14 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
             return message;
         }
 
-        public Task EchoGroup(string group, string message)
+        public Task EchoGroup(string groupName, string message)
         {
-            return Clients.Group(group).SendAsync("Echo", message);
+            return Clients.Group(groupName).SendAsync("Echo", message);
         }
 
-        public Task AddSelfToGroup(string group)
+        public Task AddSelfToGroup(string groupName)
         {
-            return Groups.AddAsync(Context.ConnectionId, group);
+            return Groups.AddAsync(groupName, Context.ConnectionId);
         }
     }
 }

--- a/test/Microsoft.AspNetCore.SignalR.Redis.Tests/RedisHubLifetimeManagerTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Redis.Tests/RedisHubLifetimeManagerTests.cs
@@ -110,7 +110,7 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
                 await manager.OnConnectedAsync(connection1).OrTimeout();
                 await manager.OnConnectedAsync(connection2).OrTimeout();
 
-                await manager.AddGroupAsync(connection1.ConnectionId, "gunit").OrTimeout();
+                await manager.AddGroupAsync("gunit", connection1.ConnectionId).OrTimeout();
 
                 await manager.SendGroupAsync("gunit", "Hello", new object[] { "World" }).OrTimeout();
 
@@ -134,8 +134,8 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
                 await manager.OnConnectedAsync(connection1).OrTimeout();
                 await manager.OnConnectedAsync(connection2).OrTimeout();
 
-                await manager.AddGroupAsync(connection1.ConnectionId, "gunit").OrTimeout();
-                await manager.AddGroupAsync(connection2.ConnectionId, "gunit").OrTimeout();
+                await manager.AddGroupAsync("gunit", connection1.ConnectionId).OrTimeout();
+                await manager.AddGroupAsync("gunit", connection2.ConnectionId).OrTimeout();
 
                 var excludedIds = new List<string> { client2.Connection.ConnectionId };
                 await manager.SendGroupExceptAsync("gunit", "Hello", new object[] { "World" }, excludedIds).OrTimeout();
@@ -257,7 +257,7 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
 
                 await manager1.OnConnectedAsync(connection).OrTimeout();
 
-                await manager1.AddGroupAsync(connection.ConnectionId, "name").OrTimeout();
+                await manager1.AddGroupAsync("name", connection.ConnectionId).OrTimeout();
 
                 await manager2.SendGroupAsync("name", "Hello", new object[] { "World" }).OrTimeout();
 
@@ -278,7 +278,7 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
 
                 await manager.OnConnectedAsync(connection).OrTimeout();
 
-                await manager.AddGroupAsync(connection.ConnectionId, "name").OrTimeout();
+                await manager.AddGroupAsync("name", connection.ConnectionId).OrTimeout();
 
                 await manager.OnDisconnectedAsync(connection).OrTimeout();
 
@@ -337,7 +337,7 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
 
                 await manager1.OnConnectedAsync(connection).OrTimeout();
 
-                await manager2.AddGroupAsync(connection.ConnectionId, "name").OrTimeout();
+                await manager2.AddGroupAsync("name", connection.ConnectionId).OrTimeout();
 
                 await manager2.SendGroupAsync("name", "Hello", new object[] { "World" }).OrTimeout();
 
@@ -358,8 +358,8 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
 
                 await manager.OnConnectedAsync(connection).OrTimeout();
 
-                await manager.AddGroupAsync(connection.ConnectionId, "name").OrTimeout();
-                await manager.AddGroupAsync(connection.ConnectionId, "name").OrTimeout();
+                await manager.AddGroupAsync("name", connection.ConnectionId).OrTimeout();
+                await manager.AddGroupAsync("name", connection.ConnectionId).OrTimeout();
 
                 await manager.SendGroupAsync("name", "Hello", new object[] { "World" }).OrTimeout();
 
@@ -382,8 +382,8 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
 
                 await manager1.OnConnectedAsync(connection).OrTimeout();
 
-                await manager1.AddGroupAsync(connection.ConnectionId, "name").OrTimeout();
-                await manager2.AddGroupAsync(connection.ConnectionId, "name").OrTimeout();
+                await manager1.AddGroupAsync("name", connection.ConnectionId).OrTimeout();
+                await manager2.AddGroupAsync("name", connection.ConnectionId).OrTimeout();
 
                 await manager2.SendGroupAsync("name", "Hello", new object[] { "World" }).OrTimeout();
 
@@ -406,7 +406,7 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
 
                 await manager1.OnConnectedAsync(connection).OrTimeout();
 
-                await manager1.AddGroupAsync(connection.ConnectionId, "name").OrTimeout();
+                await manager1.AddGroupAsync("name", connection.ConnectionId).OrTimeout();
 
                 await manager2.SendGroupAsync("name", "Hello", new object[] { "World" }).OrTimeout();
 
@@ -484,9 +484,9 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
                 var connection2 = HubConnectionContextUtils.Create(client2.Connection);
 
                 await manager.OnConnectedAsync(connection1).OrTimeout();
-                await manager.AddGroupAsync(connection1.ConnectionId, "group");
+                await manager.AddGroupAsync("group", connection1.ConnectionId);
                 await manager.OnConnectedAsync(connection2).OrTimeout();
-                await manager.AddGroupAsync(connection2.ConnectionId, "group");
+                await manager.AddGroupAsync("group", connection2.ConnectionId);
 
                 await manager.SendGroupAsync("group", "Hello", new object[] { "World" }).OrTimeout();
                 // connection1 will throw when receiving a group message, we are making sure other connections

--- a/test/Microsoft.AspNetCore.SignalR.Redis.Tests/RedisHubLifetimeManagerTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Redis.Tests/RedisHubLifetimeManagerTests.cs
@@ -110,7 +110,7 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
                 await manager.OnConnectedAsync(connection1).OrTimeout();
                 await manager.OnConnectedAsync(connection2).OrTimeout();
 
-                await manager.AddGroupAsync("gunit", connection1.ConnectionId).OrTimeout();
+                await manager.AddToGroupAsync(connection1.ConnectionId, "gunit").OrTimeout();
 
                 await manager.SendGroupAsync("gunit", "Hello", new object[] { "World" }).OrTimeout();
 
@@ -134,8 +134,8 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
                 await manager.OnConnectedAsync(connection1).OrTimeout();
                 await manager.OnConnectedAsync(connection2).OrTimeout();
 
-                await manager.AddGroupAsync("gunit", connection1.ConnectionId).OrTimeout();
-                await manager.AddGroupAsync("gunit", connection2.ConnectionId).OrTimeout();
+                await manager.AddToGroupAsync(connection1.ConnectionId, "gunit").OrTimeout();
+                await manager.AddToGroupAsync(connection2.ConnectionId, "gunit").OrTimeout();
 
                 var excludedIds = new List<string> { client2.Connection.ConnectionId };
                 await manager.SendGroupExceptAsync("gunit", "Hello", new object[] { "World" }, excludedIds).OrTimeout();
@@ -257,7 +257,7 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
 
                 await manager1.OnConnectedAsync(connection).OrTimeout();
 
-                await manager1.AddGroupAsync("name", connection.ConnectionId).OrTimeout();
+                await manager1.AddToGroupAsync(connection.ConnectionId, "name").OrTimeout();
 
                 await manager2.SendGroupAsync("name", "Hello", new object[] { "World" }).OrTimeout();
 
@@ -278,7 +278,7 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
 
                 await manager.OnConnectedAsync(connection).OrTimeout();
 
-                await manager.AddGroupAsync("name", connection.ConnectionId).OrTimeout();
+                await manager.AddToGroupAsync(connection.ConnectionId, "name").OrTimeout();
 
                 await manager.OnDisconnectedAsync(connection).OrTimeout();
 
@@ -301,7 +301,7 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
 
                 await manager.OnConnectedAsync(connection).OrTimeout();
 
-                await manager.RemoveGroupAsync(connection.ConnectionId, "name").OrTimeout();
+                await manager.RemoveFromGroupAsync(connection.ConnectionId, "name").OrTimeout();
             }
         }
 
@@ -319,7 +319,7 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
 
                 await manager1.OnConnectedAsync(connection).OrTimeout();
 
-                await manager2.RemoveGroupAsync(connection.ConnectionId, "name").OrTimeout();
+                await manager2.RemoveFromGroupAsync(connection.ConnectionId, "name").OrTimeout();
             }
         }
 
@@ -337,7 +337,7 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
 
                 await manager1.OnConnectedAsync(connection).OrTimeout();
 
-                await manager2.AddGroupAsync("name", connection.ConnectionId).OrTimeout();
+                await manager2.AddToGroupAsync(connection.ConnectionId, "name").OrTimeout();
 
                 await manager2.SendGroupAsync("name", "Hello", new object[] { "World" }).OrTimeout();
 
@@ -358,8 +358,8 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
 
                 await manager.OnConnectedAsync(connection).OrTimeout();
 
-                await manager.AddGroupAsync("name", connection.ConnectionId).OrTimeout();
-                await manager.AddGroupAsync("name", connection.ConnectionId).OrTimeout();
+                await manager.AddToGroupAsync(connection.ConnectionId, "name").OrTimeout();
+                await manager.AddToGroupAsync(connection.ConnectionId, "name").OrTimeout();
 
                 await manager.SendGroupAsync("name", "Hello", new object[] { "World" }).OrTimeout();
 
@@ -382,8 +382,8 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
 
                 await manager1.OnConnectedAsync(connection).OrTimeout();
 
-                await manager1.AddGroupAsync("name", connection.ConnectionId).OrTimeout();
-                await manager2.AddGroupAsync("name", connection.ConnectionId).OrTimeout();
+                await manager1.AddToGroupAsync(connection.ConnectionId, "name").OrTimeout();
+                await manager2.AddToGroupAsync(connection.ConnectionId, "name").OrTimeout();
 
                 await manager2.SendGroupAsync("name", "Hello", new object[] { "World" }).OrTimeout();
 
@@ -406,13 +406,13 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
 
                 await manager1.OnConnectedAsync(connection).OrTimeout();
 
-                await manager1.AddGroupAsync("name", connection.ConnectionId).OrTimeout();
+                await manager1.AddToGroupAsync(connection.ConnectionId, "name").OrTimeout();
 
                 await manager2.SendGroupAsync("name", "Hello", new object[] { "World" }).OrTimeout();
 
                 await AssertMessageAsync(client);
 
-                await manager2.RemoveGroupAsync(connection.ConnectionId, "name").OrTimeout();
+                await manager2.RemoveFromGroupAsync(connection.ConnectionId, "name").OrTimeout();
 
                 await manager2.SendGroupAsync("name", "Hello", new object[] { "World" }).OrTimeout();
 
@@ -484,9 +484,9 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
                 var connection2 = HubConnectionContextUtils.Create(client2.Connection);
 
                 await manager.OnConnectedAsync(connection1).OrTimeout();
-                await manager.AddGroupAsync("group", connection1.ConnectionId);
+                await manager.AddToGroupAsync(connection1.ConnectionId, "group");
                 await manager.OnConnectedAsync(connection2).OrTimeout();
-                await manager.AddGroupAsync("group", connection2.ConnectionId);
+                await manager.AddToGroupAsync(connection2.ConnectionId, "group");
 
                 await manager.SendGroupAsync("group", "Hello", new object[] { "World" }).OrTimeout();
                 // connection1 will throw when receiving a group message, we are making sure other connections

--- a/test/Microsoft.AspNetCore.SignalR.Tests/DefaultHubActivatorTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/DefaultHubActivatorTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.AspNetCore.SignalR.Internal;
 using Moq;
 using Moq.Protected;
 using Xunit;

--- a/test/Microsoft.AspNetCore.SignalR.Tests/DefaultHubLifetimeManagerTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/DefaultHubLifetimeManagerTests.cs
@@ -75,7 +75,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                 await manager.OnConnectedAsync(connection1).OrTimeout();
                 await manager.OnConnectedAsync(connection2).OrTimeout();
 
-                await manager.AddGroupAsync("gunit", connection1.ConnectionId).OrTimeout();
+                await manager.AddToGroupAsync(connection1.ConnectionId, "gunit").OrTimeout();
 
                 await manager.SendGroupAsync("gunit", "Hello", new object[] { "World" }).OrTimeout();
 
@@ -101,8 +101,8 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                 await manager.OnConnectedAsync(connection1).OrTimeout();
                 await manager.OnConnectedAsync(connection2).OrTimeout();
 
-                await manager.AddGroupAsync("gunit", connection1.ConnectionId).OrTimeout();
-                await manager.AddGroupAsync("gunit", connection2.ConnectionId).OrTimeout();
+                await manager.AddToGroupAsync(connection1.ConnectionId, "gunit").OrTimeout();
+                await manager.AddToGroupAsync(connection2.ConnectionId, "gunit").OrTimeout();
 
                 await manager.SendGroupExceptAsync("gunit", "Hello", new object[] { "World" }, new []{ connection2.ConnectionId }).OrTimeout();
 
@@ -145,14 +145,14 @@ namespace Microsoft.AspNetCore.SignalR.Tests
         public async Task AddGroupOnNonExistentConnectionNoops()
         {
             var manager = new DefaultHubLifetimeManager<MyHub>(new Logger<DefaultHubLifetimeManager<MyHub>>(NullLoggerFactory.Instance));
-            await manager.AddGroupAsync("MyGroup", "NotARealConnectionId").OrTimeout();
+            await manager.AddToGroupAsync("NotARealConnectionId", "MyGroup").OrTimeout();
         }
 
         [Fact]
         public async Task RemoveGroupOnNonExistentConnectionNoops()
         {
             var manager = new DefaultHubLifetimeManager<MyHub>(new Logger<DefaultHubLifetimeManager<MyHub>>(NullLoggerFactory.Instance));
-            await manager.RemoveGroupAsync("NotARealConnectionId", "MyGroup").OrTimeout();
+            await manager.RemoveFromGroupAsync("NotARealConnectionId", "MyGroup").OrTimeout();
         }
 
         private class MyHub : Hub

--- a/test/Microsoft.AspNetCore.SignalR.Tests/DefaultHubLifetimeManagerTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/DefaultHubLifetimeManagerTests.cs
@@ -75,7 +75,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                 await manager.OnConnectedAsync(connection1).OrTimeout();
                 await manager.OnConnectedAsync(connection2).OrTimeout();
 
-                await manager.AddGroupAsync(connection1.ConnectionId, "gunit").OrTimeout();
+                await manager.AddGroupAsync("gunit", connection1.ConnectionId).OrTimeout();
 
                 await manager.SendGroupAsync("gunit", "Hello", new object[] { "World" }).OrTimeout();
 
@@ -101,8 +101,8 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                 await manager.OnConnectedAsync(connection1).OrTimeout();
                 await manager.OnConnectedAsync(connection2).OrTimeout();
 
-                await manager.AddGroupAsync(connection1.ConnectionId, "gunit").OrTimeout();
-                await manager.AddGroupAsync(connection2.ConnectionId, "gunit").OrTimeout();
+                await manager.AddGroupAsync("gunit", connection1.ConnectionId).OrTimeout();
+                await manager.AddGroupAsync("gunit", connection2.ConnectionId).OrTimeout();
 
                 await manager.SendGroupExceptAsync("gunit", "Hello", new object[] { "World" }, new []{ connection2.ConnectionId }).OrTimeout();
 
@@ -145,7 +145,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
         public async Task AddGroupOnNonExistentConnectionNoops()
         {
             var manager = new DefaultHubLifetimeManager<MyHub>(new Logger<DefaultHubLifetimeManager<MyHub>>(NullLoggerFactory.Instance));
-            await manager.AddGroupAsync("NotARealConnectionId", "MyGroup").OrTimeout();
+            await manager.AddGroupAsync("MyGroup", "NotARealConnectionId").OrTimeout();
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.SignalR.Tests/HubConnectionHandlerTestUtils/Hubs.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/HubConnectionHandlerTestUtils/Hubs.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
     {
         public Task GroupRemoveMethod(string groupName)
         {
-            return Groups.RemoveAsync(Context.ConnectionId, groupName);
+            return Groups.RemoveAsync(groupName, Context.ConnectionId);
         }
 
         public Task ClientSendMethod(string userId, string message)
@@ -40,7 +40,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
 
         public Task GroupAddMethod(string groupName)
         {
-            return Groups.AddAsync(Context.ConnectionId, groupName);
+            return Groups.AddAsync(groupName, Context.ConnectionId);
         }
 
         public Task GroupSendMethod(string groupName, string message)
@@ -204,7 +204,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
 
         public Task GroupAddMethod(string groupName)
         {
-            return Groups.AddAsync(Context.ConnectionId, groupName);
+            return Groups.AddAsync(groupName, Context.ConnectionId);
         }
 
         public Task GroupSendMethod(string groupName, string message)
@@ -290,7 +290,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
 
         public Task GroupAddMethod(string groupName)
         {
-            return Groups.AddAsync(Context.ConnectionId, groupName);
+            return Groups.AddAsync(groupName, Context.ConnectionId);
         }
 
         public Task GroupSendMethod(string groupName, string message)

--- a/test/Microsoft.AspNetCore.SignalR.Tests/HubConnectionHandlerTestUtils/Hubs.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/HubConnectionHandlerTestUtils/Hubs.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
     {
         public Task GroupRemoveMethod(string groupName)
         {
-            return Groups.RemoveAsync(groupName, Context.ConnectionId);
+            return Groups.RemoveFromGroupAsync(groupName, Context.ConnectionId);
         }
 
         public Task ClientSendMethod(string userId, string message)
@@ -40,7 +40,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
 
         public Task GroupAddMethod(string groupName)
         {
-            return Groups.AddAsync(groupName, Context.ConnectionId);
+            return Groups.AddToGroupAsync(groupName, Context.ConnectionId);
         }
 
         public Task GroupSendMethod(string groupName, string message)
@@ -204,7 +204,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
 
         public Task GroupAddMethod(string groupName)
         {
-            return Groups.AddAsync(groupName, Context.ConnectionId);
+            return Groups.AddToGroupAsync(groupName, Context.ConnectionId);
         }
 
         public Task GroupSendMethod(string groupName, string message)
@@ -290,7 +290,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
 
         public Task GroupAddMethod(string groupName)
         {
-            return Groups.AddAsync(groupName, Context.ConnectionId);
+            return Groups.AddToGroupAsync(groupName, Context.ConnectionId);
         }
 
         public Task GroupSendMethod(string groupName, string message)

--- a/test/Microsoft.AspNetCore.SignalR.Tests/HubConnectionHandlerTestUtils/Hubs.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/HubConnectionHandlerTestUtils/Hubs.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
     {
         public Task GroupRemoveMethod(string groupName)
         {
-            return Groups.RemoveFromGroupAsync(groupName, Context.ConnectionId);
+            return Groups.RemoveFromGroupAsync(Context.ConnectionId, groupName);
         }
 
         public Task ClientSendMethod(string userId, string message)
@@ -40,7 +40,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
 
         public Task GroupAddMethod(string groupName)
         {
-            return Groups.AddToGroupAsync(groupName, Context.ConnectionId);
+            return Groups.AddToGroupAsync(Context.ConnectionId, groupName);
         }
 
         public Task GroupSendMethod(string groupName, string message)
@@ -204,7 +204,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
 
         public Task GroupAddMethod(string groupName)
         {
-            return Groups.AddToGroupAsync(groupName, Context.ConnectionId);
+            return Groups.AddToGroupAsync(Context.ConnectionId, groupName);
         }
 
         public Task GroupSendMethod(string groupName, string message)
@@ -290,7 +290,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
 
         public Task GroupAddMethod(string groupName)
         {
-            return Groups.AddToGroupAsync(groupName, Context.ConnectionId);
+            return Groups.AddToGroupAsync(Context.ConnectionId, groupName);
         }
 
         public Task GroupSendMethod(string groupName, string message)


### PR DESCRIPTION
- Pubternalize DefaultHubActivator and make methods virtual
- Remove HubConnectionContext.Input **(used by dispatcher so made internal instead)**
- Internalize DefaultHubCallerContext **(used by ChatSample.PresenceHubLifetimeManager so made pub internal)**
- Internalize HubConnectionStore **(used by RedisHubLifetimeManager so made pub internal)**
- Change order arguments in HubLifetimeManager.AddGroupAsync/RemoveGroupAsync
- Change order arguments in IGroupManager.AddGroupAsync/RemoveGroupAsync
- Rename: IClientProxyExtensions -> ClientProxyExtensions
- Remove HubRouteBuilder.MapHub(string)
- Rename excludedIds to excludedConnectionIds in IHubClients.NExcept methods.