### PR TITLE
[2.1.1] Handle incoming HTTP requests being canceled gracefully (#2314)

### DIFF
--- a/src/Microsoft.AspNetCore.Http.Connections/Internal/HttpConnectionDispatcher.Log.cs
+++ b/src/Microsoft.AspNetCore.Http.Connections/Internal/HttpConnectionDispatcher.Log.cs
@@ -46,6 +46,9 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
             private static readonly Action<ILogger, Exception> _terminatingConnection =
                 LoggerMessage.Define(LogLevel.Trace, new EventId(12, "TerminatingConection"), "Terminating Long Polling connection due to a DELETE request.");
 
+            private static readonly Action<ILogger, string, Exception> _failedToReadHttpRequestBody =
+                LoggerMessage.Define<string>(LogLevel.Debug, new EventId(14, "FailedToReadHttpRequestBody"), "Connection {TransportConnectionId} failed to read the HTTP request body.");
+
             public static void ConnectionDisposed(ILogger logger, string connectionId)
             {
                 _connectionDisposed(logger, connectionId, null);
@@ -104,6 +107,11 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
             public static void TerminatingConection(ILogger logger)
             {
                 _terminatingConnection(logger, null);
+            }
+
+            public static void FailedToReadHttpRequestBody(ILogger logger, string connectionId, Exception ex)
+            {
+                _failedToReadHttpRequestBody(logger, connectionId, ex);
             }
         }
     }


### PR DESCRIPTION
Port #2314 to `release/2.1`

The diff is a little funky because the original PR (#2314) was based on (https://github.com/aspnet/SignalR/pull/2180) which had been merged prior to that. Both are candidates for 2.1.1 though, so the final merge will include both changes if both are approved.