### PR TITLE
Cache some property access in json hub protocol

### DIFF
--- a/src/Microsoft.AspNetCore.SignalR.Protocols.Json/Protocol/JsonHubProtocol.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Protocols.Json/Protocol/JsonHubProtocol.cs
@@ -585,14 +585,15 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
             object[] arguments = null;
             var paramIndex = 0;
             var argumentsCount = 0;
+            var paramCount = paramTypes.Count;
 
             while (reader.Read())
             {
                 if (reader.TokenType == JsonToken.EndArray)
                 {
-                    if (argumentsCount != paramTypes.Count)
+                    if (argumentsCount != paramCount)
                     {
-                        throw new InvalidDataException($"Invocation provides {argumentsCount} argument(s) but target expects {paramTypes.Count}.");
+                        throw new InvalidDataException($"Invocation provides {argumentsCount} argument(s) but target expects {paramCount}.");
                     }
 
                     return arguments ?? Array.Empty<object>();
@@ -600,12 +601,12 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
 
                 if (arguments == null)
                 {
-                    arguments = new object[paramTypes.Count];
+                    arguments = new object[paramCount];
                 }
 
                 try
                 {
-                    if (paramIndex < paramTypes.Count)
+                    if (paramIndex < paramCount)
                     {
                         // Set all known arguments
                         arguments[paramIndex] = PayloadSerializer.Deserialize(reader, paramTypes[paramIndex]);
@@ -637,21 +638,23 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
 
         private object[] BindArguments(JArray args, IReadOnlyList<Type> paramTypes)
         {
-            if (paramTypes.Count != args.Count)
+            var paramCount = paramTypes.Count;
+            var argCount = args.Count;
+            if (paramCount != argCount)
             {
-                throw new InvalidDataException($"Invocation provides {args.Count} argument(s) but target expects {paramTypes.Count}.");
+                throw new InvalidDataException($"Invocation provides {argCount} argument(s) but target expects {paramCount}.");
             }
 
-            if (paramTypes.Count == 0)
+            if (paramCount == 0)
             {
                 return Array.Empty<object>();
             }
 
-            var arguments = new object[args.Count];
+            var arguments = new object[argCount];
 
             try
             {
-                for (var i = 0; i < paramTypes.Count; i++)
+                for (var i = 0; i < paramCount; i++)
                 {
                     var paramType = paramTypes[i];
                     arguments[i] = args[i].ToObject(paramType, PayloadSerializer);


### PR DESCRIPTION
Before:
```
             Method |          Input | HubProtocol |       Mean |     Error |    StdDev |      Op/s |  Gen 0 | Allocated |
------------------- |--------------- |------------ |-----------:|----------:|----------:|----------:|-------:|----------:|
  ReadSingleMessage |   FewArguments |        Json |   9.294 us | 0.1948 us | 0.2667 us | 107,600.6 |      - |     976 B |
 WriteSingleMessage |   FewArguments |        Json |   7.813 us | 0.1539 us | 0.2571 us | 127,984.0 |      - |     824 B |
  ReadSingleMessage | LargeArguments |        Json | 280.847 us | 5.5548 us | 7.4155 us |   3,560.7 | 0.4883 |   58872 B |
 WriteSingleMessage | LargeArguments |        Json | 180.111 us | 3.5657 us | 5.4452 us |   5,552.1 |      - |   24792 B |
  ReadSingleMessage |  ManyArguments |        Json |  14.800 us | 0.3100 us | 0.4346 us |  67,565.6 |      - |    1536 B |
 WriteSingleMessage |  ManyArguments |        Json |  14.611 us | 0.2681 us | 0.2508 us |  68,440.5 |      - |    2080 B |
  ReadSingleMessage |    NoArguments |        Json |   3.831 us | 0.0738 us | 0.0878 us | 261,010.1 |      - |     600 B |
 WriteSingleMessage |    NoArguments |        Json |   3.309 us | 0.0658 us | 0.0731 us | 302,226.7 |      - |     392 B |
```

After:
```
             Method |          Input | HubProtocol |       Mean |     Error |    StdDev |      Op/s |  Gen 0 | Allocated |
------------------- |--------------- |------------ |-----------:|----------:|----------:|----------:|-------:|----------:|
  ReadSingleMessage |   FewArguments |        Json |   8.926 us | 0.1776 us | 0.1574 us | 112,026.2 |      - |     976 B |
 WriteSingleMessage |   FewArguments |        Json |   7.384 us | 0.1472 us | 0.2377 us | 135,432.3 |      - |     824 B |
  ReadSingleMessage | LargeArguments |        Json | 270.289 us | 3.9892 us | 3.5364 us |   3,699.7 | 0.4883 |   58872 B |
 WriteSingleMessage | LargeArguments |        Json | 175.519 us | 3.4114 us | 4.1895 us |   5,697.4 |      - |   24792 B |
  ReadSingleMessage |  ManyArguments |        Json |  14.311 us | 0.2528 us | 0.3197 us |  69,878.1 |      - |    1536 B |
 WriteSingleMessage |  ManyArguments |        Json |  14.389 us | 0.2319 us | 0.2169 us |  69,496.9 |      - |    2080 B |
  ReadSingleMessage |    NoArguments |        Json |   3.809 us | 0.0583 us | 0.0516 us | 262,559.4 |      - |     600 B |
 WriteSingleMessage |    NoArguments |        Json |   3.236 us | 0.0621 us | 0.0637 us | 308,994.5 | 0.0038 |     392 B |
```