### PR TITLE
Added support for negotiate response to redirect the client to another SignalR endpoint

### DIFF
--- a/clients/ts/signalr/spec/HttpConnection.spec.ts
+++ b/clients/ts/signalr/spec/HttpConnection.spec.ts
@@ -267,10 +267,11 @@ describe("HttpConnection", () => {
         }
     });
 
-    it("does not send negotiate request if WebSockets transport requested explicitly", async (done) => {
+    it("does not send negotiate request if WebSockets transport requested explicitly and skipNegotiaiton true", async (done) => {
         const options: IHttpConnectionOptions = {
             ...commonOptions,
             httpClient: new TestHttpClient(),
+            skipNegotiation: true,
             transport: HttpTransportType.WebSockets,
         } as IHttpConnectionOptions;
 

--- a/clients/ts/signalr/spec/TestHttpClient.ts
+++ b/clients/ts/signalr/spec/TestHttpClient.ts
@@ -8,15 +8,18 @@ export type TestHttpHandler = (request: HttpRequest, next?: (request: HttpReques
 
 export class TestHttpClient extends HttpClient {
     private handler: (request: HttpRequest) => Promise<HttpResponse>;
+    public sentRequests: HttpRequest[];
 
     constructor() {
         super();
+        this.sentRequests = [];
         this.handler = (request: HttpRequest) =>
             Promise.reject(`Request has no handler: ${request.method} ${request.url}`);
 
     }
 
     public send(request: HttpRequest): Promise<HttpResponse> {
+        this.sentRequests.push(request);
         return this.handler(request);
     }
 
@@ -59,7 +62,7 @@ export class TestHttpClient extends HttpClient {
                 if (typeof val === "string") {
                     // string payload
                     return new HttpResponse(200, "OK", val);
-                } else if(typeof val === "object" && val.statusCode) {
+                } else if (typeof val === "object" && val.statusCode) {
                     // HttpResponse payload
                     return val as HttpResponse;
                 } else {

--- a/clients/ts/signalr/src/HttpConnection.ts
+++ b/clients/ts/signalr/src/HttpConnection.ts
@@ -16,6 +16,7 @@ export interface IHttpConnectionOptions {
     logger?: ILogger | LogLevel;
     accessTokenFactory?: () => string | Promise<string>;
     logMessageContent?: boolean;
+    skipNegotiation?: boolean;
 }
 
 const enum ConnectionState {
@@ -111,7 +112,7 @@ export class HttpConnection implements IConnection {
 
     private async startInternal(transferFormat: TransferFormat): Promise<void> {
         try {
-            if (this.options.transport === HttpTransportType.WebSockets) {
+            if (this.options.skipNegotiation && this.options.transport === HttpTransportType.WebSockets) {
                 // No need to add a connection ID in this case
                 this.url = this.baseUrl;
                 this.transport = this.constructTransport(HttpTransportType.WebSockets);

--- a/specs/TransportProtocols.md
+++ b/specs/TransportProtocols.md
@@ -18,32 +18,49 @@ Throughout this document, the term `[endpoint-base]` is used to refer to the rou
 
 ## `POST [endpoint-base]/negotiate` request
 
-The `POST [endpoint-base]/negotiate` request is used to establish connection between the client and the server. The response to the `POST [endpoint-base]/negotiate` request contains the `connectionId` which will be used to identify the connection on the server and the list of the transports supported by the server. The content type of the response is `application/json`. The following is a sample response to the `POST [endpoint-base]/negotiate` request
+The `POST [endpoint-base]/negotiate` request is used to establish a connection between the client and the server. The content type of the response is `application/json`. The response to the `POST [endpoint-base]/negotiate` request contains one of two types of responses:
 
-```
-{
-  "connectionId":"807809a5-31bf-470d-9e23-afaee35d8a0d",
-  "availableTransports":[
-    {
-      "transport": "WebSockets",
-      "transferFormats": [ "Text", "Binary" ]
-    },
-    {
-      "transport": "ServerSentEvents",
-      "transferFormats": [ "Text" ]
-    },
-    {
-      "transport": "LongPolling",
-      "transferFormats": [ "Text", "Binary" ]
-    }
-  ]
-}
-```
+1. A response that contains the `connectionId` which will be used to identify the connection on the server and the list of the transports supported by the server.
 
-The payload returned from this endpoint provides the following data:
+  ```
+  {
+    "connectionId":"807809a5-31bf-470d-9e23-afaee35d8a0d",
+    "availableTransports":[
+      {
+        "transport": "WebSockets",
+        "transferFormats": [ "Text", "Binary" ]
+      },
+      {
+        "transport": "ServerSentEvents",
+        "transferFormats": [ "Text" ]
+      },
+      {
+        "transport": "LongPolling",
+        "transferFormats": [ "Text", "Binary" ]
+      }
+    ]
+  }
+  ```
 
-* The `connectionId` which is **required** by the Long Polling and Server-Sent Events transports (in order to correlate sends and receives).
-* The `availableTransports` list which describes the transports the server supports. For each transport, the name of the transport (`transport`) is listed, as is a list of "transfer formats" supported by the transport (`transferFormats`)
+  The payload returned from this endpoint provides the following data:
+
+  * The `connectionId` which is **required** by the Long Polling and Server-Sent Events transports (in order to correlate sends and receives).
+  * The `availableTransports` list which describes the transports the server supports. For each transport, the name of the transport (`transport`) is listed, as is a list of "transfer formats" supported by the transport (`transferFormats`)
+
+
+2. A redirect response which tells the client which URL and optionally and access token to use as a result.
+
+  ```
+  {
+    "url": "https://myapp.com/chat",
+    "accessToken": "accessToken"
+  }
+  ```
+
+  The payload returned from this endpoint provides the following data:
+
+  * The `url` which is the URL the client should connect to.
+  * The `accessToken` which is an optional bearer token for accessing the specified url.
 
 ## Transfer Formats
 

--- a/src/Microsoft.AspNetCore.Http.Connections.Client/HttpConnection.cs
+++ b/src/Microsoft.AspNetCore.Http.Connections.Client/HttpConnection.cs
@@ -96,7 +96,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
             _logger = _loggerFactory.CreateLogger<HttpConnection>();
             _httpConnectionOptions = httpConnectionOptions;
 
-            if (httpConnectionOptions.Transports != HttpTransportType.WebSockets)
+            if (!httpConnectionOptions.SkipNegotiation || httpConnectionOptions.Transports != HttpTransportType.WebSockets)
             {
                 _httpClient = CreateHttpClient();
             }
@@ -210,7 +210,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
 
         private async Task SelectAndStartTransport(TransferFormat transferFormat)
         {
-            if (_httpConnectionOptions.Transports == HttpTransportType.WebSockets)
+            if (_httpConnectionOptions.SkipNegotiation && _httpConnectionOptions.Transports == HttpTransportType.WebSockets)
             {
                 Log.StartingTransport(_logger, _httpConnectionOptions.Transports, _httpConnectionOptions.Url);
                 await StartTransport(_httpConnectionOptions.Url, _httpConnectionOptions.Transports, transferFormat);

--- a/src/Microsoft.AspNetCore.Http.Connections.Client/HttpConnectionOptions.cs
+++ b/src/Microsoft.AspNetCore.Http.Connections.Client/HttpConnectionOptions.cs
@@ -52,6 +52,9 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
 
         public Uri Url { get; set; }
         public HttpTransportType Transports { get; set; }
+
+        public bool SkipNegotiation { get; set; }
+
         public Func<Task<string>> AccessTokenProvider { get; set; }
         public TimeSpan CloseTimeout { get; set; } = TimeSpan.FromSeconds(5);
         public ICredentials Credentials { get; set; }

--- a/src/Microsoft.AspNetCore.Http.Connections.Client/Internal/AccessTokenHttpMessageHandler.cs
+++ b/src/Microsoft.AspNetCore.Http.Connections.Client/Internal/AccessTokenHttpMessageHandler.cs
@@ -11,17 +11,21 @@ namespace Microsoft.AspNetCore.Http.Connections.Client.Internal
 {
     internal class AccessTokenHttpMessageHandler : DelegatingHandler
     {
-        private readonly Func<Task<string>> _accessTokenProvider;
+        private readonly HttpConnection _httpConnection;
 
-        public AccessTokenHttpMessageHandler(HttpMessageHandler inner, Func<Task<string>> accessTokenProvider) : base(inner)
+        public AccessTokenHttpMessageHandler(HttpMessageHandler inner, HttpConnection httpConnection) : base(inner)
         {
-            _accessTokenProvider = accessTokenProvider ?? throw new ArgumentNullException(nameof(accessTokenProvider));
+            _httpConnection = httpConnection;
         }
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            var accessToken = await _accessTokenProvider();
-            request.Headers.Authorization =  new AuthenticationHeaderValue("Bearer", accessToken);
+            var accessToken = await _httpConnection.GetAccessTokenAsync();
+
+            if (!string.IsNullOrEmpty(accessToken))
+            {
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+            }
 
             return await base.SendAsync(request, cancellationToken);
         }

--- a/src/Microsoft.AspNetCore.Http.Connections.Common/NegotiateProtocol.cs
+++ b/src/Microsoft.AspNetCore.Http.Connections.Common/NegotiateProtocol.cs
@@ -13,6 +13,8 @@ namespace Microsoft.AspNetCore.Http.Connections
     public static class NegotiateProtocol
     {
         private const string ConnectionIdPropertyName = "connectionId";
+        private const string UrlPropertyName = "url";
+        private const string AccessTokenPropertyName = "accessToken";
         private const string AvailableTransportsPropertyName = "availableTransports";
         private const string TransportPropertyName = "transport";
         private const string TransferFormatsPropertyName = "transferFormats";
@@ -25,8 +27,25 @@ namespace Microsoft.AspNetCore.Http.Connections
                 using (var jsonWriter = JsonUtils.CreateJsonTextWriter(textWriter))
                 {
                     jsonWriter.WriteStartObject();
-                    jsonWriter.WritePropertyName(ConnectionIdPropertyName);
-                    jsonWriter.WriteValue(response.ConnectionId);
+
+                    if (!string.IsNullOrEmpty(response.Url))
+                    {
+                        jsonWriter.WritePropertyName(UrlPropertyName);
+                        jsonWriter.WriteValue(response.Url);
+                    }
+
+                    if (!string.IsNullOrEmpty(response.AccessToken))
+                    {
+                        jsonWriter.WritePropertyName(AccessTokenPropertyName);
+                        jsonWriter.WriteValue(response.AccessToken);
+                    }
+
+                    if (!string.IsNullOrEmpty(response.ConnectionId))
+                    {
+                        jsonWriter.WritePropertyName(ConnectionIdPropertyName);
+                        jsonWriter.WriteValue(response.ConnectionId);
+                    }
+
                     jsonWriter.WritePropertyName(AvailableTransportsPropertyName);
                     jsonWriter.WriteStartArray();
 
@@ -69,6 +88,8 @@ namespace Microsoft.AspNetCore.Http.Connections
                     JsonUtils.EnsureObjectStart(reader);
 
                     string connectionId = null;
+                    string url = null;
+                    string accessToken = null;
                     List<AvailableTransport> availableTransports = null;
 
                     var completed = false;
@@ -81,6 +102,12 @@ namespace Microsoft.AspNetCore.Http.Connections
 
                                 switch (memberName)
                                 {
+                                    case UrlPropertyName:
+                                        url = JsonUtils.ReadAsString(reader, UrlPropertyName);
+                                        break;
+                                    case AccessTokenPropertyName:
+                                        accessToken = JsonUtils.ReadAsString(reader, AccessTokenPropertyName);
+                                        break;
                                     case ConnectionIdPropertyName:
                                         connectionId = JsonUtils.ReadAsString(reader, ConnectionIdPropertyName);
                                         break;
@@ -114,19 +141,25 @@ namespace Microsoft.AspNetCore.Http.Connections
                         }
                     }
 
-                    if (connectionId == null)
+                    if (url == null)
                     {
-                        throw new InvalidDataException($"Missing required property '{ConnectionIdPropertyName}'.");
-                    }
+                        // if url isn't specified, connectionId and available transports are optional
+                        if (connectionId == null)
+                        {
+                            throw new InvalidDataException($"Missing required property '{ConnectionIdPropertyName}'.");
+                        }
 
-                    if (availableTransports == null)
-                    {
-                        throw new InvalidDataException($"Missing required property '{AvailableTransportsPropertyName}'.");
+                        if (availableTransports == null)
+                        {
+                            throw new InvalidDataException($"Missing required property '{AvailableTransportsPropertyName}'.");
+                        }
                     }
 
                     return new NegotiationResponse
                     {
                         ConnectionId = connectionId,
+                        Url = url,
+                        AccessToken = accessToken,
                         AvailableTransports = availableTransports
                     };
                 }

--- a/src/Microsoft.AspNetCore.Http.Connections.Common/NegotiationResponse.cs
+++ b/src/Microsoft.AspNetCore.Http.Connections.Common/NegotiationResponse.cs
@@ -7,6 +7,8 @@ namespace Microsoft.AspNetCore.Http.Connections
 {
     public class NegotiationResponse
     {
+        public string Url { get; set; }
+        public string AccessToken { get; set; }
         public string ConnectionId { get; set; }
         public IList<AvailableTransport> AvailableTransports { get; set; }
     }

--- a/test/Microsoft.AspNetCore.Http.Connections.Tests/NegotiateProtocolTests.cs
+++ b/test/Microsoft.AspNetCore.Http.Connections.Tests/NegotiateProtocolTests.cs
@@ -9,21 +9,28 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
     public class NegotiateProtocolTests
     {
         [Theory]
-        [InlineData("{\"connectionId\":\"123\",\"availableTransports\":[]}", "123", new string[0])]
-        [InlineData("{\"connectionId\":\"\",\"availableTransports\":[]}", "", new string[0])]
-        [InlineData("{\"connectionId\":\"123\",\"availableTransports\":[{\"transport\":\"test\",\"transferFormats\":[]}]}", "123", new [] { "test"})]
-        public void ParsingNegotiateResponseMessageSuccessForValid(string json, string connectionId, string[] availableTransports)
+        [InlineData("{\"connectionId\":\"123\",\"availableTransports\":[]}", "123", new string[0], null, null)]
+        [InlineData("{\"connectionId\":\"\",\"availableTransports\":[]}", "", new string[0], null, null)]
+        [InlineData("{\"url\": \"http://foo.com/chat\"}", null, null, "http://foo.com/chat", null)]
+        [InlineData("{\"url\": \"http://foo.com/chat\", \"accessToken\": \"token\"}", null, null, "http://foo.com/chat", "token")]
+        [InlineData("{\"connectionId\":\"123\",\"availableTransports\":[{\"transport\":\"test\",\"transferFormats\":[]}]}", "123", new[] { "test" }, null, null)]
+        public void ParsingNegotiateResponseMessageSuccessForValid(string json, string connectionId, string[] availableTransports, string url, string accessToken)
         {
             var responseData = Encoding.UTF8.GetBytes(json);
             var ms = new MemoryStream(responseData);
             var response = NegotiateProtocol.ParseResponse(ms);
 
             Assert.Equal(connectionId, response.ConnectionId);
-            Assert.Equal(availableTransports.Length, response.AvailableTransports.Count);
+            Assert.Equal(availableTransports?.Length, response.AvailableTransports?.Count);
+            Assert.Equal(url, response.Url);
+            Assert.Equal(accessToken, response.AccessToken);
 
-            var responseTransports = response.AvailableTransports.Select(t => t.Transport).ToList();
+            if (response.AvailableTransports != null)
+            {
+                var responseTransports = response.AvailableTransports.Select(t => t.Transport).ToList();
 
-            Assert.Equal(availableTransports, responseTransports);
+                Assert.Equal(availableTransports, responseTransports);
+            }
         }
 
         [Theory]

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/TestHttpMessageHandler.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/TestHttpMessageHandler.cs
@@ -186,11 +186,21 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
 
         public void OnLongPoll(Func<CancellationToken, Task<HttpResponseMessage>> handler)
         {
+            OnLongPoll((request, token) => handler(token));
+        }
+
+        public void OnLongPoll(Func<HttpRequestMessage, CancellationToken, HttpResponseMessage> handler)
+        {
+            OnLongPoll((request, token) => Task.FromResult(handler(request, token)));
+        }
+
+        public void OnLongPoll(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler)
+        {
             OnRequest((request, next, cancellationToken) =>
             {
                 if (ResponseUtils.IsLongPollRequest(request))
                 {
-                    return handler(cancellationToken);
+                    return handler(request, cancellationToken);
                 }
                 else
                 {

--- a/test/Microsoft.AspNetCore.SignalR.Tests/EndToEndTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/EndToEndTests.cs
@@ -357,7 +357,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             {
                 var logger = loggerFactory.CreateLogger<EndToEndTests>();
 
-                var url = _serverFixture.Url + "/auth";
+                var url = ServerFixture.Url + "/auth";
                 var options = new HttpConnectionOptions
                 {
                     Url = new Uri(url),


### PR DESCRIPTION
- Adds support to the negotiate response to support a redirect url and an access token
- Made it so that choosing websockets isn't the way to specify skipping negotiation, there's now an explicit SkipNegotiation flag that needs to be specified.
- Added a redirect guard for 100 redirects without resolving the true negotiate url.
- Updated the ts client and .NET client
- Added tests

Fixes https://github.com/aspnet/SignalR/issues/1947