### PR TITLE
Revert "Use xhr.onreadystatechange instead of xhr.onload (#1838)"

### DIFF
--- a/clients/ts/signalr/src/HttpClient.ts
+++ b/clients/ts/signalr/src/HttpClient.ts
@@ -94,22 +94,15 @@ export class DefaultHttpClient extends HttpClient {
                 xhr.timeout = request.timeout;
             }
 
-            xhr.onreadystatechange = () => {
-                if (xhr.readyState === 4) {
-                    if (request.abortSignal) {
-                        request.abortSignal.onabort = null;
-                    }
+            xhr.onload = () => {
+                if (request.abortSignal) {
+                    request.abortSignal.onabort = null;
+                }
 
-                    // Some browsers report xhr.status == 0 when the
-                    // response has been cut off or there's been a TCP FIN.
-                    // Treat it like a 200 with no response.
-                    if (xhr.status === 0) {
-                        resolve(new HttpResponse(200, null, null));
-                    } else if (xhr.status >= 200 && xhr.status < 300) {
-                        resolve(new HttpResponse(xhr.status, xhr.statusText, xhr.response || xhr.responseText));
-                    } else {
-                        reject(new HttpError(xhr.statusText, xhr.status));
-                    }
+                if (xhr.status >= 200 && xhr.status < 300) {
+                    resolve(new HttpResponse(xhr.status, xhr.statusText, xhr.response || xhr.responseText));
+                } else {
+                    reject(new HttpError(xhr.statusText, xhr.status));
                 }
             };
 


### PR DESCRIPTION
This reverts commit 5e3830337764b07bb50a33122dc2cef793528e64.
Fixes issue: https://github.com/aspnet/SignalR/issues/2051
Verified this manually.
cc @muratg 