### PR TITLE
Remove handlers from HubConnection

### DIFF
--- a/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.Log.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.Log.cs
@@ -174,7 +174,6 @@ namespace Microsoft.AspNetCore.SignalR.Client
             private static readonly Action<ILogger, string, Exception> _removingHandlers =
                LoggerMessage.Define<string>(LogLevel.Debug, new EventId(58, "RemovingHandlers"), "Removing handlers for client method '{MethodName}'.");
 
-
             public static void PreparingNonBlockingInvocation(ILogger logger, string target, int count)
             {
                 _preparingNonBlockingInvocation(logger, target, count, null);

--- a/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.Log.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.Log.cs
@@ -171,6 +171,10 @@ namespace Microsoft.AspNetCore.SignalR.Client
             private static readonly Action<ILogger, string, string, Exception> _argumentBindingFailure =
                 LoggerMessage.Define<string, string>(LogLevel.Error, new EventId(57, "ArgumentBindingFailure"), "Failed to bind arguments received in invocation '{InvocationId}' of '{MethodName}'.");
 
+            private static readonly Action<ILogger, string, Exception> _removingHandlers =
+               LoggerMessage.Define<string>(LogLevel.Debug, new EventId(58, "RemovingHandlers"), "Removing handlers for client method '{MethodName}'.");
+
+
             public static void PreparingNonBlockingInvocation(ILogger logger, string target, int count)
             {
                 _preparingNonBlockingInvocation(logger, target, count, null);
@@ -358,6 +362,11 @@ namespace Microsoft.AspNetCore.SignalR.Client
             public static void RegisteringHandler(ILogger logger, string methodName)
             {
                 _registeringHandler(logger, methodName, null);
+            }
+
+            public static void RemovingHandlers(ILogger logger, string methodName)
+            {
+                _removingHandlers(logger, methodName, null);
             }
 
             public static void Starting(ILogger logger)

--- a/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.cs
@@ -175,8 +175,11 @@ namespace Microsoft.AspNetCore.SignalR.Client
 
             return new Subscription(invocationHandler, invocationList);
         }
-        
-        public void Remove(string methodName)
+        /// <summary>
+        /// Removes all handlers associated with the method with the specified method name.
+        /// </summary>
+        /// <param name="methodName">The name of the hub method from which handlers are being removed</param>
+        public void RemoveHandler(string methodName)
         {
             CheckDisposed();
             Log.RemovingHandlers(_logger, methodName);

--- a/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.cs
@@ -175,6 +175,12 @@ namespace Microsoft.AspNetCore.SignalR.Client
 
             return new Subscription(invocationHandler, invocationList);
         }
+        
+        public void Off(string methodName)
+        {
+            CheckDisposed();
+            _handlers.TryRemove(methodName, out _);
+        }
 
         /// <summary>
         /// Invokes a streaming hub method on the server using the specified method name, return type and arguments.

--- a/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.cs
@@ -179,7 +179,7 @@ namespace Microsoft.AspNetCore.SignalR.Client
         /// Removes all handlers associated with the method with the specified method name.
         /// </summary>
         /// <param name="methodName">The name of the hub method from which handlers are being removed</param>
-        public void RemoveHandler(string methodName)
+        public void Remove(string methodName)
         {
             CheckDisposed();
             Log.RemovingHandlers(_logger, methodName);

--- a/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.cs
@@ -176,7 +176,7 @@ namespace Microsoft.AspNetCore.SignalR.Client
             return new Subscription(invocationHandler, invocationList);
         }
         
-        public void Off(string methodName)
+        public void Remove(string methodName)
         {
             CheckDisposed();
             Log.RemovingHandlers(_logger, methodName);

--- a/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.cs
@@ -179,6 +179,7 @@ namespace Microsoft.AspNetCore.SignalR.Client
         public void Off(string methodName)
         {
             CheckDisposed();
+            Log.RemovingHandlers(_logger, methodName);
             _handlers.TryRemove(methodName, out _);
         }
 

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.Protocol.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.Protocol.cs
@@ -398,11 +398,10 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                     await connection.ReceiveJsonMessage(new { invocationId = "1", type = 1, target = "Foo", arguments = 1 }).OrTimeout();
                     var handlerTask = handlerCalled.Task;
 
-                    // Give the handler task 4 seconds to complete. It shouldn't because we've removed it. 
-                    var completedTask = await Task.WhenAny(Task.Delay(4000), handlerTask).OrTimeout();
+                    // We expect the handler task to timeout since the handler has been removed with the call to Off("Foo")
+                    var ex = Assert.ThrowsAsync<TimeoutException>(async () => await handlerTask.OrTimeout(2000));
 
                     // Ensure that the task from the WhenAny is not the handler task
-                    Assert.NotEqual(completedTask, handlerTask);
                     Assert.False(handlerCalled.Task.IsCompleted);
                 }
                 finally

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.Protocol.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.Protocol.cs
@@ -394,7 +394,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                         handlerCalled.TrySetResult(val);
                     });
 
-                    hubConnection.RemoveHandler("Foo");
+                    hubConnection.Remove("Foo");
                     await connection.ReceiveJsonMessage(new { invocationId = "1", type = 1, target = "Foo", arguments = 1 }).OrTimeout();
                     var handlerTask = handlerCalled.Task;
 
@@ -426,7 +426,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                         handlerCalled.TrySetResult(val);
                     });
 
-                    hubConnection.RemoveHandler("Foo");
+                    hubConnection.Remove("Foo");
                     await connection.ReceiveJsonMessage(new { invocationId = "1", type = 1, target = "Foo", arguments = 1 }).OrTimeout();
                     var handlerTask = handlerCalled.Task;
 

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.Protocol.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.Protocol.cs
@@ -394,9 +394,43 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                         handlerCalled.TrySetResult(val);
                     });
 
-                    hubConnection.Remove("Foo");
+                    hubConnection.RemoveHandler("Foo");
                     await connection.ReceiveJsonMessage(new { invocationId = "1", type = 1, target = "Foo", arguments = 1 }).OrTimeout();
                     var handlerTask = handlerCalled.Task;
+
+                    // We expect the handler task to timeout since the handler has been removed with the call to Remove("Foo")
+                    var ex = Assert.ThrowsAsync<TimeoutException>(async () => await handlerTask.OrTimeout(2000));
+
+                    // Ensure that the task from the WhenAny is not the handler task
+                    Assert.False(handlerCalled.Task.IsCompleted);
+                }
+                finally
+                {
+                    await hubConnection.DisposeAsync().OrTimeout();
+                    await connection.DisposeAsync().OrTimeout();
+                }
+            }
+
+            [Fact]
+            public async Task DisposingSubscriptionAfterCallingRemoveHandlerDoesntFail()
+            {
+                var connection = new TestConnection();
+                var hubConnection = CreateHubConnection(connection);
+                var handlerCalled = new TaskCompletionSource<int>();
+                try
+                {
+                    await hubConnection.StartAsync().OrTimeout();
+
+                    var subscription = hubConnection.On<int>("Foo", (val) =>
+                    {
+                        handlerCalled.TrySetResult(val);
+                    });
+
+                    hubConnection.RemoveHandler("Foo");
+                    await connection.ReceiveJsonMessage(new { invocationId = "1", type = 1, target = "Foo", arguments = 1 }).OrTimeout();
+                    var handlerTask = handlerCalled.Task;
+
+                    subscription.Dispose();
 
                     // We expect the handler task to timeout since the handler has been removed with the call to Remove("Foo")
                     var ex = Assert.ThrowsAsync<TimeoutException>(async () => await handlerTask.OrTimeout(2000));

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.Protocol.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.Protocol.cs
@@ -394,11 +394,11 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                         handlerCalled.TrySetResult(val);
                     });
 
-                    hubConnection.Off("Foo");
+                    hubConnection.Remove("Foo");
                     await connection.ReceiveJsonMessage(new { invocationId = "1", type = 1, target = "Foo", arguments = 1 }).OrTimeout();
                     var handlerTask = handlerCalled.Task;
 
-                    // We expect the handler task to timeout since the handler has been removed with the call to Off("Foo")
+                    // We expect the handler task to timeout since the handler has been removed with the call to Remove("Foo")
                     var ex = Assert.ThrowsAsync<TimeoutException>(async () => await handlerTask.OrTimeout(2000));
 
                     // Ensure that the task from the WhenAny is not the handler task

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.Protocol.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.Protocol.cs
@@ -412,7 +412,6 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                 }
             }
 
-
             [Fact]
             public async Task AcceptsPingMessages()
             {


### PR DESCRIPTION
Adding a method to HubConnection to  allow you to remove all handlers for a method. This means you don't have to keep a reference Subscriptions if you want to  remove handlers.
We have this in the TS client. 