### PR TITLE
Log 404 responses from long polling transport DELETE as Debug instead of Error

### DIFF
--- a/src/Microsoft.AspNetCore.Http.Connections.Client/Internal/LongPollingTransport.Log.cs
+++ b/src/Microsoft.AspNetCore.Http.Connections.Client/Internal/LongPollingTransport.Log.cs
@@ -53,6 +53,9 @@ namespace Microsoft.AspNetCore.Http.Connections.Client.Internal
             private static readonly Action<ILogger, Uri, Exception> _errorSendingDeleteRequest =
                 LoggerMessage.Define<Uri>(LogLevel.Error, new EventId(13, "ErrorSendingDeleteRequest"), "Error sending DELETE request to '{PollUrl}'.");
 
+            private static readonly Action<ILogger, Uri, Exception> _connectionAlreadyClosedSendingDeleteRequest =
+                LoggerMessage.Define<Uri>(LogLevel.Debug, new EventId(14, "ConnectionAlreadyClosedSendingDeleteRequest"), "A 404 response was returned from sending DELETE request to '{PollUrl}', likely because the transport was already closed on the server.");
+
             // EventIds 100 - 106 used in SendUtils
 
             public static void StartTransport(ILogger logger, TransferFormat transferFormat)
@@ -122,6 +125,11 @@ namespace Microsoft.AspNetCore.Http.Connections.Client.Internal
             public static void ErrorSendingDeleteRequest(ILogger logger, Uri pollUrl, Exception ex)
             {
                 _errorSendingDeleteRequest(logger, pollUrl, ex);
+            }
+
+            public static void ConnectionAlreadyClosedSendingDeleteRequest(ILogger logger, Uri pollUrl)
+            {
+                _connectionAlreadyClosedSendingDeleteRequest(logger, pollUrl, null);
             }
         }
     }

--- a/src/Microsoft.AspNetCore.Http.Connections.Client/Internal/LongPollingTransport.cs
+++ b/src/Microsoft.AspNetCore.Http.Connections.Client/Internal/LongPollingTransport.cs
@@ -221,8 +221,17 @@ namespace Microsoft.AspNetCore.Http.Connections.Client.Internal
             {
                 Log.SendingDeleteRequest(_logger, url);
                 var response = await _httpClient.DeleteAsync(url);
-                response.EnsureSuccessStatusCode();
-                Log.DeleteRequestAccepted(_logger, url);
+
+                if (response.StatusCode == HttpStatusCode.NotFound)
+                {
+                    Log.ConnectionAlreadyClosedSendingDeleteRequest(_logger, url);
+                }
+                else
+                {
+                    // Check for non-404 errors
+                    response.EnsureSuccessStatusCode();
+                    Log.DeleteRequestAccepted(_logger, url);
+                }
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Fixes https://github.com/aspnet/SignalR/issues/2362