### PR TITLE
Update Issue Template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -12,15 +12,6 @@ repository is for packages that start with `Microsoft.AspNetCore.SignalR` (and N
 * The Operating System on the Server (Windows/Linux/macOS):
 * The Operating System on the Client (Windows/Linux/macOS):
 * The Browser on the client, if using the JavaScript client (IE/Chrome/Edge/Firefox/etc.):
-* If possible, please collect Network Traces and attach them (please do not post them inline, use a service like [Gist](https://gist.github.com) to upload them and link them in the issue)
-   * For either client you can use a tool such as [Fiddler](https://www.telerik.com/fiddler) for this
-   * Many browsers allow you to capture Network Traces from their Dev Tools. See sample instructions for Chrome: https://support.zendesk.com/hc/en-us/articles/204410413-Generating-a-HAR-file-for-troubleshooting
-* If possible, please collect logs from the client:
-   * Set the `logger` option on your `HubConnection` to `LogLevel.Trace` and find the logs in the Console tab of your Browser Dev Tools
-   * Example: `new signalR.HubConnection(url, { logger: signalR.LogLevel.Trace })`
-* If possible, please collect logs from the server:
-   * When using Kestrel/HttpSysServer, these are available on the Console by default
-   * When using IIS/IIS Express, these are available in Visual Studio in the "ASP.NET Core Web Server" section of the Output Window
-   * See https://docs.microsoft.com/en-us/aspnet/core/fundamentals/logging/?tabs=aspnetcore2x for more information
+* Please use the Diagnostics Guide at https://github.com/aspnet/SignalR/wiki/Diagnostics-Guide to collect server-side and client-side logs and network traces if possible. Please **do not** put the traces and logs in the Issue text as they are quite large. The Diagnostics Guide describes how to attach them to the issue.
 
 When in doubt, feel free to file the issue, we're happy to help answer questions. We also suggest using the `asp.net-core-signalr` tag on StackOverflow to ask questions.


### PR DESCRIPTION
We changed some of the logging APIs and I decided it would be better to just write a Wiki page with a full diagnostics guide to refer to from the template. We can also link to the guide when we need to ask for more information (logs, traces, etc.).

See the diagnostics guide here: https://github.com/aspnet/SignalR/wiki/Diagnostics-Guide - At some point it can be elevated to an official "Doc" on aspnet/Docs.

The Wiki doesn't have any review mechanism, so feel free to offer suggestions for that guide here or via other communication media :).