### PR TITLE
Embed version in the JavaScript client

### DIFF
--- a/clients/ts/build/embed-version.js
+++ b/clients/ts/build/embed-version.js
@@ -13,7 +13,7 @@ for (let i = 0; i < args.length; i++) {
 }
 
 function processDirectory(dir) {
-    if(verbose) {
+    if (verbose) {
         console.log(`processing ${dir}`);
     }
     for (const item of fs.readdirSync(dir)) {

--- a/clients/ts/build/embed-version.js
+++ b/clients/ts/build/embed-version.js
@@ -1,0 +1,26 @@
+const path = require("path");
+const fs = require("fs");
+const pkg = require(path.resolve(process.cwd(), "package.json"));
+
+function processDirectory(dir) {
+    for (const item of fs.readdirSync(dir)) {
+        const stats = fs.statSync(item);
+        if (stats.isDirectory()) {
+            processDirectory(item);
+        } else if (stats.isFile()) {
+            processFile(item);
+        }
+    }
+}
+
+const SEARCH_STRING = "0.0.0-DEV_VERSION";
+/**
+ * @param {string} file 
+ */
+function processFile(file) {
+    if (file.endsWith(".js") || file.endsWith(".ts")) {
+        let content = fs.readFileSync(file);
+        content = content.toString().replace(SEARCH_STRING, pkg.version);
+        fs.writeFileSync(file, content);
+    }
+}

--- a/clients/ts/build/embed-version.js
+++ b/clients/ts/build/embed-version.js
@@ -4,11 +4,12 @@ const pkg = require(path.resolve(process.cwd(), "package.json"));
 
 function processDirectory(dir) {
     for (const item of fs.readdirSync(dir)) {
-        const stats = fs.statSync(item);
+        const fullPath = path.resolve(dir, item);
+        const stats = fs.statSync(fullPath);
         if (stats.isDirectory()) {
-            processDirectory(item);
+            processDirectory(fullPath);
         } else if (stats.isFile()) {
-            processFile(item);
+            processFile(fullPath);
         }
     }
 }

--- a/clients/ts/build/embed-version.js
+++ b/clients/ts/build/embed-version.js
@@ -2,7 +2,20 @@ const path = require("path");
 const fs = require("fs");
 const pkg = require(path.resolve(process.cwd(), "package.json"));
 
+const args = process.argv.slice(2);
+let verbose = false;
+for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+        case "-v":
+            verbose = true;
+            break;
+    }
+}
+
 function processDirectory(dir) {
+    if(verbose) {
+        console.log(`processing ${dir}`);
+    }
     for (const item of fs.readdirSync(dir)) {
         const fullPath = path.resolve(dir, item);
         const stats = fs.statSync(fullPath);
@@ -14,14 +27,18 @@ function processDirectory(dir) {
     }
 }
 
-const SEARCH_STRING = "0.0.0-DEV_VERSION";
-/**
- * @param {string} file 
- */
+const SEARCH_STRING = "0.0.0-DEV_BUILD";
 function processFile(file) {
     if (file.endsWith(".js") || file.endsWith(".ts")) {
+        if (verbose) {
+            console.log(`processing ${file}`);
+        }
         let content = fs.readFileSync(file);
         content = content.toString().replace(SEARCH_STRING, pkg.version);
         fs.writeFileSync(file, content);
+    } else if (verbose) {
+        console.log(`skipping ${file}`);
     }
 }
+
+processDirectory(path.resolve(process.cwd(), "dist"));

--- a/clients/ts/rollup-base.js
+++ b/clients/ts/rollup-base.js
@@ -19,10 +19,12 @@ export default function(rootDir, moduleGlobals) {
             format: "umd",
             name: pkg.umd_name,
             sourcemap: true,
-            banner: "/* @license\r\n" +
+            banner: "/** \r\n" +
+                " * @overview ASP.NET Core SignalR JavaScript Client.\r\n" +
+                " * @version 0.0.0-DEV_BUILD.\r\n" +
+                " * @license\r\n" +
                 " * Copyright (c) .NET Foundation. All rights reserved.\r\n" +
                 " * Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.\r\n" +
-                " * @version 0.0.0-DEV_BUILD.\r\n" +
                 " */",
             globals: moduleGlobals,
         },

--- a/clients/ts/rollup-base.js
+++ b/clients/ts/rollup-base.js
@@ -22,6 +22,7 @@ export default function(rootDir, moduleGlobals) {
             banner: "/* @license\r\n" +
                 " * Copyright (c) .NET Foundation. All rights reserved.\r\n" +
                 " * Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.\r\n" +
+                " * @version 0.0.0-DEV_BUILD.\r\n" +
                 " */",
             globals: moduleGlobals,
         },

--- a/clients/ts/signalr-protocol-msgpack/package.json
+++ b/clients/ts/signalr-protocol-msgpack/package.json
@@ -18,6 +18,7 @@
     "build:cjs": "node ../node_modules/typescript/bin/tsc --project ./tsconfig.json --module commonjs --outDir ./dist/cjs",
     "build:browser": "node ../node_modules/rollup/bin/rollup -c",
     "build:uglify": "node ../node_modules/uglify-js/bin/uglifyjs --source-map \"url='signalr-protocol-msgpack.min.js.map',content='./dist/browser/signalr-protocol-msgpack.js.map'\" --comments -o ./dist/browser/signalr-protocol-msgpack.min.js ./dist/browser/signalr-protocol-msgpack.js",
+    "prepack": "node ../build/embed-version.js",
     "test": "echo \"Run 'npm test' in the 'clients\\ts' folder to test this package\" && exit 1"
   },
   "keywords": [

--- a/clients/ts/signalr-protocol-msgpack/src/index.ts
+++ b/clients/ts/signalr-protocol-msgpack/src/index.ts
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 // Version token that will be replaced by the prepack command
+/** The version of the SignalR client. */
 export const VERSION = "0.0.0-DEV_BUILD";
 
 export { MessagePackHubProtocol } from "./MessagePackHubProtocol";

--- a/clients/ts/signalr-protocol-msgpack/src/index.ts
+++ b/clients/ts/signalr-protocol-msgpack/src/index.ts
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 // Version token that will be replaced by the prepack command
-/** The version of the SignalR client. */
+/** The version of the SignalR Message Pack protocol library. */
 export const VERSION = "0.0.0-DEV_BUILD";
 
 export { MessagePackHubProtocol } from "./MessagePackHubProtocol";

--- a/clients/ts/signalr-protocol-msgpack/src/index.ts
+++ b/clients/ts/signalr-protocol-msgpack/src/index.ts
@@ -1,4 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+// Version token that will be replaced by the prepack command
+export const VERSION = "0.0.0-DEV_BUILD";
+
 export { MessagePackHubProtocol } from "./MessagePackHubProtocol";

--- a/clients/ts/signalr/package.json
+++ b/clients/ts/signalr/package.json
@@ -18,6 +18,7 @@
     "build:cjs": "node ../node_modules/typescript/bin/tsc --project ./tsconfig.json --module commonjs --outDir ./dist/cjs",
     "build:browser": "node ../node_modules/rollup/bin/rollup -c",
     "build:uglify": "node ../node_modules/uglify-js/bin/uglifyjs --source-map \"url='signalr.min.js.map',content='./dist/browser/signalr.js.map'\" --comments -o ./dist/browser/signalr.min.js ./dist/browser/signalr.js",
+    "prepack": "node ../build/embed-version.js",
     "test": "echo \"Run 'npm test' in the 'clients\\ts' folder to test this package\" && exit 1"
   },
   "repository": {

--- a/clients/ts/signalr/src/index.ts
+++ b/clients/ts/signalr/src/index.ts
@@ -2,7 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 // Version token that will be replaced by the prepack command
-export const VERSION = "0.0.0-DEV_BUILD";
+/** The version of the SignalR client. */
+export const VERSION: string = "0.0.0-DEV_BUILD";
 
 // Everything that users need to access must be exported here. Including interfaces.
 export { AbortSignal } from "./AbortController";

--- a/clients/ts/signalr/src/index.ts
+++ b/clients/ts/signalr/src/index.ts
@@ -1,6 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+// Version token that will be replaced by the prepack command
+export const VERSION = "0.0.0-DEV_BUILD";
+
 // Everything that users need to access must be exported here. Including interfaces.
 export { AbortSignal } from "./AbortController";
 export { HttpError, TimeoutError } from "./Errors";


### PR DESCRIPTION
Related to https://github.com/aspnet/SignalR/issues/2130

The way this works for now is that it takes advantage of the fact that we update the `package.json` version from MSBuild during the packaging step. This happens **after** the build phase, so I added a script to the `prepack` phase in NPM that scans all files under `dist` (build outputs) and replaces a token with the actual version in `package.json`