### PR TITLE
Don't ignore params

### DIFF
--- a/src/Microsoft.AspNetCore.SignalR.Client/HubConnectionBuilderHttpExtensions.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client/HubConnectionBuilderHttpExtensions.cs
@@ -99,7 +99,7 @@ namespace Microsoft.AspNetCore.SignalR.Client
         /// <returns>The same instance of the <see cref="IHubConnectionBuilder"/> for chaining.</returns>
         public static IHubConnectionBuilder WithUrl(this IHubConnectionBuilder hubConnectionBuilder, Uri url, HttpTransportType transports)
         {
-            hubConnectionBuilder.WithUrlCore(url, null, _ => { });
+            hubConnectionBuilder.WithUrlCore(url, transports, _ => { });
             return hubConnectionBuilder;
         }
 
@@ -113,7 +113,7 @@ namespace Microsoft.AspNetCore.SignalR.Client
         /// <returns>The same instance of the <see cref="IHubConnectionBuilder"/> for chaining.</returns>
         public static IHubConnectionBuilder WithUrl(this IHubConnectionBuilder hubConnectionBuilder, Uri url, HttpTransportType transports, Action<HttpConnectionOptions> configureHttpConnection)
         {
-            hubConnectionBuilder.WithUrlCore(url, transports, _ => { });
+            hubConnectionBuilder.WithUrlCore(url, transports, configureHttpConnection);
             return hubConnectionBuilder;
         }
 

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionBuilderExtensionsTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionBuilderExtensionsTests.cs
@@ -43,6 +43,36 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
         }
 
         [Fact]
+        public void WithUrlUsingUriSetsTransport()
+        {
+            var connectionBuilder = new HubConnectionBuilder();
+            var uri = new Uri("http://tempuri.org");
+            connectionBuilder.WithUrl(uri, HttpTransportType.LongPolling);
+
+            var serviceProvider = connectionBuilder.Services.BuildServiceProvider();
+
+            var value = serviceProvider.GetService<IOptions<HttpConnectionOptions>>().Value;
+
+            Assert.Equal(HttpTransportType.LongPolling, value.Transports);
+        }
+
+        [Fact]
+        public void WithUrlUsingUriHttpConnectionCallsConfigure()
+        {
+            var proxy = Mock.Of<IWebProxy>();
+
+            var connectionBuilder = new HubConnectionBuilder();
+            var uri = new Uri("http://tempuri.org");
+            connectionBuilder.WithUrl(uri, HttpTransportType.LongPolling, options => { options.Proxy = proxy; });
+
+            var serviceProvider = connectionBuilder.Services.BuildServiceProvider();
+
+            var value = serviceProvider.GetService<IOptions<HttpConnectionOptions>>().Value;
+
+            Assert.Same(proxy, value.Proxy);
+        }
+
+        [Fact]
         public void WithHttpConnectionCallsConfigure()
         {
             var proxy = Mock.Of<IWebProxy>();


### PR DESCRIPTION
For issue: https://github.com/aspnet/SignalR/issues/2219
We were ignoring the transports flags and the HttpConnectionOptions parameters in some cases in the HubConnectionBuilder.