### PR TITLE
Disable packing Microsoft.AspNetCore.SignalR.Specification.Tests

### DIFF
--- a/src/Microsoft.AspNetCore.SignalR.Specification.Tests/Microsoft.AspNetCore.SignalR.Specification.Tests.csproj
+++ b/src/Microsoft.AspNetCore.SignalR.Specification.Tests/Microsoft.AspNetCore.SignalR.Specification.Tests.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <Description>Tests for users to verify their own implementations of SignalR types</Description>
+    <!-- Temporarily suppress packing this project until we can fix issues in its dependencies. -->
+    <IsPackable>false</IsPackable>
     <DeveloperBuildTestTfms>netcoreapp2.2</DeveloperBuildTestTfms>
     <StandardTestTfms>$(DeveloperBuildTestTfms)</StandardTestTfms>
     <StandardTestTfms Condition=" '$(DeveloperBuild)' != 'true' AND '$(OS)' == 'Windows_NT' ">$(StandardTestTfms);net461</StandardTestTfms>


### PR DESCRIPTION
To unblock CI, let's disable this project from packing until we can address https://github.com/aspnet/SignalR/pull/2353#pullrequestreview-126915153