### PR TITLE
Use custom group names in tests to not collide with other tests running

### DIFF
--- a/test/Microsoft.AspNetCore.SignalR.Redis.Tests/RedisEndToEnd.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Redis.Tests/RedisEndToEnd.cs
@@ -78,7 +78,7 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
                 var tcs2 = new TaskCompletionSource<string>();
                 secondConnection.On<string>("Echo", message => tcs2.TrySetResult(message));
 
-                var groupName = $"TestGroup_{transportType}_{protocolName}";
+                var groupName = $"TestGroup_{transportType}_{protocolName}_{Guid.NewGuid()}";
 
                 await secondConnection.StartAsync().OrTimeout();
                 await connection.StartAsync().OrTimeout();

--- a/test/Microsoft.AspNetCore.SignalR.Redis.Tests/RedisEndToEnd.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Redis.Tests/RedisEndToEnd.cs
@@ -78,11 +78,13 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
                 var tcs2 = new TaskCompletionSource<string>();
                 secondConnection.On<string>("Echo", message => tcs2.TrySetResult(message));
 
+                var groupName = $"TestGroup_{transportType}_{protocolName}";
+
                 await secondConnection.StartAsync().OrTimeout();
                 await connection.StartAsync().OrTimeout();
-                await connection.InvokeAsync("AddSelfToGroup", "Test").OrTimeout();
-                await secondConnection.InvokeAsync("AddSelfToGroup", "Test").OrTimeout();
-                await connection.InvokeAsync("EchoGroup", "Test", "Hello, World!").OrTimeout();
+                await connection.InvokeAsync("AddSelfToGroup", groupName).OrTimeout();
+                await secondConnection.InvokeAsync("AddSelfToGroup", groupName).OrTimeout();
+                await connection.InvokeAsync("EchoGroup", groupName, "Hello, World!").OrTimeout();
 
                 Assert.Equal("Hello, World!", await tcs.Task.OrTimeout());
                 Assert.Equal("Hello, World!", await tcs2.Task.OrTimeout());


### PR DESCRIPTION
Thanks @mikeharder for getting the logs for this!