### PR TITLE
[2.1.1] Add Content-Type header in HttpClient.ts (#2242)

### DIFF
--- a/clients/ts/FunctionalTests/TestHub.cs
+++ b/clients/ts/FunctionalTests/TestHub.cs
@@ -83,5 +83,10 @@ namespace FunctionalTests
                 String = "hello world",
             };
         }
+
+        public string GetContentTypeHeader()
+        {
+            return Context.GetHttpContext().Request.Headers["Content-Type"];
+        }
     }
 }

--- a/clients/ts/FunctionalTests/ts/HubConnectionTests.ts
+++ b/clients/ts/FunctionalTests/ts/HubConnectionTests.ts
@@ -686,6 +686,24 @@ describe("hubConnection", () => {
         }
     });
 
+    it("populates the Content-Type header when sending XMLHttpRequest", async (done) => {
+        const hubConnection = getConnectionBuilder(HttpTransportType.LongPolling, TESTHUB_NOWEBSOCKETS_ENDPOINT_URL)
+            .withHubProtocol(new JsonHubProtocol())
+            .build();
+
+        try {
+            await hubConnection.start();
+
+            // Check what transport was used by asking the server to tell us.
+            expect(await hubConnection.invoke("GetActiveTransportName")).toEqual("LongPolling");
+            // Check to see that the Content-Type header is set the expected value
+            expect(await hubConnection.invoke("GetContentTypeHeader")).toEqual("text/plain;charset=UTF-8");
+            done();
+        } catch (e) {
+            fail(e);
+        }
+    });
+
     function getJwtToken(url: string): Promise<string> {
         return new Promise((resolve, reject) => {
             const xhr = new XMLHttpRequest();

--- a/clients/ts/signalr/src/HttpClient.ts
+++ b/clients/ts/signalr/src/HttpClient.ts
@@ -163,6 +163,8 @@ export class DefaultHttpClient extends HttpClient {
             xhr.open(request.method, request.url, true);
             xhr.withCredentials = true;
             xhr.setRequestHeader("X-Requested-With", "XMLHttpRequest");
+            // Explicitly setting the Content-Type header for React Native on Android platform.
+            xhr.setRequestHeader("Content-Type", "text/plain;charset=UTF-8");
 
             if (request.headers) {
                 Object.keys(request.headers)


### PR DESCRIPTION
Port #2242 to 2.1.1 patch