### PR TITLE
clean up the shutdown timer

### DIFF
--- a/clients/ts/signalr/spec/LongPollingTransport.spec.ts
+++ b/clients/ts/signalr/spec/LongPollingTransport.spec.ts
@@ -8,6 +8,7 @@ import { ConsoleLogger } from "../src/Utils";
 import { TestHttpClient } from "./TestHttpClient";
 import { asyncit as it, PromiseSource, delay } from "./Utils";
 import { HttpError, TimeoutError } from "../src/Errors";
+import { AbortSignal } from "../src/AbortController";
 
 describe("LongPollingTransport", () => {
     it("shuts down poll after timeout even if server doesn't shut it down on receiving the DELETE", async () => {
@@ -59,7 +60,6 @@ describe("LongPollingTransport", () => {
                 deleteReceived.resolve();
                 return new HttpResponse(202);
             });
-        const logMessages: string[] = [];
         const transport = new LongPollingTransport(client, null, NullLogger.instance, false, 100);
 
         await transport.connect("http://example.com", TransferFormat.Text);
@@ -115,9 +115,8 @@ describe("LongPollingTransport", () => {
             // fake timers!
             await delay(150);
 
-            expect(logMessages)
-                .not
-                .toContain("(LongPolling transport) server did not terminate after DELETE request, canceling poll.");
+            // The pollAbort token should be left unaborted because we shut down gracefully.
+            expect(transport.pollAborted).toBe(false);
         });
     }
 });

--- a/clients/ts/signalr/src/LongPollingTransport.ts
+++ b/clients/ts/signalr/src/LongPollingTransport.ts
@@ -108,9 +108,6 @@ export class LongPollingTransport implements ITransport {
                     if (response.statusCode === 204) {
                         this.logger.log(LogLevel.Information, "(LongPolling transport) Poll terminated by server");
 
-                        // If we were on a timeout waiting for shutdown, unregister it.
-                        clearTimeout(this.shutdownTimer);
-
                         this.running = false;
                     } else if (response.statusCode !== 200) {
                         this.logger.log(LogLevel.Error, `(LongPolling transport) Unexpected response code: ${response.statusCode}`);


### PR DESCRIPTION
Found during #2193, forking off into a separate PR. We should take this for RTM even if we don't take #2193.

When `connection.stop` is called, we check the `pollAborted` "AbortSignal" (JavaScript equivalent of a CancellationToken) to see the poll is still running and if it is, we set a timer to see if the server will shut it down (we already sent the `DELETE` which should stop the server). However, if the poll completes normally before `connection.stop` is called, we don't set that token so we set up the timer anyway, logging an inaccurate log message 5 seconds after we shut down. There's no functional "break", but it's bad to log something that isn't true. Also, in Node JS applications (or tests), leaving this timeout on the queue can cause delays in shutting down.

This can also happen if we **are** mid-poll but the server **does** stop the poll before the timeout elapses. In that case, the timeout fires because we never clean it up.

Testing this requires asserting a timer callback never fires, which is a little tricky but I hacked something up. Jest has a set of fake timers so once #2193 is in and we start revamping our tests, we can look at using that to make it cleaner