### PR TITLE
Dygray/ping catcher

### DIFF
--- a/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.cs
@@ -884,7 +884,7 @@ namespace Microsoft.AspNetCore.SignalR.Client
 
         private async Task TimerLoop(TimerAwaitable timer)
         {
-            // tell the server you intend to ping
+            // tell the server we intend to ping
             await SendHubMessage(PingMessage.Instance);
 
             // initialize the timers

--- a/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.cs
@@ -885,7 +885,7 @@ namespace Microsoft.AspNetCore.SignalR.Client
         private async Task TimerLoop(TimerAwaitable timer)
         {
             // Tell the server we intend to ping
-            // Pld clients never ping, and shouldn't be timed out
+            // Old clients never ping, and shouldn't be timed out
             // So ping to tell the server that we should be timed out if we stop
             await SendHubMessage(PingMessage.Instance);
 

--- a/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.cs
@@ -884,7 +884,9 @@ namespace Microsoft.AspNetCore.SignalR.Client
 
         private async Task TimerLoop(TimerAwaitable timer)
         {
-            // tell the server we intend to ping
+            // Tell the server we intend to ping
+            // Pld clients never ping, and shouldn't be timed out
+            // So ping to tell the server that we should be timed out if we stop
             await SendHubMessage(PingMessage.Instance);
 
             // initialize the timers

--- a/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.cs
@@ -886,12 +886,11 @@ namespace Microsoft.AspNetCore.SignalR.Client
         {
             // tell the server you intend to ping
             await SendHubMessage(PingMessage.Instance);
-            //await SendCoreAsyncCore(PingMessage.Instance);
 
             // initialize the timers
-            ResetSendPing();
-            ResetTimeout();
             timer.Start();
+            ResetTimeout();
+            ResetSendPing();
 
             using (timer)
             {

--- a/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.cs
@@ -884,11 +884,15 @@ namespace Microsoft.AspNetCore.SignalR.Client
 
         private async Task TimerLoop(TimerAwaitable timer)
         {
+            // tell the server you intend to ping
+            await SendHubMessage(PingMessage.Instance);
+            //await SendCoreAsyncCore(PingMessage.Instance);
+
             // initialize the timers
-            timer.Start();
             ResetSendPing();
             ResetTimeout();
-            
+            timer.Start();
+
             using (timer)
             {
                 // await returns True until `timer.Stop()` is called in the `finally` block of `ReceiveLoop`

--- a/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionContext.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionContext.cs
@@ -34,7 +34,7 @@ namespace Microsoft.AspNetCore.SignalR
 
         private long _lastSendTimeStamp = DateTime.UtcNow.Ticks;
         private long _lastReceivedTimeStamp = DateTime.UtcNow.Ticks;
-        internal bool _receivedMessageThisInterval = false;
+        private bool _receivedMessageThisInterval = false;
         private ReadOnlyMemory<byte> _cachedPingMessage;
         private bool _clientTimeoutActive;
 
@@ -506,6 +506,11 @@ namespace Microsoft.AspNetCore.SignalR
                 // Communicate the fact that we're finished triggering abort callbacks
                 connection._abortCompletedTcs.TrySetResult(null);
             }
+        }
+
+        internal void ResetClientTimeout()
+        {
+            _receivedMessageThisInterval = true;
         }
 
         private static class Log

--- a/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionContext.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionContext.cs
@@ -121,7 +121,7 @@ namespace Microsoft.AspNetCore.SignalR
             }
 
             // Otherwise, release the lock acquired when entering WriteAsync
-            DoneWithSend();
+            _writeLock.Release();
 
             return default;
         }
@@ -151,7 +151,7 @@ namespace Microsoft.AspNetCore.SignalR
             }
 
             // Otherwise, release the lock acquired when entering WriteAsync
-            DoneWithSend();
+            _writeLock.Release();
 
             return default;
         }
@@ -204,7 +204,7 @@ namespace Microsoft.AspNetCore.SignalR
             finally
             {
                 // Release the lock acquired when entering WriteAsync
-                DoneWithSend();
+                _writeLock.Release();
             }
         }
 
@@ -223,7 +223,7 @@ namespace Microsoft.AspNetCore.SignalR
             }
             finally
             {
-                DoneWithSend();
+                _writeLock.Release();
             }
         }
 
@@ -242,7 +242,7 @@ namespace Microsoft.AspNetCore.SignalR
             }
             finally
             {
-                DoneWithSend();
+                _writeLock.Release();
             }
         }
 
@@ -272,7 +272,7 @@ namespace Microsoft.AspNetCore.SignalR
             }
             finally
             {
-                DoneWithSend();
+                _writeLock.Release();
             }
         }
 
@@ -296,7 +296,7 @@ namespace Microsoft.AspNetCore.SignalR
             }
             finally
             {
-                DoneWithSend();
+                _writeLock.Release();
             }
         }
 
@@ -456,6 +456,8 @@ namespace Microsoft.AspNetCore.SignalR
                 // adding a Ping message when the transport is full is unnecessary since the
                 // transport is still in the process of sending frames.
                 _ = TryWritePingAsync();
+
+                Interlocked.Exchange(ref _lastSendTimestamp, currentTime);
             }
         }
 
@@ -499,12 +501,6 @@ namespace Microsoft.AspNetCore.SignalR
                 // Communicate the fact that we're finished triggering abort callbacks
                 connection._abortCompletedTcs.TrySetResult(null);
             }
-        }
-
-        private void DoneWithSend()
-        {
-            _writeLock.Release();
-            Volatile.Write(ref _lastSendTimestamp, DateTime.UtcNow.Ticks);
         }
 
         private static class Log

--- a/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionContext.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionContext.cs
@@ -115,7 +115,7 @@ namespace Microsoft.AspNetCore.SignalR
             }
 
             // Otherwise, release the lock acquired when entering WriteAsync
-            _writeLock.Release();
+            DoneWithSend();
 
             return default;
         }
@@ -145,7 +145,7 @@ namespace Microsoft.AspNetCore.SignalR
             }
 
             // Otherwise, release the lock acquired when entering WriteAsync
-            _writeLock.Release();
+            DoneWithSend();
 
             return default;
         }
@@ -198,7 +198,7 @@ namespace Microsoft.AspNetCore.SignalR
             finally
             {
                 // Release the lock acquired when entering WriteAsync
-                _writeLock.Release();
+                DoneWithSend();
             }
         }
 
@@ -217,7 +217,7 @@ namespace Microsoft.AspNetCore.SignalR
             }
             finally
             {
-                _writeLock.Release();
+                DoneWithSend();
             }
         }
 
@@ -236,7 +236,7 @@ namespace Microsoft.AspNetCore.SignalR
             }
             finally
             {
-                _writeLock.Release();
+                DoneWithSend();
             }
         }
 
@@ -266,7 +266,7 @@ namespace Microsoft.AspNetCore.SignalR
             }
             finally
             {
-                _writeLock.Release();
+                DoneWithSend();
             }
         }
 
@@ -290,7 +290,7 @@ namespace Microsoft.AspNetCore.SignalR
             }
             finally
             {
-                _writeLock.Release();
+                DoneWithSend();
             }
         }
 
@@ -449,8 +449,6 @@ namespace Microsoft.AspNetCore.SignalR
                 // adding a Ping message when the transport is full is unnecessary since the
                 // transport is still in the process of sending frames.
                 _ = TryWritePingAsync();
-
-                Interlocked.Exchange(ref _lastSendTimestamp, currentTime);
             }
         }
 
@@ -494,6 +492,12 @@ namespace Microsoft.AspNetCore.SignalR
                 // Communicate the fact that we're finished triggering abort callbacks
                 connection._abortCompletedTcs.TrySetResult(null);
             }
+        }
+
+        private void DoneWithSend()
+        {
+            _writeLock.Release();
+            Interlocked.Exchange(ref _lastSendTimestamp, DateTime.UtcNow.Ticks);
         }
 
         private static class Log

--- a/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionContext.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionContext.cs
@@ -463,7 +463,7 @@ namespace Microsoft.AspNetCore.SignalR
 
         private void CheckClientTimeout()
         {
-            // if it's been too long since we've heard from the client, then close this
+            // If it's been too long since we've heard from the client, then close this
             if (DateTime.UtcNow.Ticks - Interlocked.Read(ref _lastReceivedTimestamp) > _clientTimeoutInterval.Ticks)
             {
                 Abort();

--- a/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionContext.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionContext.cs
@@ -35,6 +35,7 @@ namespace Microsoft.AspNetCore.SignalR
         private long _lastSendTimestamp = DateTime.UtcNow.Ticks;
         private long _lastReceivedTimestamp = DateTime.UtcNow.Ticks;
         private ReadOnlyMemory<byte> _cachedPingMessage;
+        private bool _clientTimeoutActive;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="HubConnectionContext"/> class.
@@ -387,9 +388,6 @@ namespace Microsoft.AspNetCore.SignalR
                                         Features.Get<IConnectionHeartbeatFeature>()?.OnHeartbeat(state => ((HubConnectionContext)state).KeepAliveTick(), this);
                                     }
 
-                                    // only assign this if the 
-                                    Features.Get<IConnectionHeartbeatFeature>()?.OnHeartbeat(state => ((HubConnectionContext)state).CheckClientTimeout(), this);
-
                                     Log.HandshakeComplete(_logger, Protocol.Name);
                                     await WriteHandshakeResponseAsync(HandshakeResponseMessage.Empty);
                                     return true;
@@ -451,6 +449,16 @@ namespace Microsoft.AspNetCore.SignalR
 
                 Interlocked.Exchange(ref _lastSendTimestamp, currentTime);
             }
+        }
+
+        public void StartPeriodicallyCheckingForClientTimeout()
+        {
+            if (_clientTimeoutActive)
+            {
+                return;
+            }
+            _clientTimeoutActive = true;
+            Features.Get<IConnectionHeartbeatFeature>()?.OnHeartbeat(state => ((HubConnectionContext)state).CheckClientTimeout(), this);
         }
 
         private void CheckClientTimeout()

--- a/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionContext.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionContext.cs
@@ -44,14 +44,17 @@ namespace Microsoft.AspNetCore.SignalR
         /// <param name="keepAliveInterval">How often this client is pinged.</param>
         /// <param name="loggerFactory">The logger factory.</param>
         /// <param name="clientTimeoutInterval">Clients we haven't heard from in this interval are assumed to have disconnected.</param>
-        public HubConnectionContext(ConnectionContext connectionContext, TimeSpan keepAliveInterval, ILoggerFactory loggerFactory, TimeSpan? clientTimeoutInterval = null)
+        public HubConnectionContext(ConnectionContext connectionContext, TimeSpan keepAliveInterval, ILoggerFactory loggerFactory, TimeSpan clientTimeoutInterval)
         {
             _connectionContext = connectionContext;
             _logger = loggerFactory.CreateLogger<HubConnectionContext>();
             ConnectionAborted = _connectionAbortedTokenSource.Token;
             _keepAliveInterval = keepAliveInterval.Ticks;
-            _clientTimeoutInterval = (clientTimeoutInterval ?? HubOptionsSetup.DefaultClientTimeoutInterval).Ticks;
+            _clientTimeoutInterval = clientTimeoutInterval.Ticks;
         }
+
+        public HubConnectionContext(ConnectionContext connectionContext, TimeSpan keepAliveInterval, ILoggerFactory loggerFactory)
+            : this(connectionContext, keepAliveInterval, loggerFactory, HubOptionsSetup.DefaultClientTimeoutInterval) { }
 
         /// <summary>
         /// Gets a <see cref="CancellationToken"/> that notifies when the connection is aborted.

--- a/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionContext.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionContext.cs
@@ -501,7 +501,7 @@ namespace Microsoft.AspNetCore.SignalR
             }
         }
 
-        private void SendCompleted()
+        private void DoneWithSend()
         {
             _writeLock.Release();
             Volatile.Write(ref _lastSendTimestamp, DateTime.UtcNow.Ticks);

--- a/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionContext.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionContext.cs
@@ -387,6 +387,7 @@ namespace Microsoft.AspNetCore.SignalR
                                         Features.Get<IConnectionHeartbeatFeature>()?.OnHeartbeat(state => ((HubConnectionContext)state).KeepAliveTick(), this);
                                     }
 
+                                    // only assign this if the 
                                     Features.Get<IConnectionHeartbeatFeature>()?.OnHeartbeat(state => ((HubConnectionContext)state).CheckClientTimeout(), this);
 
                                     Log.HandshakeComplete(_logger, Protocol.Name);
@@ -454,10 +455,8 @@ namespace Microsoft.AspNetCore.SignalR
 
         private void CheckClientTimeout()
         {
-            var currentTime = DateTime.UtcNow.Ticks;
-
             // if it's been too long since we've heard from the client, then close this
-            if (currentTime - Interlocked.Read(ref _lastReceivedTimestamp) > _clientTimeoutInterval.Ticks)
+            if (DateTime.UtcNow.Ticks - Interlocked.Read(ref _lastReceivedTimestamp) > _clientTimeoutInterval.Ticks)
             {
                 Abort();
             }

--- a/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionHandler.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionHandler.cs
@@ -69,7 +69,7 @@ namespace Microsoft.AspNetCore.SignalR
             // We check to see if HubOptions<THub> are set because those take precedence over global hub options.
             // Then set the keepAlive and handshakeTimeout values to the defaults in HubOptionsSetup incase they were explicitly set to null.
             var keepAlive = _hubOptions.KeepAliveInterval ?? _globalHubOptions.KeepAliveInterval ?? HubOptionsSetup.DefaultKeepAliveInterval;
-            var clientTimeout = _hubOptions.ClientTimeoutInterval ?? _globalHubOptions.ClientTimeoutInterval; 
+            var clientTimeout = _hubOptions.ClientTimeoutInterval ?? _globalHubOptions.ClientTimeoutInterval ?? HubOptionsSetup.DefaultClientTimeoutInterval; 
             var handshakeTimeout = _hubOptions.HandshakeTimeout ?? _globalHubOptions.HandshakeTimeout ?? HubOptionsSetup.DefaultHandshakeTimeout;
             var supportedProtocols = _hubOptions.SupportedProtocols ?? _globalHubOptions.SupportedProtocols;
 

--- a/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionHandler.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionHandler.cs
@@ -200,7 +200,7 @@ namespace Microsoft.AspNetCore.SignalR
 
                     if (!buffer.IsEmpty)
                     {
-                        connection.ResetClientTimeout();
+                        connection._receivedMessageThisInterval = true;
 
                         while (protocol.TryParseMessage(ref buffer, _dispatcher, out var message))
                         {

--- a/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionHandler.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionHandler.cs
@@ -88,6 +88,8 @@ namespace Microsoft.AspNetCore.SignalR
                 return;
             }
 
+            // -- the connectionContext has been set up --
+
             try
             {
                 await _lifetimeManager.OnConnectedAsync(connectionContext);

--- a/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionHandler.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionHandler.cs
@@ -200,7 +200,7 @@ namespace Microsoft.AspNetCore.SignalR
 
                     if (!buffer.IsEmpty)
                     {
-                        connection._receivedMessageThisInterval = true;
+                        connection.ResetClientTimeout();
 
                         while (protocol.TryParseMessage(ref buffer, _dispatcher, out var message))
                         {

--- a/src/Microsoft.AspNetCore.SignalR.Core/HubOptions.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/HubOptions.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNetCore.SignalR
         public TimeSpan? KeepAliveInterval { get; set; } = null;
 
         /// <summary>
-        /// Gets or sets the time window clients have to send a message before we close the connection
+        /// Gets or sets the time window clients have to send a message before the server closes the connection.
         /// </summary>
         public TimeSpan? ClientTimeoutInterval { get; set; } = null;
 

--- a/src/Microsoft.AspNetCore.SignalR.Core/HubOptions.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/HubOptions.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNetCore.SignalR
         public TimeSpan? KeepAliveInterval { get; set; } = null;
 
         /// <summary>
-        /// Gets or sets the interval used by the server to 
+        /// Gets or sets the time window clients have to send a message before we close the connection
         /// </summary>
         public TimeSpan? ClientTimeoutInterval { get; set; } = null;
 

--- a/src/Microsoft.AspNetCore.SignalR.Core/HubOptions.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/HubOptions.cs
@@ -27,6 +27,11 @@ namespace Microsoft.AspNetCore.SignalR
         public TimeSpan? KeepAliveInterval { get; set; } = null;
 
         /// <summary>
+        /// Gets or sets the interval used by the server to 
+        /// </summary>
+        public TimeSpan? ClientTimeoutInterval { get; set; } = null;
+
+        /// <summary>
         /// Gets or sets a collection of supported hub protocol names.
         /// </summary>
         public IList<string> SupportedProtocols { get; set; } = null;

--- a/src/Microsoft.AspNetCore.SignalR.Core/HubOptions`T.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/HubOptions`T.cs
@@ -7,5 +7,7 @@ namespace Microsoft.AspNetCore.SignalR
     /// Options used to configure the specified hub type instances. These options override globally set options.
     /// </summary>
     /// <typeparam name="THub">The hub type to configure.</typeparam>
-    public class HubOptions<THub> : HubOptions where THub : Hub { }
+    public class HubOptions<THub> : HubOptions where THub : Hub
+    {
+    }
 }

--- a/src/Microsoft.AspNetCore.SignalR.Core/Internal/DefaultHubDispatcher.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/Internal/DefaultHubDispatcher.cs
@@ -107,7 +107,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal
                     break;
 
                 case PingMessage _:
-                    // We don't care about pings
+                    connection.StartPeriodicallyCheckingForClientTimeout();
                     break;
 
                 // Other kind of message we weren't expecting

--- a/src/Microsoft.AspNetCore.SignalR.Core/Internal/DefaultHubDispatcher.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/Internal/DefaultHubDispatcher.cs
@@ -107,7 +107,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal
                     break;
 
                 case PingMessage _:
-                    connection.StartPeriodicallyCheckingForClientTimeout();
+                    // We don't care about pings
                     break;
 
                 // Other kind of message we weren't expecting

--- a/src/Microsoft.AspNetCore.SignalR.Core/Internal/DefaultHubDispatcher.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/Internal/DefaultHubDispatcher.cs
@@ -107,7 +107,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal
                     break;
 
                 case PingMessage _:
-                    connection.StartPeriodicallyCheckingForClientTimeout();
+                    connection.StartClientTimeout();
                     break;
 
                 // Other kind of message we weren't expecting

--- a/src/Microsoft.AspNetCore.SignalR.Core/Internal/HubOptionsSetup.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/Internal/HubOptionsSetup.cs
@@ -14,6 +14,8 @@ namespace Microsoft.AspNetCore.SignalR.Internal
 
         internal static TimeSpan DefaultKeepAliveInterval => TimeSpan.FromSeconds(15);
 
+        public static TimeSpan DefaultClientTimeoutInterval => TimeSpan.FromSeconds(15);
+
         private readonly List<string> _protocols = new List<string>();
 
         public HubOptionsSetup(IEnumerable<IHubProtocol> protocols)

--- a/src/Microsoft.AspNetCore.SignalR.Core/Internal/HubOptionsSetup.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/Internal/HubOptionsSetup.cs
@@ -14,28 +14,23 @@ namespace Microsoft.AspNetCore.SignalR.Internal
 
         internal static TimeSpan DefaultKeepAliveInterval => TimeSpan.FromSeconds(15);
 
-        public static TimeSpan DefaultClientTimeoutInterval => TimeSpan.FromSeconds(15);
+        public static TimeSpan DefaultClientTimeoutInterval => TimeSpan.FromSeconds(30);
 
-        private readonly List<string> _protocols = new List<string>();
+        private readonly List<string> _defaultProtocols = new List<string>();
 
         public HubOptionsSetup(IEnumerable<IHubProtocol> protocols)
         {
             foreach (var hubProtocol in protocols)
             {
-                _protocols.Add(hubProtocol.Name);
+                _defaultProtocols.Add(hubProtocol.Name);
             }
         }
 
         public void Configure(HubOptions options)
         {
-            if (options.SupportedProtocols == null)
-            {
-                options.SupportedProtocols = new List<string>();
-            }
-
             if (options.KeepAliveInterval == null)
             {
-                // The default keep - alive interval.This is set to exactly half of the default client timeout window,
+                // The default keep - alive interval. This is set to exactly half of the default client timeout window,
                 // to ensure a ping can arrive in time to satisfy the client timeout.
                 options.KeepAliveInterval = DefaultKeepAliveInterval;
             }
@@ -45,7 +40,12 @@ namespace Microsoft.AspNetCore.SignalR.Internal
                 options.HandshakeTimeout = DefaultHandshakeTimeout;
             }
 
-            foreach (var protocol in _protocols)
+            if (options.SupportedProtocols == null)
+            {
+                options.SupportedProtocols = new List<string>();
+            }
+
+            foreach (var protocol in _defaultProtocols)
             {
                 options.SupportedProtocols.Add(protocol);
             }

--- a/src/Microsoft.AspNetCore.SignalR.Core/Internal/HubOptionsSetup.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/Internal/HubOptionsSetup.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal
 
         internal static TimeSpan DefaultKeepAliveInterval => TimeSpan.FromSeconds(15);
 
-        public static TimeSpan DefaultClientTimeoutInterval => TimeSpan.FromSeconds(30);
+        internal static TimeSpan DefaultClientTimeoutInterval => TimeSpan.FromSeconds(30);
 
         private readonly List<string> _defaultProtocols = new List<string>();
 

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.Protocol.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.Protocol.cs
@@ -580,10 +580,10 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                 {
                     await hubConnection.StartAsync().OrTimeout();
 
-                    var firstPing = await connection.ReadSentTextMessageAsync().OrTimeout();
+                    var firstPing = await connection.ReadSentTextMessageAsync(ignorePings: false).OrTimeout();
                     Assert.Equal("{\"type\":6}", firstPing);
 
-                    var secondPing = await connection.ReadSentTextMessageAsync().OrTimeout();
+                    var secondPing = await connection.ReadSentTextMessageAsync(ignorePings: false).OrTimeout();
                     Assert.Equal("{\"type\":6}", secondPing);
                 }
                 finally

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/TestConnection.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/TestConnection.cs
@@ -126,7 +126,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
             {
                 var result = await ReadSentTextMessageAsyncInner();
 
-                var receivedMessageType = (int)JObject.Parse(result).Property("type").Value;
+                var receivedMessageType = (int?)JObject.Parse(result)["type"];
                 if (ignorePings && receivedMessageType == HubProtocolConstants.PingMessageType)
                 {
                     continue;

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/TestConnection.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/TestConnection.cs
@@ -14,6 +14,7 @@ using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Internal;
 using Microsoft.AspNetCore.SignalR.Protocol;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.AspNetCore.SignalR.Client.Tests
 {
@@ -124,7 +125,9 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
             while (true)
             {
                 var result = await ReadSentTextMessageAsyncInner();
-                if (ignorePings && result == "{\"type\":6}")
+
+                var receivedMessageType = (int)JObject.Parse(result).Property("type").Value;
+                if (ignorePings && receivedMessageType == HubProtocolConstants.PingMessageType)
                 {
                     continue;
                 }

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/TestConnection.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/TestConnection.cs
@@ -116,9 +116,23 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
         {
             return Application.Output.WriteAsync(bytes).AsTask();
         }
-        public async Task<string> ReadSentTextMessageAsync()
+        public async Task<string> ReadSentTextMessageAsync(bool ignorePings=true)
         {
             // Read a single text message from the Application Input pipe
+
+            while (true)
+            {
+                var result = await ReadSentTextMessageAsyncInner();
+                if (ignorePings && result == "{\"type\":6}")
+                {
+                    continue;
+                }
+                return result;
+            }
+        }
+        
+        private async Task<string> ReadSentTextMessageAsyncInner()
+        {
             while (true)
             {
                 var result = await Application.Input.ReadAsync();
@@ -144,7 +158,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
             }
         }
 
-        public async Task<IList<string>> ReadAllSentMessagesAsync()
+        public async Task<IList<string>> ReadAllSentMessagesAsync(bool ignorePings=true)
         {
             if (!Disposed.IsCompleted)
             {
@@ -155,7 +169,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
 
             while (true)
             {
-                var message = await ReadSentTextMessageAsync();
+                var message = await ReadSentTextMessageAsync(ignorePings);
                 if (message == null)
                 {
                     break;

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/TestConnection.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/TestConnection.cs
@@ -116,7 +116,8 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
         {
             return Application.Output.WriteAsync(bytes).AsTask();
         }
-        public async Task<string> ReadSentTextMessageAsync(bool ignorePings=true)
+
+        public async Task<string> ReadSentTextMessageAsync(bool ignorePings = true)
         {
             // Read a single text message from the Application Input pipe
 

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/TestConnection.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/TestConnection.cs
@@ -56,7 +56,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
             Application.Input.OnWriterCompleted((ex, _) =>
             {
                 Application.Output.Complete();
-            }, 
+            },
             null);
         }
 
@@ -127,6 +127,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                 var result = await ReadSentTextMessageAsyncInner();
 
                 var receivedMessageType = (int?)JObject.Parse(result)["type"];
+
                 if (ignorePings && receivedMessageType == HubProtocolConstants.PingMessageType)
                 {
                     continue;
@@ -134,7 +135,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                 return result;
             }
         }
-        
+
         private async Task<string> ReadSentTextMessageAsyncInner()
         {
             while (true)
@@ -162,7 +163,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
             }
         }
 
-        public async Task<IList<string>> ReadAllSentMessagesAsync(bool ignorePings=true)
+        public async Task<IList<string>> ReadAllSentMessagesAsync(bool ignorePings = true)
         {
             if (!Disposed.IsCompleted)
             {

--- a/test/Microsoft.AspNetCore.SignalR.Tests.Utils/HubConnectionContextUtils.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests.Utils/HubConnectionContextUtils.cs
@@ -22,7 +22,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
 
         public static Mock<HubConnectionContext> CreateMock(ConnectionContext connection)
         {
-            var mock = new Mock<HubConnectionContext>(connection, TimeSpan.FromSeconds(15), NullLoggerFactory.Instance) { CallBase = true };
+            var mock = new Mock<HubConnectionContext>(connection, TimeSpan.FromSeconds(15), NullLoggerFactory.Instance, TimeSpan.FromSeconds(15)) { CallBase = true };
             var protocol = new JsonHubProtocol();
             mock.SetupGet(m => m.Protocol).Returns(protocol);
             return mock;

--- a/test/Microsoft.AspNetCore.SignalR.Tests/HubConnectionHandlerTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/HubConnectionHandlerTests.cs
@@ -2038,7 +2038,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                 client.TickHeartbeat();
 
                 // but client should still be open, since it never pinged to activate the timeout checking
-                await Assert.ThrowsAsync<TimeoutException>(() => connectionHandlerTask.OrTimeout(60));
+                Assert.False(connectionHandlerTask.IsCompleted);
             }
         }
 
@@ -2059,7 +2059,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                 await Task.Delay(120);
                 client.TickHeartbeat();
 
-                await connectionHandlerTask.OrTimeout(60);
+                await connectionHandlerTask.OrTimeout();
             }
         }
 
@@ -2084,7 +2084,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                     await client.SendHubMessageAsync(PingMessage.Instance);
                 }
 
-                await Assert.ThrowsAsync<TimeoutException>(() => connectionHandlerTask.OrTimeout(50));
+                Assert.False(connectionHandlerTask.IsCompleted);
             }
         }
 

--- a/test/Microsoft.AspNetCore.SignalR.Tests/HubConnectionHandlerTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/HubConnectionHandlerTests.cs
@@ -2071,7 +2071,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
         {
             var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider(services =>
                 services.Configure<HubOptions>(options =>
-                     options.ClientTimeoutInterval = TimeSpan.FromMilliseconds(100)));
+                     options.ClientTimeoutInterval = TimeSpan.FromMilliseconds(300)));
             var connectionHandler = serviceProvider.GetService<HubConnectionHandler<MethodHub>>();
 
             using (var client = new TestClient(new JsonHubProtocol()))
@@ -2080,9 +2080,9 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                 await client.Connected.OrTimeout();
                 await client.SendHubMessageAsync(PingMessage.Instance);
 
-                for (int i = 0; i < 5; i++)
+                for (int i = 0; i < 10; i++)
                 {
-                    await Task.Delay(20);
+                    await Task.Delay(100);
                     client.TickHeartbeat();
                     await client.SendHubMessageAsync(PingMessage.Instance);
                 }

--- a/test/Microsoft.AspNetCore.SignalR.Tests/HubConnectionHandlerTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/HubConnectionHandlerTests.cs
@@ -2056,7 +2056,10 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                 await client.Connected.OrTimeout();
                 await client.SendHubMessageAsync(PingMessage.Instance);
 
-                await Task.Delay(120);
+                await Task.Delay(300);
+                client.TickHeartbeat();
+
+                await Task.Delay(300);
                 client.TickHeartbeat();
 
                 await connectionHandlerTask.OrTimeout();

--- a/test/Microsoft.AspNetCore.SignalR.Tests/HubConnectionHandlerTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/HubConnectionHandlerTests.cs
@@ -2033,9 +2033,11 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                 await client.Connected.OrTimeout();
                 // This is a fake client -- it doesn't auto-ping to signal
 
+                // We go over the 100 ms timeout interval...
                 await Task.Delay(120);
                 client.TickHeartbeat();
 
+                // but client should still be open, since it never pinged to activate the timeout checking
                 await Assert.ThrowsAsync<TimeoutException>(() => connectionHandlerTask.OrTimeout(60));
             }
         }

--- a/test/Microsoft.AspNetCore.SignalR.Tests/HubConnectionHandlerTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/HubConnectionHandlerTests.cs
@@ -2020,7 +2020,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
         }
 
         [Fact]
-        public async Task ConnectionNotTimedOutIfItNeverPings()
+        public async Task ConnectionNotTimedOutIfClientNeverPings()
         {
             var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider(services =>
                 services.Configure<HubOptions>(options =>
@@ -2031,6 +2031,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             {
                 var connectionHandlerTask = await client.ConnectAsync(connectionHandler);
                 await client.Connected.OrTimeout();
+                // This is a fake client -- it doesn't auto-ping to signal
 
                 await Task.Delay(120);
                 client.TickHeartbeat();


### PR DESCRIPTION
Fixes #2289

Server catches pings from clients. Silent clients are timed out and disconnected.

Clients auto-ping on startup to signal that it's a pinging client. This first ping is caught in ```DefaultHubDispatcher```, which registers a timeout method to the ```HubConnectionContext``` heartbeat. 

The timeout window is reset whenever a message is received (per connection, under ```DispatchMessagesAsync``` in ```HubConnectionHandler```).

On timeout the connection is closed.

