### PR TITLE
Removes resource consuming Redis subscription process from a global lock

### DIFF
--- a/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/RedisHubLifetimeManagerSubscriptionsBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/RedisHubLifetimeManagerSubscriptionsBenchmark.cs
@@ -1,0 +1,77 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Microsoft.AspNetCore.SignalR.Internal;
+using Microsoft.AspNetCore.SignalR.Protocol;
+using Microsoft.AspNetCore.SignalR.Redis;
+using Microsoft.AspNetCore.SignalR.Tests;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using StackExchange.Redis;
+
+namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
+{
+    public class RedisHubLifetimeManagerSubscriptionsBenchmark
+    {
+        private RedisHubLifetimeManager<TestHub> _manager;
+        private HubConnectionContext[] _connections;
+
+        public int ClientCount { get; set; } = 30;
+
+        [Params(1, 20)]
+        public int UserCount { get; set; }
+
+        [Params(1, 15)]
+        public int GroupCount { get; set; }
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            var server = new TestRedisServer(1);
+            var logger = NullLogger<RedisHubLifetimeManager<TestHub>>.Instance;
+            var protocol = new JsonHubProtocol();
+            var options = Options.Create(new RedisOptions()
+            {
+                ConnectionFactory = _ => Task.FromResult<IConnectionMultiplexer>(new TestConnectionMultiplexer(server))
+            });
+            var resolver = new DefaultHubProtocolResolver(new[] { protocol }, NullLogger<DefaultHubProtocolResolver>.Instance);
+
+            _manager = new RedisHubLifetimeManager<TestHub>(logger, options, resolver);
+
+            // Create connections
+            _connections = new HubConnectionContext[ClientCount];
+            var tasks = new Task[ClientCount];
+            for (var i = 0; i < _connections.Length; i++)
+            {
+                _connections[i] = HubConnectionContextUtils.Create(new TestClient(protocol: protocol).Connection, protocol, $"User{i % UserCount}");
+            }
+        }
+
+        [Benchmark]
+        public async Task JoinLeave()
+        {
+            var tasks = new Task[ClientCount];
+            for (var i = 0; i < _connections.Length; i++)
+            {
+                tasks[i] = JoinLeave(i);
+            }
+            await Task.WhenAll(tasks);
+        }
+
+        private Task JoinLeave(int i)
+        {
+            return Task.Run(async () => {
+                await _manager.OnConnectedAsync(_connections[i]);
+                await _manager.AddToGroupAsync(_connections[i].ConnectionId, $"Group{i % GroupCount}");
+                await _manager.RemoveFromGroupAsync(_connections[i].ConnectionId, $"Group{i % GroupCount}");
+                await _manager.OnDisconnectedAsync(_connections[i]);
+            });
+        }
+
+        public class TestHub : Hub
+        {
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.SignalR.Redis/Internal/RedisSubscriptionManager.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Redis/Internal/RedisSubscriptionManager.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -10,53 +11,104 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Internal
 {
     internal class RedisSubscriptionManager
     {
-        private readonly ConcurrentDictionary<string, HubConnectionStore> _subscriptions = new ConcurrentDictionary<string, HubConnectionStore>(StringComparer.Ordinal);
-        private readonly SemaphoreSlim _lock = new SemaphoreSlim(1, 1);
+        private class SubscriptionData
+        {
+            public readonly SemaphoreSlim Lock = new SemaphoreSlim(1, 1);
+            public readonly HubConnectionStore Connections = new HubConnectionStore();
+        }
+
+        private readonly Dictionary<string, int> _subscriptionsConnectionCount = new Dictionary<string, int>(StringComparer.Ordinal);
+
+        private readonly ConcurrentDictionary<string, SubscriptionData> _subscriptions = new ConcurrentDictionary<string, SubscriptionData>(StringComparer.Ordinal);
+        private readonly SemaphoreSlim _counterLock = new SemaphoreSlim(1, 1);
 
         public async Task AddSubscriptionAsync(string id, HubConnectionContext connection, Func<string, HubConnectionStore, Task> subscribeMethod)
         {
-            await _lock.WaitAsync();
+            await IncrementSubsciprionConnections(id);
+
+            var subscription = _subscriptions.GetOrAdd(id, _ => new SubscriptionData());
+
+            await subscription.Lock.WaitAsync();
 
             try
             {
-                var subscription = _subscriptions.GetOrAdd(id, _ => new HubConnectionStore());
-
-                subscription.Add(connection);
+                subscription.Connections.Add(connection);
 
                 // Subscribe once
-                if (subscription.Count == 1)
+                if (subscription.Connections.Count == 1)
                 {
-                    await subscribeMethod(id, subscription);
+                    await subscribeMethod(id, subscription.Connections);
                 }
             }
             finally
             {
-                _lock.Release();
+                subscription.Lock.Release();
             }
         }
 
         public async Task RemoveSubscriptionAsync(string id, HubConnectionContext connection, Func<string, Task> unsubscribeMethod)
         {
-            await _lock.WaitAsync();
+            if (!_subscriptions.TryGetValue(id, out var subscription))
+            {
+                return;
+            }
+
+            await subscription.Lock.WaitAsync();
 
             try
             {
-                if (!_subscriptions.TryGetValue(id, out var subscription))
+                if (subscription.Connections.Count > 0)
                 {
-                    return;
-                }
+                    subscription.Connections.Remove(connection);
 
-                subscription.Remove(connection);
-
-                if (subscription.Count == 0)
-                {
-                    _subscriptions.TryRemove(id, out _);
-                    await unsubscribeMethod(id);
+                    if (subscription.Connections.Count == 0)
+                    {
+                        await unsubscribeMethod(id);
+                    }
                 }
             }
             finally
             {
-                _lock.Release();
+                subscription.Lock.Release();
+            }
+
+            await DecrementSubsciprionConnections(id);
+        }
+
+        private async Task IncrementSubsciprionConnections(string id)
+        {
+            await _counterLock.WaitAsync();
+            try
+            {
+                //the idea to register an intention to use subscription data as soon as possible in global lock
+                //so other connections won't remove it while we use subscription lock
+                _subscriptionsConnectionCount.TryGetValue(id, out var count);
+                _subscriptionsConnectionCount[id] = ++count;
+            }
+            finally
+            {
+                _counterLock.Release();
+            }
+        }
+
+        private async Task DecrementSubsciprionConnections(string id)
+        {
+            await _counterLock.WaitAsync();
+            try
+            {
+                if (_subscriptionsConnectionCount.TryGetValue(id, out var count))
+                {
+                    _subscriptionsConnectionCount[id] = --count;
+                }
+                if (count == 0) //no connection intents to use this subscription we are free to remove it
+                {
+                    _subscriptionsConnectionCount.Remove(id);
+                    _subscriptions.TryRemove(id, out _);
+                }
+            }
+            finally
+            {
+                _counterLock.Release();
             }
         }
     }


### PR DESCRIPTION
Removes resource consuming Redis subscription process from a global lock
- Adds a new structure to hold connection count to each subscription
- Makes global lock much shorter