### PR TITLE
Add Redis support to E2E benchmarks

### DIFF
--- a/benchmarkapps/BenchmarkServer/BenchmarkServer.csproj
+++ b/benchmarkapps/BenchmarkServer/BenchmarkServer.csproj
@@ -14,6 +14,7 @@
   <ItemGroup Condition="'$(BenchmarksTargetFramework)' == ''">
     <ProjectReference Include="..\..\src\Microsoft.AspNetCore.SignalR\Microsoft.AspNetCore.SignalR.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.AspNetCore.SignalR.Protocols.MessagePack\Microsoft.AspNetCore.SignalR.Protocols.MessagePack.csproj" />
+    <ProjectReference Include="..\..\src\Microsoft.AspNetCore.SignalR.Redis\Microsoft.AspNetCore.SignalR.Redis.csproj" />
 
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="$(MicrosoftAspNetCoreServerKestrelPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="$(MicrosoftExtensionsConfigurationCommandLinePackageVersion)" />

--- a/benchmarkapps/BenchmarkServer/Startup.cs
+++ b/benchmarkapps/BenchmarkServer/Startup.cs
@@ -4,19 +4,32 @@
 using BenchmarkServer.Hubs;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace BenchmarkServer
 {
     public class Startup
     {
+        private readonly IConfiguration _config;
+        public Startup(IConfiguration configuration)
+        {
+            _config = configuration;
+        }
+
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddSignalR(o =>
+            var signalrBuilder = services.AddSignalR(o =>
             {
                 o.EnableDetailedErrors = true;
             })
             .AddMessagePackProtocol();
+
+            var redisConnectionString = _config["SignalRRedis"];
+            if (!string.IsNullOrEmpty(redisConnectionString))
+            {
+                signalrBuilder.AddRedis(redisConnectionString);
+            }
         }
 
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)


### PR DESCRIPTION
Part of https://github.com/aspnet/SignalR/issues/1804
The rest of the work will be infrastructure etc.