### PR TITLE
Android HttpClientHandler.ClientCertificates fix

### DIFF
--- a/src/Microsoft.AspNetCore.Http.Connections.Client/HttpConnection.cs
+++ b/src/Microsoft.AspNetCore.Http.Connections.Client/HttpConnection.cs
@@ -486,10 +486,16 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
                 {
                     httpClientHandler.CookieContainer = _httpConnectionOptions.Cookies;
                 }
-                if (_httpConnectionOptions.ClientCertificates != null)
+
+                // Only access HttpClientHandler.ClientCertificates if the user has configured client certs
+                // Mono does not support client certs and will throw NotImplementedException
+                // https://github.com/aspnet/SignalR/issues/2232
+                var clientCertificates = _httpConnectionOptions.ClientCertificates;
+                if (clientCertificates != null && clientCertificates.Count > 0)
                 {
-                    httpClientHandler.ClientCertificates.AddRange(_httpConnectionOptions.ClientCertificates);
+                    httpClientHandler.ClientCertificates.AddRange(clientCertificates);
                 }
+
                 if (_httpConnectionOptions.UseDefaultCredentials != null)
                 {
                     httpClientHandler.UseDefaultCredentials = _httpConnectionOptions.UseDefaultCredentials.Value;

--- a/src/Microsoft.AspNetCore.Http.Connections.Client/HttpConnection.cs
+++ b/src/Microsoft.AspNetCore.Http.Connections.Client/HttpConnection.cs
@@ -491,7 +491,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
                 // Mono does not support client certs and will throw NotImplementedException
                 // https://github.com/aspnet/SignalR/issues/2232
                 var clientCertificates = _httpConnectionOptions.ClientCertificates;
-                if (clientCertificates != null && clientCertificates.Count > 0)
+                if (clientCertificates?.Count > 0)
                 {
                     httpClientHandler.ClientCertificates.AddRange(clientCertificates);
                 }


### PR DESCRIPTION
Check if client cert is configured before accessing HttpClientHandler.ClientCertificates to fix Android

https://github.com/aspnet/SignalR/issues/2232

There is no way to unit test without running tests on Android.

Is this 2.1 worthy? I have two concerns:
1. A dev should verify that this fix works on Xamarin.
2. There might be other Xamarin bugs that show up after fixing this one.