### PR TITLE
Rename excludedIds to excludedConnectionIds

### DIFF
--- a/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/RedisHubLifetimeManagerBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/RedisHubLifetimeManagerBenchmark.cs
@@ -24,7 +24,7 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
         private RedisHubLifetimeManager<TestHub> _manager2;
         private TestClient[] _clients;
         private object[] _args;
-        private readonly List<string> _excludedIds = new List<string>();
+        private readonly List<string> _excludedConnectionIds = new List<string>();
         private readonly List<string> _sendIds = new List<string>();
         private readonly List<string> _groups = new List<string>();
         private readonly List<string> _users = new List<string>();
@@ -70,7 +70,7 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
                 {
                     group = "Evens";
                     user = "EvenUser";
-                    _excludedIds.Add(_clients[i].Connection.ConnectionId);
+                    _excludedConnectionIds.Add(_clients[i].Connection.ConnectionId);
                 }
                 else
                 {
@@ -144,13 +144,13 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
         [Benchmark]
         public async Task SendAllExcept()
         {
-            await _manager1.SendAllExceptAsync("Test", _args, _excludedIds);
+            await _manager1.SendAllExceptAsync("Test", _args, _excludedConnectionIds);
         }
 
         [Benchmark]
         public async Task SendGroupExcept()
         {
-            await _manager1.SendGroupExceptAsync("Everyone", "Test", _args, _excludedIds);
+            await _manager1.SendGroupExceptAsync("Everyone", "Test", _args, _excludedConnectionIds);
         }
 
         [Benchmark]

--- a/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/RedisProtocolBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/RedisProtocolBenchmark.cs
@@ -17,8 +17,8 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
         private RedisGroupCommand _groupCommand;
         private object[] _args;
         private string _methodName;
-        private IReadOnlyList<string> _excludedIdsSmall;
-        private IReadOnlyList<string> _excludedIdsLarge;
+        private IReadOnlyList<string> _excludedConnectionIdsSmall;
+        private IReadOnlyList<string> _excludedConnectionIdsLarge;
         private byte[] _writtenAck;
         private byte[] _writtenGroupCommand;
         private byte[] _writtenInvocationNoExclusions;
@@ -39,14 +39,14 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
             _args = Array.Empty<object>();
             _methodName = "Method";
 
-            _excludedIdsSmall = GenerateIds(2);
-            _excludedIdsLarge = GenerateIds(20);
+            _excludedConnectionIdsSmall = GenerateIds(2);
+            _excludedConnectionIdsLarge = GenerateIds(20);
 
             _writtenAck = _protocol.WriteAck(42);
             _writtenGroupCommand = _protocol.WriteGroupCommand(_groupCommand);
             _writtenInvocationNoExclusions = _protocol.WriteInvocation(_methodName, _args, null);
-            _writtenInvocationSmallExclusions = _protocol.WriteInvocation(_methodName, _args, _excludedIdsSmall);
-            _writtenInvocationLargeExclusions = _protocol.WriteInvocation(_methodName, _args, _excludedIdsLarge);
+            _writtenInvocationSmallExclusions = _protocol.WriteInvocation(_methodName, _args, _excludedConnectionIdsSmall);
+            _writtenInvocationLargeExclusions = _protocol.WriteInvocation(_methodName, _args, _excludedConnectionIdsLarge);
         }
 
         [Benchmark]
@@ -70,13 +70,13 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
         [Benchmark]
         public void WriteInvocationSmallExclusions()
         {
-            _protocol.WriteInvocation(_methodName, _args, _excludedIdsSmall);
+            _protocol.WriteInvocation(_methodName, _args, _excludedConnectionIdsSmall);
         }
 
         [Benchmark]
         public void WriteInvocationLargeExclusions()
         {
-            _protocol.WriteInvocation(_methodName, _args, _excludedIdsLarge);
+            _protocol.WriteInvocation(_methodName, _args, _excludedConnectionIdsLarge);
         }
 
         [Benchmark]

--- a/samples/ChatSample/PresenceHubLifetimeManager.cs
+++ b/samples/ChatSample/PresenceHubLifetimeManager.cs
@@ -143,9 +143,9 @@ namespace ChatSample
             return _wrappedHubLifetimeManager.SendAllAsync(methodName, args);
         }
 
-        public override Task SendAllExceptAsync(string methodName, object[] args, IReadOnlyList<string> excludedIds)
+        public override Task SendAllExceptAsync(string methodName, object[] args, IReadOnlyList<string> excludedConnectionIds)
         {
-            return _wrappedHubLifetimeManager.SendAllExceptAsync(methodName, args, excludedIds);
+            return _wrappedHubLifetimeManager.SendAllExceptAsync(methodName, args, excludedConnectionIds);
         }
 
         public override Task SendConnectionAsync(string connectionId, string methodName, object[] args)
@@ -183,9 +183,9 @@ namespace ChatSample
             return _wrappedHubLifetimeManager.RemoveFromGroupAsync(connectionId, groupName);
         }
 
-        public override Task SendGroupExceptAsync(string groupName, string methodName, object[] args, IReadOnlyList<string> excludedIds)
+        public override Task SendGroupExceptAsync(string groupName, string methodName, object[] args, IReadOnlyList<string> excludedConnectionIds)
         {
-            return _wrappedHubLifetimeManager.SendGroupExceptAsync(groupName, methodName, args, excludedIds);
+            return _wrappedHubLifetimeManager.SendGroupExceptAsync(groupName, methodName, args, excludedConnectionIds);
         }
 
         public override Task SendUsersAsync(IReadOnlyList<string> userIds, string methodName, object[] args)

--- a/src/Microsoft.AspNetCore.SignalR.Core/DefaultHubLifetimeManager.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/DefaultHubLifetimeManager.cs
@@ -219,7 +219,7 @@ namespace Microsoft.AspNetCore.SignalR
             return Task.CompletedTask;
         }
 
-        public override Task SendGroupExceptAsync(string groupName, string methodName, object[] args, IReadOnlyList<string> excludedIds)
+        public override Task SendGroupExceptAsync(string groupName, string methodName, object[] args, IReadOnlyList<string> excludedConnectionIds)
         {
             if (groupName == null)
             {
@@ -232,7 +232,7 @@ namespace Microsoft.AspNetCore.SignalR
                 List<Task> tasks = null;
                 SerializedHubMessage message = null;
 
-                SendToGroupConnections(methodName, args, group, connection => !excludedIds.Contains(connection.ConnectionId), ref tasks, ref message);
+                SendToGroupConnections(methodName, args, group, connection => !excludedConnectionIds.Contains(connection.ConnectionId), ref tasks, ref message);
 
                 if (tasks != null)
                 {
@@ -271,9 +271,9 @@ namespace Microsoft.AspNetCore.SignalR
             return Task.CompletedTask;
         }
 
-        public override Task SendAllExceptAsync(string methodName, object[] args, IReadOnlyList<string> excludedIds)
+        public override Task SendAllExceptAsync(string methodName, object[] args, IReadOnlyList<string> excludedConnectionIds)
         {
-            return SendToAllConnections(methodName, args, connection => !excludedIds.Contains(connection.ConnectionId));
+            return SendToAllConnections(methodName, args, connection => !excludedConnectionIds.Contains(connection.ConnectionId));
         }
 
         public override Task SendConnectionsAsync(IReadOnlyList<string> connectionIds, string methodName, object[] args)

--- a/src/Microsoft.AspNetCore.SignalR.Core/DynamicHubClients.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/DynamicHubClients.cs
@@ -16,13 +16,13 @@ namespace Microsoft.AspNetCore.SignalR
         }
 
         public dynamic All => new DynamicClientProxy(_clients.All);
-        public dynamic AllExcept(IReadOnlyList<string> excludedIds) => new DynamicClientProxy(_clients.AllExcept(excludedIds));
+        public dynamic AllExcept(IReadOnlyList<string> excludedConnectionIds) => new DynamicClientProxy(_clients.AllExcept(excludedConnectionIds));
         public dynamic Caller => new DynamicClientProxy(_clients.Caller);
         public dynamic Client(string connectionId) => new DynamicClientProxy(_clients.Client(connectionId));
         public dynamic Clients(IReadOnlyList<string> connectionIds) => new DynamicClientProxy(_clients.Clients(connectionIds));
         public dynamic Group(string groupName) => new DynamicClientProxy(_clients.Group(groupName));
         public dynamic Groups(IReadOnlyList<string> groupNames) => new DynamicClientProxy(_clients.Groups(groupNames));
-        public dynamic GroupExcept(string groupName, IReadOnlyList<string> excludedIds) => new DynamicClientProxy(_clients.GroupExcept(groupName, excludedIds));
+        public dynamic GroupExcept(string groupName, IReadOnlyList<string> excludedConnectionIds) => new DynamicClientProxy(_clients.GroupExcept(groupName, excludedConnectionIds));
         public dynamic OthersInGroup(string groupName) => new DynamicClientProxy(_clients.OthersInGroup(groupName));
         public dynamic Others => new DynamicClientProxy(_clients.Others);
         public dynamic User(string userId) => new DynamicClientProxy(_clients.User(userId));

--- a/src/Microsoft.AspNetCore.SignalR.Core/HubLifetimeManager.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/HubLifetimeManager.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.SignalR
 
         public abstract Task SendAllAsync(string methodName, object[] args);
 
-        public abstract Task SendAllExceptAsync(string methodName, object[] args, IReadOnlyList<string> excludedIds);
+        public abstract Task SendAllExceptAsync(string methodName, object[] args, IReadOnlyList<string> excludedConnectionIds);
 
         public abstract Task SendConnectionAsync(string connectionId, string methodName, object[] args);
 
@@ -24,7 +24,7 @@ namespace Microsoft.AspNetCore.SignalR
 
         public abstract Task SendGroupsAsync(IReadOnlyList<string> groupNames, string methodName, object[] args);
 
-        public abstract Task SendGroupExceptAsync(string groupName, string methodName, object[] args, IReadOnlyList<string> excludedIds);
+        public abstract Task SendGroupExceptAsync(string groupName, string methodName, object[] args, IReadOnlyList<string> excludedConnectionIds);
 
         public abstract Task SendUserAsync(string userId, string methodName, object[] args);
 

--- a/src/Microsoft.AspNetCore.SignalR.Core/Internal/Proxies.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/Internal/Proxies.cs
@@ -78,18 +78,18 @@ namespace Microsoft.AspNetCore.SignalR.Internal
     {
         private readonly string _groupName;
         private readonly HubLifetimeManager<THub> _lifetimeManager;
-        private readonly IReadOnlyList<string> _excludedIds;
+        private readonly IReadOnlyList<string> _excludedConnectionIds;
 
-        public GroupExceptProxy(HubLifetimeManager<THub> lifetimeManager, string groupName, IReadOnlyList<string> excludedIds)
+        public GroupExceptProxy(HubLifetimeManager<THub> lifetimeManager, string groupName, IReadOnlyList<string> excludedConnectionIds)
         {
             _lifetimeManager = lifetimeManager;
             _groupName = groupName;
-            _excludedIds = excludedIds;
+            _excludedConnectionIds = excludedConnectionIds;
         }
 
         public Task SendCoreAsync(string method, object[] args)
         {
-            return _lifetimeManager.SendGroupExceptAsync(_groupName, method, args, _excludedIds);
+            return _lifetimeManager.SendGroupExceptAsync(_groupName, method, args, _excludedConnectionIds);
         }
     }
 
@@ -111,17 +111,17 @@ namespace Microsoft.AspNetCore.SignalR.Internal
     internal class AllClientsExceptProxy<THub> : IClientProxy where THub : Hub
     {
         private readonly HubLifetimeManager<THub> _lifetimeManager;
-        private readonly IReadOnlyList<string> _excludedIds;
+        private readonly IReadOnlyList<string> _excludedConnectionIds;
 
-        public AllClientsExceptProxy(HubLifetimeManager<THub> lifetimeManager, IReadOnlyList<string> excludedIds)
+        public AllClientsExceptProxy(HubLifetimeManager<THub> lifetimeManager, IReadOnlyList<string> excludedConnectionIds)
         {
             _lifetimeManager = lifetimeManager;
-            _excludedIds = excludedIds;
+            _excludedConnectionIds = excludedConnectionIds;
         }
 
         public Task SendCoreAsync(string method, object[] args)
         {
-            return _lifetimeManager.SendAllExceptAsync(method, args, _excludedIds);
+            return _lifetimeManager.SendAllExceptAsync(method, args, _excludedConnectionIds);
         }
     }
 

--- a/src/Microsoft.AspNetCore.SignalR.Redis/Internal/RedisInvocation.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Redis/Internal/RedisInvocation.cs
@@ -10,24 +10,24 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Internal
         /// Gets a list of connections that should be excluded from this invocation.
         /// May be null to indicate that no connections are to be excluded.
         /// </summary>
-        public IReadOnlyList<string> ExcludedIds { get; }
+        public IReadOnlyList<string> ExcludedConnectionIds { get; }
 
         /// <summary>
         /// Gets the message serialization cache containing serialized payloads for the message.
         /// </summary>
         public SerializedHubMessage Message { get; }
 
-        public RedisInvocation(SerializedHubMessage message, IReadOnlyList<string> excludedIds)
+        public RedisInvocation(SerializedHubMessage message, IReadOnlyList<string> excludedConnectionIds)
         {
             Message = message;
-            ExcludedIds = excludedIds;
+            ExcludedConnectionIds = excludedConnectionIds;
         }
 
-        public static RedisInvocation Create(string target, object[] arguments, IReadOnlyList<string> excludedIds = null)
+        public static RedisInvocation Create(string target, object[] arguments, IReadOnlyList<string> excludedConnectionIds = null)
         {
             return new RedisInvocation(
                 new SerializedHubMessage(new InvocationMessage(target, null, arguments)),
-                excludedIds);
+                excludedConnectionIds);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.SignalR.Redis/RedisHubLifetimeManager.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Redis/RedisHubLifetimeManager.cs
@@ -112,9 +112,9 @@ namespace Microsoft.AspNetCore.SignalR.Redis
             return PublishAsync(_channels.All, message);
         }
 
-        public override Task SendAllExceptAsync(string methodName, object[] args, IReadOnlyList<string> excludedIds)
+        public override Task SendAllExceptAsync(string methodName, object[] args, IReadOnlyList<string> excludedConnectionIds)
         {
-            var message = _protocol.WriteInvocation(methodName, args, excludedIds);
+            var message = _protocol.WriteInvocation(methodName, args, excludedConnectionIds);
             return PublishAsync(_channels.All, message);
         }
 
@@ -148,14 +148,14 @@ namespace Microsoft.AspNetCore.SignalR.Redis
             return PublishAsync(_channels.Group(groupName), message);
         }
 
-        public override async Task SendGroupExceptAsync(string groupName, string methodName, object[] args, IReadOnlyList<string> excludedIds)
+        public override async Task SendGroupExceptAsync(string groupName, string methodName, object[] args, IReadOnlyList<string> excludedConnectionIds)
         {
             if (groupName == null)
             {
                 throw new ArgumentNullException(nameof(groupName));
             }
 
-            var message = _protocol.WriteInvocation(methodName, args, excludedIds);
+            var message = _protocol.WriteInvocation(methodName, args, excludedConnectionIds);
             await PublishAsync(_channels.Group(groupName), message);
         }
 
@@ -388,7 +388,7 @@ namespace Microsoft.AspNetCore.SignalR.Redis
 
                     foreach (var connection in _connections)
                     {
-                        if (invocation.ExcludedIds == null || !invocation.ExcludedIds.Contains(connection.ConnectionId))
+                        if (invocation.ExcludedConnectionIds == null || !invocation.ExcludedConnectionIds.Contains(connection.ConnectionId))
                         {
                             tasks.Add(connection.WriteAsync(invocation.Message).AsTask());
                         }
@@ -487,7 +487,7 @@ namespace Microsoft.AspNetCore.SignalR.Redis
                     var tasks = new List<Task>();
                     foreach (var groupConnection in group.Connections)
                     {
-                        if (invocation.ExcludedIds?.Contains(groupConnection.ConnectionId) == true)
+                        if (invocation.ExcludedConnectionIds?.Contains(groupConnection.ConnectionId) == true)
                         {
                             continue;
                         }

--- a/test/Microsoft.AspNetCore.SignalR.Redis.Tests/RedisHubLifetimeManagerTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Redis.Tests/RedisHubLifetimeManagerTests.cs
@@ -137,8 +137,8 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
                 await manager.AddToGroupAsync(connection1.ConnectionId, "gunit").OrTimeout();
                 await manager.AddToGroupAsync(connection2.ConnectionId, "gunit").OrTimeout();
 
-                var excludedIds = new List<string> { client2.Connection.ConnectionId };
-                await manager.SendGroupExceptAsync("gunit", "Hello", new object[] { "World" }, excludedIds).OrTimeout();
+                var excludedConnectionIds = new List<string> { client2.Connection.ConnectionId };
+                await manager.SendGroupExceptAsync("gunit", "Hello", new object[] { "World" }, excludedConnectionIds).OrTimeout();
 
                 await AssertMessageAsync(client1);
                 Assert.Null(client2.TryRead());

--- a/test/Microsoft.AspNetCore.SignalR.Redis.Tests/RedisProtocolTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Redis.Tests/RedisProtocolTests.cs
@@ -138,7 +138,7 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
 
             var decoded = protocol.ReadInvocation(testData.Encoded);
 
-            Assert.Equal(testData.Decoded.ExcludedIds, decoded.ExcludedIds);
+            Assert.Equal(testData.Decoded.ExcludedConnectionIds, decoded.ExcludedConnectionIds);
 
             // Verify the deserialized object has the necessary serialized forms
             foreach (var hubProtocol in hubProtocols)
@@ -159,7 +159,7 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
 
             // Actual invocation doesn't matter because we're using a dummy hub protocol.
             // But the dummy protocol will check that we gave it the test message to make sure everything flows through properly.
-            var encoded = protocol.WriteInvocation(_testMessage.Target, _testMessage.Arguments, testData.Decoded.ExcludedIds);
+            var encoded = protocol.WriteInvocation(_testMessage.Target, _testMessage.Arguments, testData.Decoded.ExcludedConnectionIds);
 
             Assert.Equal(testData.Encoded, encoded);
         }

--- a/test/Microsoft.AspNetCore.SignalR.Tests/ClientProxyTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/ClientProxyTests.cs
@@ -107,7 +107,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
 
             var o = new Mock<HubLifetimeManager<FakeHub>>();
             o.Setup(m => m.SendGroupExceptAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<IReadOnlyList<string>>()))
-                .Callback<string, string, object[], IReadOnlyList<string>>((groupName, methodName, args, excludedIds) => { resultArgs = args; })
+                .Callback<string, string, object[], IReadOnlyList<string>>((groupName, methodName, args, excludedConnectionIds) => { resultArgs = args; })
                 .Returns(Task.CompletedTask);
 
             var proxy = new GroupExceptProxy<FakeHub>(o.Object, string.Empty, new List<string>());
@@ -149,7 +149,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
 
             var o = new Mock<HubLifetimeManager<FakeHub>>();
             o.Setup(m => m.SendAllExceptAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<IReadOnlyList<string>>()))
-                .Callback<string, object[], IReadOnlyList<string>>((methodName, args, excludedIds) => { resultArgs = args; })
+                .Callback<string, object[], IReadOnlyList<string>>((methodName, args, excludedConnectionIds) => { resultArgs = args; })
                 .Returns(Task.CompletedTask);
 
             var proxy = new AllClientsExceptProxy<FakeHub>(o.Object, new List<string>());

--- a/test/Microsoft.AspNetCore.SignalR.Tests/HubConnectionHandlerTestUtils/Hubs.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/HubConnectionHandlerTestUtils/Hubs.cs
@@ -48,9 +48,9 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             return Clients.Group(groupName).SendAsync("Send", message);
         }
 
-        public Task GroupExceptSendMethod(string groupName, string message, IReadOnlyList<string> excludedIds)
+        public Task GroupExceptSendMethod(string groupName, string message, IReadOnlyList<string> excludedConnectionIds)
         {
-            return Clients.GroupExcept(groupName, excludedIds).SendAsync("Send", message);
+            return Clients.GroupExcept(groupName, excludedConnectionIds).SendAsync("Send", message);
         }
 
         public Task SendToMultipleGroups(string message, IReadOnlyList<string> groupNames)
@@ -137,9 +137,9 @@ namespace Microsoft.AspNetCore.SignalR.Tests
         {
         }
 
-        public Task SendToAllExcept(string message, IReadOnlyList<string> excludedIds)
+        public Task SendToAllExcept(string message, IReadOnlyList<string> excludedConnectionIds)
         {
-            return Clients.AllExcept(excludedIds).SendAsync("Send", message);
+            return Clients.AllExcept(excludedConnectionIds).SendAsync("Send", message);
         }
 
         public bool HasHttpContext()
@@ -212,9 +212,9 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             return Clients.Group(groupName).Send(message);
         }
 
-        public Task GroupExceptSendMethod(string groupName, string message, IReadOnlyList<string> excludedIds)
+        public Task GroupExceptSendMethod(string groupName, string message, IReadOnlyList<string> excludedConnectionIds)
         {
-            return Clients.GroupExcept(groupName, excludedIds).Send(message);
+            return Clients.GroupExcept(groupName, excludedConnectionIds).Send(message);
         }
 
         public Task SendToOthersInGroup(string groupName, string message)
@@ -232,9 +232,9 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             return Clients.All.Broadcast(message);
         }
 
-        public Task SendToAllExcept(string message, IReadOnlyList<string> excludedIds)
+        public Task SendToAllExcept(string message, IReadOnlyList<string> excludedConnectionIds)
         {
-            return Clients.AllExcept(excludedIds).Send(message);
+            return Clients.AllExcept(excludedConnectionIds).Send(message);
         }
 
         public Task SendToOthers(string message)
@@ -298,9 +298,9 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             return Clients.Group(groupName).Send(message);
         }
 
-        public Task GroupExceptSendMethod(string groupName, string message, IReadOnlyList<string> excludedIds)
+        public Task GroupExceptSendMethod(string groupName, string message, IReadOnlyList<string> excludedConnectionIds)
         {
-            return Clients.GroupExcept(groupName, excludedIds).Send(message);
+            return Clients.GroupExcept(groupName, excludedConnectionIds).Send(message);
         }
 
         public Task SendToMultipleGroups(string message, IReadOnlyList<string> groupNames)
@@ -318,9 +318,9 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             return Clients.All.Broadcast(message);
         }
 
-        public Task SendToAllExcept(string message, IReadOnlyList<string> excludedIds)
+        public Task SendToAllExcept(string message, IReadOnlyList<string> excludedConnectionIds)
         {
-            return Clients.AllExcept(excludedIds).Send(message);
+            return Clients.AllExcept(excludedConnectionIds).Send(message);
         }
 
         public Task SendToOthers(string message)

--- a/test/Microsoft.AspNetCore.SignalR.Tests/HubConnectionHandlerTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/HubConnectionHandlerTests.cs
@@ -1156,9 +1156,9 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                 await firstClient.InvokeAsync(nameof(MethodHub.GroupAddMethod), "testGroup").OrTimeout();
                 await secondClient.InvokeAsync(nameof(MethodHub.GroupAddMethod), "testGroup").OrTimeout();
 
-                var excludedIds = new List<string> { firstClient.Connection.ConnectionId };
+                var excludedConnectionIds = new List<string> { firstClient.Connection.ConnectionId };
 
-                await firstClient.SendInvocationAsync("GroupExceptSendMethod", "testGroup", "test", excludedIds).OrTimeout();
+                await firstClient.SendInvocationAsync("GroupExceptSendMethod", "testGroup", "test", excludedConnectionIds).OrTimeout();
 
                 // check that 'secondConnection' has received the group send
                 var hubMessage = await secondClient.ReadAsync().OrTimeout();


### PR DESCRIPTION
Renamed everywhere for consistency. From API review.