### PR TITLE
Add test coverage to TS Client tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ ipch/
 *.aps
 *.opendb
 *.db
+coverage/

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -24,6 +24,7 @@
     "uglify-js": "^3.3.5"
   },
   "jest": {
+    "collectCoverage": true,
     "globals": {
       "ts-jest": {
         "tsConfigFile": "./tsconfig.jest.json",

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "build": "cd ./signalr && npm run build && cd ../signalr-protocol-msgpack && npm run build",
-    "test": "jest"
+    "test": "jest",
+    "coverage": "jest --coverage"
   },
   "author": "Microsoft",
   "license": "Apache-2.0",
@@ -24,7 +25,6 @@
     "uglify-js": "^3.3.5"
   },
   "jest": {
-    "collectCoverage": true,
     "globals": {
       "ts-jest": {
         "tsConfigFile": "./tsconfig.jest.json",


### PR DESCRIPTION
Tests now take ~30 seconds from ~8 seconds. We might consider adding a flag to enable this?

Sample of what it looks like:
![codecov](https://user-images.githubusercontent.com/7574801/40751792-98190660-6421-11e8-86c2-3b957c5a0428.JPG)
