### PR TITLE
Added support for negotiate response to redirect the client to anothe…

### DIFF
--- a/clients/ts/signalr/spec/TestHttpClient.ts
+++ b/clients/ts/signalr/spec/TestHttpClient.ts
@@ -8,15 +8,18 @@ export type TestHttpHandler = (request: HttpRequest, next?: (request: HttpReques
 
 export class TestHttpClient extends HttpClient {
     private handler: (request: HttpRequest) => Promise<HttpResponse>;
+    public sentRequests: HttpRequest[];
 
     constructor() {
         super();
+        this.sentRequests = [];
         this.handler = (request: HttpRequest) =>
             Promise.reject(`Request has no handler: ${request.method} ${request.url}`);
 
     }
 
     public send(request: HttpRequest): Promise<HttpResponse> {
+        this.sentRequests.push(request);
         return this.handler(request);
     }
 
@@ -59,7 +62,7 @@ export class TestHttpClient extends HttpClient {
                 if (typeof val === "string") {
                     // string payload
                     return new HttpResponse(200, "OK", val);
-                } else if(typeof val === "object" && val.statusCode) {
+                } else if (typeof val === "object" && val.statusCode) {
                     // HttpResponse payload
                     return val as HttpResponse;
                 } else {

--- a/specs/TransportProtocols.md
+++ b/specs/TransportProtocols.md
@@ -18,32 +18,49 @@ Throughout this document, the term `[endpoint-base]` is used to refer to the rou
 
 ## `POST [endpoint-base]/negotiate` request
 
-The `POST [endpoint-base]/negotiate` request is used to establish connection between the client and the server. The response to the `POST [endpoint-base]/negotiate` request contains the `connectionId` which will be used to identify the connection on the server and the list of the transports supported by the server. The content type of the response is `application/json`. The following is a sample response to the `POST [endpoint-base]/negotiate` request
+The `POST [endpoint-base]/negotiate` request is used to establish a connection between the client and the server. The content type of the response is `application/json`. The response to the `POST [endpoint-base]/negotiate` request contains one of two types of responses:
 
-```
-{
-  "connectionId":"807809a5-31bf-470d-9e23-afaee35d8a0d",
-  "availableTransports":[
-    {
-      "transport": "WebSockets",
-      "transferFormats": [ "Text", "Binary" ]
-    },
-    {
-      "transport": "ServerSentEvents",
-      "transferFormats": [ "Text" ]
-    },
-    {
-      "transport": "LongPolling",
-      "transferFormats": [ "Text", "Binary" ]
-    }
-  ]
-}
-```
+1. A response that contains the `connectionId` which will be used to identify the connection on the server and the list of the transports supported by the server.
 
-The payload returned from this endpoint provides the following data:
+  ```
+  {
+    "connectionId":"807809a5-31bf-470d-9e23-afaee35d8a0d",
+    "availableTransports":[
+      {
+        "transport": "WebSockets",
+        "transferFormats": [ "Text", "Binary" ]
+      },
+      {
+        "transport": "ServerSentEvents",
+        "transferFormats": [ "Text" ]
+      },
+      {
+        "transport": "LongPolling",
+        "transferFormats": [ "Text", "Binary" ]
+      }
+    ]
+  }
+  ```
 
-* The `connectionId` which is **required** by the Long Polling and Server-Sent Events transports (in order to correlate sends and receives).
-* The `availableTransports` list which describes the transports the server supports. For each transport, the name of the transport (`transport`) is listed, as is a list of "transfer formats" supported by the transport (`transferFormats`)
+  The payload returned from this endpoint provides the following data:
+
+  * The `connectionId` which is **required** by the Long Polling and Server-Sent Events transports (in order to correlate sends and receives).
+  * The `availableTransports` list which describes the transports the server supports. For each transport, the name of the transport (`transport`) is listed, as is a list of "transfer formats" supported by the transport (`transferFormats`)
+
+
+2. A redirect response which tells the client which URL and optionally access token to use as a result.
+
+  ```
+  {
+    "url": "https://myapp.com/chat",
+    "accessToken": "accessToken"
+  }
+  ```
+
+  The payload returned from this endpoint provides the following data:
+
+  * The `url` which is the URL the client should connect to.
+  * The `accessToken` which is an optional bearer token for accessing the specified url.
 
 ## Transfer Formats
 

--- a/src/Microsoft.AspNetCore.Http.Connections.Client/HttpConnection.cs
+++ b/src/Microsoft.AspNetCore.Http.Connections.Client/HttpConnection.cs
@@ -20,6 +20,11 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
 {
     public partial class HttpConnection : ConnectionContext, IConnectionInherentKeepAliveFeature
     {
+        // Not configurable on purpose, high enough that if we reach here, it's likely
+        // a buggy server
+        private static readonly int _maxRedirects = 100;
+        private static readonly Task<string> _noAccessToken = Task.FromResult<string>(null);
+
         private static readonly TimeSpan HttpClientTimeout = TimeSpan.FromSeconds(120);
 #if !NETCOREAPP2_1
         private static readonly Version Windows8Version = new Version(6, 2);
@@ -40,6 +45,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
         private readonly ConnectionLogScope _logScope;
         private readonly IDisposable _scopeDisposable;
         private readonly ILoggerFactory _loggerFactory;
+        private Func<Task<string>> _accessTokenProvider;
 
         public override IDuplexPipe Transport
         {
@@ -96,7 +102,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
             _logger = _loggerFactory.CreateLogger<HttpConnection>();
             _httpConnectionOptions = httpConnectionOptions;
 
-            if (httpConnectionOptions.Transports != HttpTransportType.WebSockets)
+            if (!httpConnectionOptions.SkipNegotiation || httpConnectionOptions.Transports != HttpTransportType.WebSockets)
             {
                 _httpClient = CreateHttpClient();
             }
@@ -210,17 +216,54 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
 
         private async Task SelectAndStartTransport(TransferFormat transferFormat)
         {
-            if (_httpConnectionOptions.Transports == HttpTransportType.WebSockets)
+            var uri = _httpConnectionOptions.Url;
+            // Set the initial access token provider back to the original one from options
+            _accessTokenProvider = _httpConnectionOptions.AccessTokenProvider;
+
+            if (_httpConnectionOptions.SkipNegotiation)
             {
-                Log.StartingTransport(_logger, _httpConnectionOptions.Transports, _httpConnectionOptions.Url);
-                await StartTransport(_httpConnectionOptions.Url, _httpConnectionOptions.Transports, transferFormat);
+                if (_httpConnectionOptions.Transports == HttpTransportType.WebSockets)
+                {
+                    Log.StartingTransport(_logger, _httpConnectionOptions.Transports, uri);
+                    await StartTransport(uri, _httpConnectionOptions.Transports, transferFormat);
+                }
+                else
+                {
+                    throw new InvalidOperationException("Negotiation can only be skipped when using the WebSocket transport directly.");
+                }
             }
             else
             {
-                var negotiationResponse = await GetNegotiationResponse();
+                NegotiationResponse negotiationResponse;
+                var redirects = 0;
+
+                do
+                {
+                    negotiationResponse = await GetNegotiationResponseAsync(uri);
+
+                    if (negotiationResponse.Url != null)
+                    {
+                        uri = new Uri(negotiationResponse.Url);
+                    }
+
+                    if (negotiationResponse.AccessToken != null)
+                    {
+                        string accessToken = negotiationResponse.AccessToken;
+                        // Set the current access token factory so that future requests use this access token
+                        _accessTokenProvider = () => Task.FromResult(accessToken);
+                    }
+
+                    redirects++;
+                }
+                while (negotiationResponse.Url != null && redirects < _maxRedirects);
+
+                if (redirects == _maxRedirects && negotiationResponse.Url != null)
+                {
+                    throw new InvalidOperationException("Negotiate redirection limit exceeded.");
+                }
 
                 // This should only need to happen once
-                var connectUrl = CreateConnectUrl(_httpConnectionOptions.Url, negotiationResponse.ConnectionId);
+                var connectUrl = CreateConnectUrl(uri, negotiationResponse.ConnectionId);
 
                 // We're going to search for the transfer format as a string because we don't want to parse
                 // all the transfer formats in the negotiation response, and we want to allow transfer formats
@@ -256,8 +299,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
                             // The negotiation response gets cleared in the fallback scenario.
                             if (negotiationResponse == null)
                             {
-                                negotiationResponse = await GetNegotiationResponse();
-                                connectUrl = CreateConnectUrl(_httpConnectionOptions.Url, negotiationResponse.ConnectionId);
+                                negotiationResponse = await GetNegotiationResponseAsync(uri);
+                                connectUrl = CreateConnectUrl(uri, negotiationResponse.ConnectionId);
                             }
 
                             Log.StartingTransport(_logger, transportType, connectUrl);
@@ -281,7 +324,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
             }
         }
 
-        private async Task<NegotiationResponse> Negotiate(Uri url, HttpClient httpClient, ILogger logger)
+        private async Task<NegotiationResponse> NegotiateAsync(Uri url, HttpClient httpClient, ILogger logger)
         {
             try
             {
@@ -399,10 +442,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
                 }
 
                 // Apply the authorization header in a handler instead of a default header because it can change with each request
-                if (_httpConnectionOptions.AccessTokenProvider != null)
-                {
-                    httpMessageHandler = new AccessTokenHttpMessageHandler(httpMessageHandler, _httpConnectionOptions.AccessTokenProvider);
-                }
+                httpMessageHandler = new AccessTokenHttpMessageHandler(httpMessageHandler, this);
             }
 
             // Wrap message handler after HttpMessageHandlerFactory to ensure not overriden
@@ -428,6 +468,15 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
             httpClient.DefaultRequestHeaders.Add("X-Requested-With", "XMLHttpRequest");
 
             return httpClient;
+        }
+
+        internal Task<string> GetAccessTokenAsync()
+        {
+            if (_accessTokenProvider == null)
+            {
+                return _noAccessToken;
+            }
+            return _accessTokenProvider();
         }
 
         private void CheckDisposed()
@@ -458,9 +507,9 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
 #endif
         }
 
-        private async Task<NegotiationResponse> GetNegotiationResponse()
+        private async Task<NegotiationResponse> GetNegotiationResponseAsync(Uri uri)
         {
-            var negotiationResponse = await Negotiate(_httpConnectionOptions.Url, _httpClient, _logger);
+            var negotiationResponse = await NegotiateAsync(uri, _httpClient, _logger);
             _connectionId = negotiationResponse.ConnectionId;
             _logScope.ConnectionId = _connectionId;
             return negotiationResponse;

--- a/src/Microsoft.AspNetCore.Http.Connections.Client/HttpConnectionOptions.cs
+++ b/src/Microsoft.AspNetCore.Http.Connections.Client/HttpConnectionOptions.cs
@@ -52,6 +52,9 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
 
         public Uri Url { get; set; }
         public HttpTransportType Transports { get; set; }
+
+        public bool SkipNegotiation { get; set; }
+
         public Func<Task<string>> AccessTokenProvider { get; set; }
         public TimeSpan CloseTimeout { get; set; } = TimeSpan.FromSeconds(5);
         public ICredentials Credentials { get; set; }

--- a/src/Microsoft.AspNetCore.Http.Connections.Client/Internal/AccessTokenHttpMessageHandler.cs
+++ b/src/Microsoft.AspNetCore.Http.Connections.Client/Internal/AccessTokenHttpMessageHandler.cs
@@ -11,17 +11,21 @@ namespace Microsoft.AspNetCore.Http.Connections.Client.Internal
 {
     internal class AccessTokenHttpMessageHandler : DelegatingHandler
     {
-        private readonly Func<Task<string>> _accessTokenProvider;
+        private readonly HttpConnection _httpConnection;
 
-        public AccessTokenHttpMessageHandler(HttpMessageHandler inner, Func<Task<string>> accessTokenProvider) : base(inner)
+        public AccessTokenHttpMessageHandler(HttpMessageHandler inner, HttpConnection httpConnection) : base(inner)
         {
-            _accessTokenProvider = accessTokenProvider ?? throw new ArgumentNullException(nameof(accessTokenProvider));
+            _httpConnection = httpConnection;
         }
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            var accessToken = await _accessTokenProvider();
-            request.Headers.Authorization =  new AuthenticationHeaderValue("Bearer", accessToken);
+            var accessToken = await _httpConnection.GetAccessTokenAsync();
+
+            if (!string.IsNullOrEmpty(accessToken))
+            {
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+            }
 
             return await base.SendAsync(request, cancellationToken);
         }

--- a/src/Microsoft.AspNetCore.Http.Connections.Common/NegotiationResponse.cs
+++ b/src/Microsoft.AspNetCore.Http.Connections.Common/NegotiationResponse.cs
@@ -7,6 +7,8 @@ namespace Microsoft.AspNetCore.Http.Connections
 {
     public class NegotiationResponse
     {
+        public string Url { get; set; }
+        public string AccessToken { get; set; }
         public string ConnectionId { get; set; }
         public IList<AvailableTransport> AvailableTransports { get; set; }
     }

--- a/test/Microsoft.AspNetCore.Http.Connections.Tests/NegotiateProtocolTests.cs
+++ b/test/Microsoft.AspNetCore.Http.Connections.Tests/NegotiateProtocolTests.cs
@@ -9,21 +9,28 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
     public class NegotiateProtocolTests
     {
         [Theory]
-        [InlineData("{\"connectionId\":\"123\",\"availableTransports\":[]}", "123", new string[0])]
-        [InlineData("{\"connectionId\":\"\",\"availableTransports\":[]}", "", new string[0])]
-        [InlineData("{\"connectionId\":\"123\",\"availableTransports\":[{\"transport\":\"test\",\"transferFormats\":[]}]}", "123", new [] { "test"})]
-        public void ParsingNegotiateResponseMessageSuccessForValid(string json, string connectionId, string[] availableTransports)
+        [InlineData("{\"connectionId\":\"123\",\"availableTransports\":[]}", "123", new string[0], null, null)]
+        [InlineData("{\"connectionId\":\"\",\"availableTransports\":[]}", "", new string[0], null, null)]
+        [InlineData("{\"url\": \"http://foo.com/chat\"}", null, null, "http://foo.com/chat", null)]
+        [InlineData("{\"url\": \"http://foo.com/chat\", \"accessToken\": \"token\"}", null, null, "http://foo.com/chat", "token")]
+        [InlineData("{\"connectionId\":\"123\",\"availableTransports\":[{\"transport\":\"test\",\"transferFormats\":[]}]}", "123", new[] { "test" }, null, null)]
+        public void ParsingNegotiateResponseMessageSuccessForValid(string json, string connectionId, string[] availableTransports, string url, string accessToken)
         {
             var responseData = Encoding.UTF8.GetBytes(json);
             var ms = new MemoryStream(responseData);
             var response = NegotiateProtocol.ParseResponse(ms);
 
             Assert.Equal(connectionId, response.ConnectionId);
-            Assert.Equal(availableTransports.Length, response.AvailableTransports.Count);
+            Assert.Equal(availableTransports?.Length, response.AvailableTransports?.Count);
+            Assert.Equal(url, response.Url);
+            Assert.Equal(accessToken, response.AccessToken);
 
-            var responseTransports = response.AvailableTransports.Select(t => t.Transport).ToList();
+            if (response.AvailableTransports != null)
+            {
+                var responseTransports = response.AvailableTransports.Select(t => t.Transport).ToList();
 
-            Assert.Equal(availableTransports, responseTransports);
+                Assert.Equal(availableTransports, responseTransports);
+            }
         }
 
         [Theory]

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.Negotiate.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HttpConnectionTests.Negotiate.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.Net;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Http.Connections;
@@ -70,7 +71,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                 });
 
                 using (var noErrorScope = new VerifyNoErrorsScope())
-                { 
+                {
                     await WithConnectionAsync(
                         CreateConnection(testHttpHandler, url: requestedUrl, loggerFactory: noErrorScope.LoggerFactory),
                         async (connection) =>
@@ -80,6 +81,173 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                 }
 
                 Assert.Equal(expectedNegotiate, await negotiateUrlTcs.Task.OrTimeout());
+            }
+
+            [Fact]
+            public async Task NegotiateThatReturnsUrlGetFollowed()
+            {
+                var testHttpHandler = new TestHttpMessageHandler(autoNegotiate: false);
+                var firstNegotiate = true;
+                testHttpHandler.OnNegotiate((request, cancellationToken) =>
+                {
+                    if (firstNegotiate)
+                    {
+                        firstNegotiate = false;
+                        return ResponseUtils.CreateResponse(HttpStatusCode.OK,
+                            JsonConvert.SerializeObject(new
+                            {
+                                url = "https://another.domain.url/chat"
+                            }));
+                    }
+
+                    return ResponseUtils.CreateResponse(HttpStatusCode.OK,
+                        JsonConvert.SerializeObject(new
+                        {
+                            connectionId = "0rge0d00-0040-0030-0r00-000q00r00e00",
+                            availableTransports = new object[]
+                            {
+                                new
+                                {
+                                    transport = "LongPolling",
+                                    transferFormats = new[] { "Text" }
+                                },
+                            }
+                        }));
+                });
+
+                testHttpHandler.OnLongPoll((token) =>
+                {
+                    var tcs = new TaskCompletionSource<HttpResponseMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
+                    
+                    token.Register(() => tcs.TrySetResult(ResponseUtils.CreateResponse(HttpStatusCode.NoContent)));
+
+                    return tcs.Task;
+                });
+
+                testHttpHandler.OnLongPollDelete((token) => ResponseUtils.CreateResponse(HttpStatusCode.Accepted));
+
+                using (var noErrorScope = new VerifyNoErrorsScope())
+                {
+                    await WithConnectionAsync(
+                        CreateConnection(testHttpHandler, loggerFactory: noErrorScope.LoggerFactory),
+                        async (connection) =>
+                        {
+                            await connection.StartAsync(TransferFormat.Text).OrTimeout();
+                        });
+                }
+
+                Assert.Equal("http://fakeuri.org/negotiate", testHttpHandler.ReceivedRequests[0].RequestUri.ToString());
+                Assert.Equal("https://another.domain.url/chat/negotiate", testHttpHandler.ReceivedRequests[1].RequestUri.ToString());
+                Assert.Equal("https://another.domain.url/chat?id=0rge0d00-0040-0030-0r00-000q00r00e00", testHttpHandler.ReceivedRequests[2].RequestUri.ToString());
+                Assert.Equal("https://another.domain.url/chat?id=0rge0d00-0040-0030-0r00-000q00r00e00", testHttpHandler.ReceivedRequests[3].RequestUri.ToString());
+                Assert.Equal(5, testHttpHandler.ReceivedRequests.Count);
+            }
+
+            [Fact]
+            public async Task NegotiateThatReturnsRedirectUrlForeverThrowsAfter100Tries()
+            {
+                var testHttpHandler = new TestHttpMessageHandler(autoNegotiate: false);
+                testHttpHandler.OnNegotiate((request, cancellationToken) =>
+                {
+                    return ResponseUtils.CreateResponse(HttpStatusCode.OK,
+                            JsonConvert.SerializeObject(new
+                            {
+                                url = "https://another.domain.url/chat"
+                            }));
+                });
+
+                using (var noErrorScope = new VerifyNoErrorsScope())
+                {
+                    await WithConnectionAsync(
+                        CreateConnection(testHttpHandler, loggerFactory: noErrorScope.LoggerFactory),
+                        async (connection) =>
+                        {
+                            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => connection.StartAsync(TransferFormat.Text).OrTimeout());
+                            Assert.Equal("Negotiate redirection limit exceeded.", exception.Message);
+                        });
+                }
+            }
+
+            [Fact]
+            public async Task NegotiateThatReturnsUrlGetFollowedWithAccessToken()
+            {
+                var testHttpHandler = new TestHttpMessageHandler(autoNegotiate: false);
+                var firstNegotiate = true;
+                testHttpHandler.OnNegotiate((request, cancellationToken) =>
+                {
+                    if (firstNegotiate)
+                    {
+                        firstNegotiate = false;
+
+                        // The first negotiate requires an access token
+                        if (request.Headers.Authorization?.Parameter != "firstSecret")
+                        {
+                            return ResponseUtils.CreateResponse(HttpStatusCode.Unauthorized);
+                        }
+
+                        return ResponseUtils.CreateResponse(HttpStatusCode.OK,
+                            JsonConvert.SerializeObject(new
+                            {
+                                url = "https://another.domain.url/chat",
+                                accessToken = "secondSecret"
+                            }));
+                    }
+
+                    // All other requests require an access token
+                    if (request.Headers.Authorization?.Parameter != "secondSecret")
+                    {
+                        return ResponseUtils.CreateResponse(HttpStatusCode.Unauthorized);
+                    }
+
+                    return ResponseUtils.CreateResponse(HttpStatusCode.OK,
+                        JsonConvert.SerializeObject(new
+                        {
+                            connectionId = "0rge0d00-0040-0030-0r00-000q00r00e00",
+                            availableTransports = new object[]
+                            {
+                                new
+                                {
+                                    transport = "LongPolling",
+                                    transferFormats = new[] { "Text" }
+                                },
+                            }
+                        }));
+                });
+
+                testHttpHandler.OnLongPoll((request, token) =>
+                {
+                    // All other requests require an access token
+                    if (request.Headers.Authorization?.Parameter != "secondSecret")
+                    {
+                        return Task.FromResult(ResponseUtils.CreateResponse(HttpStatusCode.Unauthorized));
+                    }
+                    var tcs = new TaskCompletionSource<HttpResponseMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+                    token.Register(() => tcs.TrySetResult(ResponseUtils.CreateResponse(HttpStatusCode.NoContent)));
+
+                    return tcs.Task;
+                });
+
+                testHttpHandler.OnLongPollDelete((token) => ResponseUtils.CreateResponse(HttpStatusCode.Accepted));
+
+                Task<string> AccessTokenProvider() => Task.FromResult<string>("firstSecret");
+
+                using (var noErrorScope = new VerifyNoErrorsScope())
+                {
+                    await WithConnectionAsync(
+                        CreateConnection(testHttpHandler, loggerFactory: noErrorScope.LoggerFactory, accessTokenProvider: AccessTokenProvider),
+                        async (connection) =>
+                        {
+                            await connection.StartAsync(TransferFormat.Text).OrTimeout();
+                        });
+                }
+
+                Assert.Equal("http://fakeuri.org/negotiate", testHttpHandler.ReceivedRequests[0].RequestUri.ToString());
+                Assert.Equal("https://another.domain.url/chat/negotiate", testHttpHandler.ReceivedRequests[1].RequestUri.ToString());
+                Assert.Equal("https://another.domain.url/chat?id=0rge0d00-0040-0030-0r00-000q00r00e00", testHttpHandler.ReceivedRequests[2].RequestUri.ToString());
+                Assert.Equal("https://another.domain.url/chat?id=0rge0d00-0040-0030-0r00-000q00r00e00", testHttpHandler.ReceivedRequests[3].RequestUri.ToString());
+                // Delete request
+                Assert.Equal(5, testHttpHandler.ReceivedRequests.Count);
             }
 
             [Fact]

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/TestHttpMessageHandler.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/TestHttpMessageHandler.cs
@@ -186,11 +186,21 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
 
         public void OnLongPoll(Func<CancellationToken, Task<HttpResponseMessage>> handler)
         {
+            OnLongPoll((request, token) => handler(token));
+        }
+
+        public void OnLongPoll(Func<HttpRequestMessage, CancellationToken, HttpResponseMessage> handler)
+        {
+            OnLongPoll((request, token) => Task.FromResult(handler(request, token)));
+        }
+
+        public void OnLongPoll(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler)
+        {
             OnRequest((request, next, cancellationToken) =>
             {
                 if (ResponseUtils.IsLongPollRequest(request))
                 {
-                    return handler(cancellationToken);
+                    return handler(request, cancellationToken);
                 }
                 else
                 {


### PR DESCRIPTION
…r SignalR endpoint (#2070)

- Add a SkipNegotiation flag to the .NET and ts client
to allow skipping the negotiation phase. Don't infer it based on the transport type.
-  Updated the negotiate protocol to support returning a redirect url
- Added support to .NET client to handle redirect negotiations
- Handle poorly written endpoints that sends infinite redirects
- Added access token support and an infinite redirect guard
- Add delete handler for stopping the transport