### PR TITLE
fix #2187 by passing min size through to buffer writer when encoding

### DIFF
--- a/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/HubProtocolBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/HubProtocolBenchmark.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
         [Params(Message.NoArguments, Message.FewArguments, Message.ManyArguments, Message.LargeArguments)]
         public Message Input { get; set; }
 
-        [Params(/*Protocol.MsgPack,*/ Protocol.Json)]
+        [Params(Protocol.MsgPack, Protocol.Json)]
         public Protocol HubProtocol { get; set; }
 
         [GlobalSetup]

--- a/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/HubProtocolBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/HubProtocolBenchmark.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
         [Params(Message.NoArguments, Message.FewArguments, Message.ManyArguments, Message.LargeArguments)]
         public Message Input { get; set; }
 
-        [Params(Protocol.MsgPack, Protocol.Json)]
+        [Params(/*Protocol.MsgPack,*/ Protocol.Json)]
         public Protocol HubProtocol { get; set; }
 
         [GlobalSetup]

--- a/src/Common/Utf8BufferTextWriter.cs
+++ b/src/Common/Utf8BufferTextWriter.cs
@@ -14,6 +14,7 @@ namespace Microsoft.AspNetCore.Internal
     internal sealed class Utf8BufferTextWriter : TextWriter
     {
         private static readonly UTF8Encoding _utf8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+        private static readonly int MaximumBytesPerUtf8Char = 4;
 
         [ThreadStatic]
         private static Utf8BufferTextWriter _cachedInstance;
@@ -139,7 +140,8 @@ namespace Microsoft.AspNetCore.Internal
 
         private void EnsureBuffer()
         {
-            if (_memoryUsed == _memory.Length)
+            var remaining = _memory.Length - _memoryUsed;
+            if (remaining < MaximumBytesPerUtf8Char)
             {
                 // Used up the memory from the buffer writer so advance and get more
                 if (_memoryUsed > 0)
@@ -147,7 +149,7 @@ namespace Microsoft.AspNetCore.Internal
                     _bufferWriter.Advance(_memoryUsed);
                 }
 
-                _memory = _bufferWriter.GetMemory();
+                _memory = _bufferWriter.GetMemory(MaximumBytesPerUtf8Char);
                 _memoryUsed = 0;
             }
         }

--- a/src/Common/Utf8BufferTextWriter.cs
+++ b/src/Common/Utf8BufferTextWriter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -140,6 +140,10 @@ namespace Microsoft.AspNetCore.Internal
 
         private void EnsureBuffer()
         {
+            // We need at least enough bytes to encode a single UTF-8 character, or Encoder.Convert will throw.
+            // Normally, if there isn't enough space to write every character of a char buffer, Encoder.Convert just
+            // writes what it can. However, if it can't even write a single character, it throws. So if the buffer has only
+            // 2 bytes left and the next character to write is 3 bytes in UTF-8, an exception is thrown.
             var remaining = _memory.Length - _memoryUsed;
             if (remaining < MaximumBytesPerUtf8Char)
             {

--- a/test/Microsoft.AspNetCore.SignalR.Common.Tests/Internal/Protocol/Utf8BufferTextWriterTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Common.Tests/Internal/Protocol/Utf8BufferTextWriterTests.cs
@@ -262,7 +262,10 @@ namespace Microsoft.AspNetCore.SignalR.Common.Tests.Internal.Protocol
             // へ => E3-81-B8
             // ど => E3-81-A9
             // g => 67
-            const string testString = "aいbろcdはにeほfへどg";
+            // h => 68
+            // i => 69
+            // \uD800\uDC00 => F0-90-80-80 (this is a surrogate pair that is represented as a single 4-byte UTF-8 encoding)
+            const string testString = "aいbろcdはにeほfへどghi\uD800\uDC00";
 
             // By mixing single byte and multi-byte characters, we know that there will
             // be spaces in the active segment that cannot fit the current character. This
@@ -283,7 +286,8 @@ namespace Microsoft.AspNetCore.SignalR.Common.Tests.Internal.Protocol
                 seg => Assert.Equal(new byte[] { 0xE3, 0x81, 0xAB, 0x65 }, seg),        // "にe"
                 seg => Assert.Equal(new byte[] { 0xE3, 0x81, 0xBB, 0x66 }, seg),        // "ほf"
                 seg => Assert.Equal(new byte[] { 0xE3, 0x81, 0xB8 }, seg),              // "へ"
-                seg => Assert.Equal(new byte[] { 0xE3, 0x81, 0xA9, 0x67 }, seg));       // "どg"
+                seg => Assert.Equal(new byte[] { 0xE3, 0x81, 0xA9, 0x67, 0x68 }, seg),        // "どgh"
+                seg => Assert.Equal(new byte[] { 0x69, 0xF0, 0x90, 0x80, 0x80 }, seg));       // "i\uD800\uDC00"
 
             Assert.Equal(testString, Encoding.UTF8.GetString(bufferWriter.ToArray()));
         }

--- a/test/Microsoft.AspNetCore.SignalR.Common.Tests/Internal/Protocol/Utf8BufferTextWriterTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Common.Tests/Internal/Protocol/Utf8BufferTextWriterTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Buffers;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using Microsoft.AspNetCore.Internal;
 using Microsoft.AspNetCore.SignalR.Internal;
@@ -202,20 +203,21 @@ namespace Microsoft.AspNetCore.SignalR.Common.Tests.Internal.Protocol
             textWriter.Write(chars);
             textWriter.Flush();
 
-            Assert.Equal(6, bufferWriter.Segments.Count);
+            var segments = bufferWriter.GetSegments();
+            Assert.Equal(6, segments.Count);
             Assert.Equal(1, bufferWriter.Position);
 
-            Assert.Equal((byte)'H', bufferWriter.Segments[0].Span[0]);
-            Assert.Equal((byte)'e', bufferWriter.Segments[0].Span[1]);
-            Assert.Equal((byte)'l', bufferWriter.Segments[1].Span[0]);
-            Assert.Equal((byte)'l', bufferWriter.Segments[1].Span[1]);
-            Assert.Equal((byte)'o', bufferWriter.Segments[2].Span[0]);
-            Assert.Equal((byte)' ', bufferWriter.Segments[2].Span[1]);
-            Assert.Equal((byte)'w', bufferWriter.Segments[3].Span[0]);
-            Assert.Equal((byte)'o', bufferWriter.Segments[3].Span[1]);
-            Assert.Equal((byte)'r', bufferWriter.Segments[4].Span[0]);
-            Assert.Equal((byte)'l', bufferWriter.Segments[4].Span[1]);
-            Assert.Equal((byte)'d', bufferWriter.Segments[5].Span[0]);
+            Assert.Equal((byte)'H', segments[0].Span[0]);
+            Assert.Equal((byte)'e', segments[0].Span[1]);
+            Assert.Equal((byte)'l', segments[1].Span[0]);
+            Assert.Equal((byte)'l', segments[1].Span[1]);
+            Assert.Equal((byte)'o', segments[2].Span[0]);
+            Assert.Equal((byte)' ', segments[2].Span[1]);
+            Assert.Equal((byte)'w', segments[3].Span[0]);
+            Assert.Equal((byte)'o', segments[3].Span[1]);
+            Assert.Equal((byte)'r', segments[4].Span[0]);
+            Assert.Equal((byte)'l', segments[4].Span[1]);
+            Assert.Equal((byte)'d', segments[5].Span[0]);
         }
 
         [Fact]
@@ -242,35 +244,85 @@ namespace Microsoft.AspNetCore.SignalR.Common.Tests.Internal.Protocol
             Assert.Same(textWriter1, textWriter2);
         }
 
+        [Fact]
+        private void WriteMultiByteCharactersToSmallBuffers()
+        {
+            // Test string breakdown (char => UTF-8 hex values):
+            // a => 61
+            // い => E3-81-84
+            // b => 62
+            // ろ => E3-82-8D
+            // c => 63
+            // d => 64
+            // は => E3-81-AF
+            // に => E3-81-AB
+            // e => 65
+            // ほ => E3-81-BB
+            // f => 66
+            // へ => E3-81-B8
+            // ど => E3-81-A9
+            // g => 67
+            const string testString = "aいbろcdはにeほfへどg";
+
+            // By mixing single byte and multi-byte characters, we know that there will
+            // be spaces in the active segment that cannot fit the current character. This
+            // means we'll be testing the GetMemory(minimumSize) logic.
+            var bufferWriter = new TestMemoryBufferWriter(segmentSize: 5);
+
+            var writer = new Utf8BufferTextWriter();
+            writer.SetWriter(bufferWriter);
+            writer.Write(testString);
+            writer.Flush();
+
+            // Verify the output
+            var allSegments = bufferWriter.GetSegments().Select(s => s.ToArray()).ToArray();
+            Assert.Collection(allSegments,
+                seg => Assert.Equal(new byte[] { 0x61, 0xE3, 0x81, 0x84, 0x62 }, seg),  // "aいb"
+                seg => Assert.Equal(new byte[] { 0xE3, 0x82, 0x8D, 0x63, 0x64 }, seg),  // "ろcd"
+                seg => Assert.Equal(new byte[] { 0xE3, 0x81, 0xAF }, seg),              // "は"
+                seg => Assert.Equal(new byte[] { 0xE3, 0x81, 0xAB, 0x65 }, seg),        // "にe"
+                seg => Assert.Equal(new byte[] { 0xE3, 0x81, 0xBB, 0x66 }, seg),        // "ほf"
+                seg => Assert.Equal(new byte[] { 0xE3, 0x81, 0xB8 }, seg),              // "へ"
+                seg => Assert.Equal(new byte[] { 0xE3, 0x81, 0xA9, 0x67 }, seg));       // "どg"
+
+            Assert.Equal(testString, Encoding.UTF8.GetString(bufferWriter.ToArray()));
+        }
+
         private sealed class TestMemoryBufferWriter : IBufferWriter<byte>
         {
             private readonly int _segmentSize;
 
-            internal List<Memory<byte>> Segments { get; }
+            private List<Memory<byte>> _completedSegments = new List<Memory<byte>>();
+            private int _totalLength;
+
+            public Memory<byte> CurrentSegment { get; private set; }
             internal int Position { get; private set; }
 
             public TestMemoryBufferWriter(int segmentSize = 2048)
             {
                 _segmentSize = segmentSize;
-
-                Segments = new List<Memory<byte>>();
+                CurrentSegment = Memory<byte>.Empty;
             }
-
-            public Memory<byte> CurrentSegment => Segments.Count > 0 ? Segments[Segments.Count - 1] : null;
 
             public void Advance(int count)
             {
                 Position += count;
+                _totalLength += count;
             }
 
             public Memory<byte> GetMemory(int sizeHint = 0)
             {
-                // TODO: Use sizeHint
-
-                if (Segments.Count == 0 || Position == _segmentSize)
+                // Need special handling for sizeHint == 0, because for that we want to enter the if even if there are "sizeHint" (i.e. 0) bytes left :).
+                if ((sizeHint == 0 && CurrentSegment.Length == Position) || (CurrentSegment.Length - Position < sizeHint))
                 {
-                    // TODO: Rent memory from a pool
-                    Segments.Add(new Memory<byte>(new byte[_segmentSize]));
+                    if (Position > 0)
+                    {
+                        // Complete the current segment
+                        _completedSegments.Add(CurrentSegment.Slice(0, Position));
+                    }
+
+                    // Allocate a new segment and reset the position.
+                    CurrentSegment = new Memory<byte>(new byte[_segmentSize]);
                     Position = 0;
                 }
 
@@ -284,30 +336,43 @@ namespace Microsoft.AspNetCore.SignalR.Common.Tests.Internal.Protocol
 
             public byte[] ToArray()
             {
-                if (Segments.Count == 0)
+                if (CurrentSegment.IsEmpty && _completedSegments.Count == 0)
                 {
                     return Array.Empty<byte>();
                 }
 
-                var totalLength = (Segments.Count - 1) * _segmentSize;
-                totalLength += Position;
-
-                var result = new byte[totalLength];
+                var result = new byte[_totalLength];
 
                 var totalWritten = 0;
 
-                // Copy full segments
-                for (var i = 0; i < Segments.Count - 1; i++)
+                // Copy completed segments
+                foreach (var segment in _completedSegments)
                 {
-                    Segments[i].CopyTo(result.AsMemory(totalWritten, _segmentSize));
+                    segment.CopyTo(result.AsMemory(totalWritten, segment.Length));
 
-                    totalWritten += _segmentSize;
+                    totalWritten += segment.Length;
                 }
 
-                // Copy current incomplete segment
+                // Copy current segment
                 CurrentSegment.Slice(0, Position).CopyTo(result.AsMemory(totalWritten, Position));
 
                 return result;
+            }
+
+            public IList<Memory<byte>> GetSegments()
+            {
+                var list = new List<Memory<byte>>();
+                foreach (var segment in _completedSegments)
+                {
+                    list.Add(segment);
+                }
+
+                if (CurrentSegment.Length > 0)
+                {
+                    list.Add(CurrentSegment.Slice(0, Position));
+                }
+
+                return list;
             }
         }
     }


### PR DESCRIPTION
This fixes an error that occurs when a multi-byte character is about to be written by Utf8BufferTextWriter, but there isn't enough space for it in the buffer. We use [`Encoder.Convert`](https://docs.microsoft.com/en-us/dotnet/api/system.text.encoder.convert?view=netstandard-2.0#System_Text_Encoder_Convert_System_Char__System_Int32_System_Byte__System_Int32_System_Boolean_System_Int32__System_Int32__System_Boolean__) which writes as many characters as it can fit into the provided buffer. However, if there isn't even enough space for a single character, it throws. 

Consider this example of the current behavior, where the buffers are in 4-byte segments (of course the real buffers are like 2048 bytes, but for illustration...):

1. The buffer has 4 bytes of space: `[ ] [ ] [ ] [ ]`
2. We write `aい`, which takes up 4 bytes: `[0x61] [0xE3] [0x81] [0x84]`
3. We call `GetMemory(0)` and since the buffer is full, we get a new 4 byte buffer: `[ ] [ ] [ ] [ ]`
4. We try to write `はに`. Only the first character fits, so we fill 3 bytes: `[0xE3] [0x81] [0xAF] [ ]`
5. We call `GetMemory(0)` but since the buffer is not full, we get the same buffer: `[0xE3] [0x81] [0xAF] [ ]`
6. We try to write `に` (since it wasn't written before). The buffer is only 1 byte in size, so the encoder throws:

```
System.ArgumentException: The output byte buffer is too small to contain the encoded data, encoding 'Unicode (UTF-8)' fallback 'System.Text.EncoderReplacementFallback'.
Parameter name: bytes
```

The new behavior is similar, but it specifies a `sizeHint` value of `4` (the maximum number of bytes needed to encoded a UTF-8 character to `IBufferWriter.GetMemory`, which means it will force a new segment to be allocated if there isn't enough space in the current segment. So the updated logic for the same input as above is:

1. The buffer has 4 bytes of space: `[ ] [ ] [ ] [ ]`
2. We write `aい`, which takes up 4 bytes: `[0x61] [0xE3] [0x81] [0x84]`
3. We call `GetMemory(4)`; since the buffer is full, we get a new 4 byte buffer: `[ ] [ ] [ ] [ ]`
4. We try to write `はに`. Only the first character fits, so we fill 3 bytes: `[0xE3] [0x81] [0xAF] [ ]`
5. We call `GetMemory(4)`; since the buffer doesn't have 4 bytes left, we get a new buffer: `[ ] [ ] [ ] [ ]`
6. We try to write `に` (since it wasn't written before). And it fits: `[0xE3] [0x81] [0xAB] [ ]`

I'll run the hub protocol benchmarks and post the results here.

Fixes #2187 