### PR TITLE
Add Content-Type header in HttpClient.ts

### DIFF
--- a/clients/ts/FunctionalTests/TestHub.cs
+++ b/clients/ts/FunctionalTests/TestHub.cs
@@ -83,5 +83,10 @@ namespace FunctionalTests
                 String = "hello world",
             };
         }
+
+        public string GetContentTypeHeader()
+        {
+            return Context.GetHttpContext().Request.Headers["Content-Type"];
+        }
     }
 }

--- a/clients/ts/FunctionalTests/ts/HubConnectionTests.ts
+++ b/clients/ts/FunctionalTests/ts/HubConnectionTests.ts
@@ -686,6 +686,24 @@ describe("hubConnection", () => {
         }
     });
 
+    it("populates the Content-Type header when sending XMLHttpRequest", async (done) => {
+        const hubConnection = getConnectionBuilder(HttpTransportType.LongPolling, TESTHUB_NOWEBSOCKETS_ENDPOINT_URL)
+            .withHubProtocol(new JsonHubProtocol())
+            .build();
+
+        try {
+            await hubConnection.start();
+
+            // Check what transport was used by asking the server to tell us.
+            expect(await hubConnection.invoke("GetActiveTransportName")).toEqual("LongPolling");
+            // Check to see that the Content-Type header is set the expected value
+            expect(await hubConnection.invoke("GetContentTypeHeader")).toEqual("text/plain;charset=UTF-8");
+            done();
+        } catch (e) {
+            fail(e);
+        }
+    });
+
     function getJwtToken(url: string): Promise<string> {
         return new Promise((resolve, reject) => {
             const xhr = new XMLHttpRequest();

--- a/clients/ts/signalr/src/HttpClient.ts
+++ b/clients/ts/signalr/src/HttpClient.ts
@@ -163,6 +163,7 @@ export class DefaultHttpClient extends HttpClient {
             xhr.open(request.method, request.url, true);
             xhr.withCredentials = true;
             xhr.setRequestHeader("X-Requested-With", "XMLHttpRequest");
+            xhr.setRequestHeader("Content-Type", "text/plain;charset=UTF-8");
 
             if (request.headers) {
                 Object.keys(request.headers)

--- a/clients/ts/signalr/src/HttpClient.ts
+++ b/clients/ts/signalr/src/HttpClient.ts
@@ -163,7 +163,7 @@ export class DefaultHttpClient extends HttpClient {
             xhr.open(request.method, request.url, true);
             xhr.withCredentials = true;
             xhr.setRequestHeader("X-Requested-With", "XMLHttpRequest");
-            // Explicitly setting the Content-Type header is need for React Native on Android platform. 
+            // Explicitly setting the Content-Type header for React Native on Android platform. 
             xhr.setRequestHeader("Content-Type", "text/plain;charset=UTF-8");
 
             if (request.headers) {

--- a/clients/ts/signalr/src/HttpClient.ts
+++ b/clients/ts/signalr/src/HttpClient.ts
@@ -163,7 +163,7 @@ export class DefaultHttpClient extends HttpClient {
             xhr.open(request.method, request.url, true);
             xhr.withCredentials = true;
             xhr.setRequestHeader("X-Requested-With", "XMLHttpRequest");
-            // Explicitly setting the Content-Type header for React Native on Android platform. 
+            // Explicitly setting the Content-Type header for React Native on Android platform.
             xhr.setRequestHeader("Content-Type", "text/plain;charset=UTF-8");
 
             if (request.headers) {

--- a/clients/ts/signalr/src/HttpClient.ts
+++ b/clients/ts/signalr/src/HttpClient.ts
@@ -163,6 +163,7 @@ export class DefaultHttpClient extends HttpClient {
             xhr.open(request.method, request.url, true);
             xhr.withCredentials = true;
             xhr.setRequestHeader("X-Requested-With", "XMLHttpRequest");
+            // Explicitly setting the Content-Type header is need for React Native on Android platform. 
             xhr.setRequestHeader("Content-Type", "text/plain;charset=UTF-8");
 
             if (request.headers) {


### PR DESCRIPTION
This change prevents an error in react-native when running on the Android platform. If the Content-Type header is not set, an error is thrown.

Setting the value to `text/plain;charset=UTF-8` matches what Chrome sends without the header being specified.

Error w/out change:
![image](https://user-images.githubusercontent.com/4699747/39844289-31ad2e3e-53a4-11e8-998e-76dd944a5a7d.png)

When setting the `LogLevel` to `Debug`,  it would fail after:

`Debug: Sending negotiation request: ...`

When debugging the `xhr.onerror` function in HttpClient.ts, the details on the `xhr` object shows the underlying error from react-native is "Payload is set but no content-type header specified".

With this proposed change, the error is not thrown and results in the connection established and working as expected.

Thanks.