### PR TITLE
[2.1.1] Fix JsonHubProtocol error message when too many arguments (#2312)

### DIFF
--- a/src/Microsoft.AspNetCore.SignalR.Protocols.Json/Protocol/JsonHubProtocol.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Protocols.Json/Protocol/JsonHubProtocol.cs
@@ -629,6 +629,10 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
                         // Set all known arguments
                         arguments[paramIndex] = PayloadSerializer.Deserialize(reader, paramTypes[paramIndex]);
                     }
+                    else
+                    {
+                        reader.Skip();
+                    }
 
                     argumentsCount++;
                     paramIndex++;

--- a/test/Microsoft.AspNetCore.SignalR.Common.Tests/Internal/Protocol/JsonHubProtocolTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Common.Tests/Internal/Protocol/JsonHubProtocolTests.cs
@@ -248,6 +248,8 @@ namespace Microsoft.AspNetCore.SignalR.Common.Tests.Internal.Protocol
         [InlineData("{'type':1,'invocationId':'42','arguments':[ 'abc', 'xyz'], 'target':'foo'}", "Error binding arguments. Make sure that the types of the provided values match the types of the hub method being invoked.")]
         [InlineData("{'type':4,'invocationId':'42','target':'foo','arguments':[]}", "Invocation provides 0 argument(s) but target expects 2.")]
         [InlineData("{'type':4,'invocationId':'42','target':'foo','arguments':[ 'abc', 'xyz']}", "Error binding arguments. Make sure that the types of the provided values match the types of the hub method being invoked.")]
+        [InlineData("{'type':1,'invocationId':'42','target':'foo','arguments':[1,'',{'1':1,'2':2}]}", "Invocation provides 3 argument(s) but target expects 2.")]
+        [InlineData("{'type':1,'arguments':[1,'',{'1':1,'2':2}]},'invocationId':'42','target':'foo'", "Invocation provides 3 argument(s) but target expects 2.")]
         public void ArgumentBindingErrors(string input, string expectedMessage)
         {
             input = Frame(input);


### PR DESCRIPTION
Port #2312 to `release/2.1`

⚠️⚠️⚠️ **DO NOT MERGE** ⚠️⚠️⚠️
`release/2.1` has not yet been opened for servicing fixes.
⚠️⚠️⚠️ **DO NOT MERGE** ⚠️⚠️⚠️