### PR TITLE
remove verbose flag

### DIFF
--- a/clients/ts/FunctionalTests/selenium/run-ci-tests.ts
+++ b/clients/ts/FunctionalTests/selenium/run-ci-tests.ts
@@ -80,9 +80,9 @@ if (configuration) {
     args.push("--configuration");
     args.push(configuration);
 }
-
+if (verbose) {
     args.push("--verbose");
-
+}
 
 let command = "npm";
 


### PR DESCRIPTION
As the indentation indicates, this was temporarily removed and then didn't get unremoved.

![https://media1.tenor.com/images/20ac0577cc7b851e51034ef1a6eefdab/tenor.gif?itemid=5070696](https://media1.tenor.com/images/20ac0577cc7b851e51034ef1a6eefdab/tenor.gif?itemid=5070696)