### PR TITLE
ping timeout changes

### DIFF
--- a/specs/HubProtocol.md
+++ b/specs/HubProtocol.md
@@ -131,7 +131,17 @@ Keep alive behavior is achieved via the `Ping` message type. **Either endpoint**
 
 Ping messages do not have any payload, they are completely empty messages (aside from the encoding necessary to identify the message as a `Ping` message).
 
-It is up to the server implementation to decide how frequently (if at all) `Ping` frames are sent. The ASP.NET Core implementation sends `Ping` frames only when using the Server Sent Events and WebSockets transports, at a default interval of 15 seconds (configurable). However, a `Ping` frame is only sent if 15 seconds elapses since the last message was sent. Clients may choose to use the "Ping rate" to provide a timeout for the server connection. Since the Client can expect the server to send `Ping` frames at regular intervals, even when the connection is idle, it can use that to determine if the server has left without closing the connection. The ASP.NET Core implementation (both JavaScript and C#) use a default timeout window of 30 seconds, which is twice the server ping rate interval.
+The default ASP.NET implementation automatically pings both directions on active connections. These pings are at regular intervals, and allow detection of unpexpected disconnects (for example, unplugging a server). If the client detects that the server has stopped pinging, the client will close the connection, and vice versa.
+
+| .. | option name | default value |
+|-|-|-|
+|**Server**: how often to ping client | ```_hubOptions.KeepAliveInterval``` | 15 seconds |
+|**Server**: if the client hasn't messaged in this interval, close the connection | ```_hubOptions.ClientTimeout``` | 30 seconds |
+|**Client**: how often to ping server | ```HubConnection.PingInterval``` | 15 seconds |
+|**Client**: if the server hasn't messsaged in this interval, close the connection | ```HubConnection.ServerTimeout``` | 30 seconds |
+
+If there's other traffic through the connection, keep-alive pings aren't needed. A `Ping` is only sent if the interval has elapsed without a message being sent.
+
 
 ## Example
 

--- a/specs/HubProtocol.md
+++ b/specs/HubProtocol.md
@@ -133,10 +133,10 @@ Ping messages do not have any payload, they are completely empty messages (aside
 
 The default ASP.NET implementation automatically pings both directions on active connections. These pings are at regular intervals, and allow detection of unpexpected disconnects (for example, unplugging a server). If the client detects that the server has stopped pinging, the client will close the connection, and vice versa.
 
-| .. | option name | default value |
+|  | Option name | Default value |
 |-|-|-|
-|**Server**: how often to ping client | ```_hubOptions.KeepAliveInterval``` | 15 seconds |
-|**Server**: if the client hasn't messaged in this interval, close the connection | ```_hubOptions.ClientTimeout``` | 30 seconds |
+|**Server**: how often to ping client | ```HubOptions.KeepAliveInterval``` | 15 seconds |
+|**Server**: if the client hasn't messaged in this interval, close the connection | ```HubOptions.ClientTimeout``` | 30 seconds |
 |**Client**: how often to ping server | ```HubConnection.PingInterval``` | 15 seconds |
 |**Client**: if the server hasn't messsaged in this interval, close the connection | ```HubConnection.ServerTimeout``` | 30 seconds |
 

--- a/specs/HubProtocol.md
+++ b/specs/HubProtocol.md
@@ -131,13 +131,13 @@ Keep alive behavior is achieved via the `Ping` message type. **Either endpoint**
 
 Ping messages do not have any payload, they are completely empty messages (aside from the encoding necessary to identify the message as a `Ping` message).
 
-The default ASP.NET implementation automatically pings both directions on active connections. These pings are at regular intervals, and allow detection of unpexpected disconnects (for example, unplugging a server). If the client detects that the server has stopped pinging, the client will close the connection, and vice versa.
+The default ASP.NET Core implementation automatically pings both directions on active connections. These pings are at regular intervals, and allow detection of unexpected disconnects (for example, unplugging a server). If the client detects that the server has stopped pinging, the client will close the connection, and vice versa.
 
 |  | Option name | Default value |
 |-|-|-|
 |**Server**: how often to ping client | ```HubOptions.KeepAliveInterval``` | 15 seconds |
 |**Server**: if the client hasn't messaged in this interval, close the connection | ```HubOptions.ClientTimeout``` | 30 seconds |
-|**Client**: how often to ping server | ```HubConnection.PingInterval``` | 15 seconds |
+|**Client**: how often to ping server | ```HubConnection.KeepAliveInterval``` | 15 seconds |
 |**Client**: if the server hasn't messsaged in this interval, close the connection | ```HubConnection.ServerTimeout``` | 30 seconds |
 
 If there's other traffic through the connection, keep-alive pings aren't needed. A `Ping` is only sent if the interval has elapsed without a message being sent.

--- a/specs/HubProtocol.md
+++ b/specs/HubProtocol.md
@@ -131,17 +131,7 @@ Keep alive behavior is achieved via the `Ping` message type. **Either endpoint**
 
 Ping messages do not have any payload, they are completely empty messages (aside from the encoding necessary to identify the message as a `Ping` message).
 
-The default ASP.NET Core implementation automatically pings both directions on active connections. These pings are at regular intervals, and allow detection of unexpected disconnects (for example, unplugging a server). If the client detects that the server has stopped pinging, the client will close the connection, and vice versa.
-
-|  | Option name | Default value |
-|-|-|-|
-|**Server**: how often to ping client | ```HubOptions.KeepAliveInterval``` | 15 seconds |
-|**Server**: if the client hasn't messaged in this interval, close the connection | ```HubOptions.ClientTimeout``` | 30 seconds |
-|**Client**: how often to ping server | ```HubConnection.KeepAliveInterval``` | 15 seconds |
-|**Client**: if the server hasn't messsaged in this interval, close the connection | ```HubConnection.ServerTimeout``` | 30 seconds |
-
-If there's other traffic through the connection, keep-alive pings aren't needed. A `Ping` is only sent if the interval has elapsed without a message being sent.
-
+The default ASP.NET Core implementation automatically pings both directions on active connections. These pings are at regular intervals, and allow detection of unexpected disconnects (for example, unplugging a server). If the client detects that the server has stopped pinging, the client will close the connection, and vice versa. If there's other traffic through the connection, keep-alive pings aren't needed. A `Ping` is only sent if the interval has elapsed without a message being sent.
 
 ## Example
 


### PR DESCRIPTION
Fixes #2382 

Renamed client "PingInterval" to "KeepAliveInterval" for consistency with server.

Updated Protocol documentation to reflect changes.

