### PR TITLE
EchoAll scenario doesn't work well with warmup

### DIFF
--- a/benchmarkapps/BenchmarkServer/signalr.json
+++ b/benchmarkapps/BenchmarkServer/signalr.json
@@ -18,6 +18,7 @@
     "ClientProperties": { "Scenario": "echo" }
   },
   "SignalREchoAll": {
-    "ClientProperties": { "Scenario": "echoAll" }
+    "ClientProperties": { "Scenario": "echoAll" },
+    "Warmup": 0
   }
 }


### PR DESCRIPTION
Warmup runs will fill up the connection pipes on the server and when the connections are closed the server will still be processing messages because that's what we do. Then the main run will start while the warmup messages are still running, ruining our benchmark results