### PR TITLE
Clean up Spec Test dependencies

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -72,6 +72,8 @@
     <SystemThreadingChannelsPackageVersion>4.6.0-preview1-26605-01</SystemThreadingChannelsPackageVersion>
     <SystemThreadingTasksExtensionsPackageVersion>4.6.0-preview1-26605-01</SystemThreadingTasksExtensionsPackageVersion>
     <XunitPackageVersion>2.3.1</XunitPackageVersion>
+    <XunitAssertPackageVersion>2.3.1</XunitAssertPackageVersion>
+    <XunitExtensibilityCorePackageVersion>2.3.1</XunitExtensibilityCorePackageVersion>
     <XunitRunnerVisualStudioPackageVersion>2.4.0-beta.1.build3945</XunitRunnerVisualStudioPackageVersion>
   </PropertyGroup>
   <Import Project="$(DotNetPackageVersionPropsPath)" Condition=" '$(DotNetPackageVersionPropsPath)' != '' " />

--- a/src/Microsoft.AspNetCore.SignalR.Specification.Tests/Microsoft.AspNetCore.SignalR.Specification.Tests.csproj
+++ b/src/Microsoft.AspNetCore.SignalR.Specification.Tests/Microsoft.AspNetCore.SignalR.Specification.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Tests for users to verify their own implementations of SignalR types</Description>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFrameworks>netcoreapp2.2;net461</TargetFrameworks>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Microsoft.AspNetCore.SignalR.Specification.Tests/Microsoft.AspNetCore.SignalR.Specification.Tests.csproj
+++ b/src/Microsoft.AspNetCore.SignalR.Specification.Tests/Microsoft.AspNetCore.SignalR.Specification.Tests.csproj
@@ -4,7 +4,7 @@
     <Description>Tests for users to verify their own implementations of SignalR types</Description>
     <!-- Temporarily suppress packing this project until we can fix issues in its dependencies. -->
     <IsPackable>false</IsPackable>
-    <DeveloperBuildTestTfms>netcoreapp2.2</DeveloperBuildTestTfms>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <StandardTestTfms>$(DeveloperBuildTestTfms)</StandardTestTfms>
     <StandardTestTfms Condition=" '$(DeveloperBuild)' != 'true' AND '$(OS)' == 'Windows_NT' ">$(StandardTestTfms);net461</StandardTestTfms>
     <RuntimeIdentifier Condition="'$(TargetFramework)' == 'net461'">win7-x86</RuntimeIdentifier>
@@ -28,11 +28,10 @@
 
   <ItemGroup>
     <PackageReference Include="Internal.AspNetCore.Sdk" PrivateAssets="All" Version="$(InternalAspNetCoreSdkPackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Testing" Version="$(MicrosoftAspNetCoreTestingPackageVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
     <PackageReference Include="Moq" Version="$(MoqPackageVersion)" />
-    <PackageReference Include="xunit" Version="$(XunitPackageVersion)" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitRunnerVisualStudioPackageVersion)" />
+    <PackageReference Include="xunit.extensibility.core" Version="$(XunitPackageVersion)" />
+    <PackageReference Include="xunit.assert" Version="$(XunitPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.AspNetCore.SignalR.Specification.Tests/Microsoft.AspNetCore.SignalR.Specification.Tests.csproj
+++ b/src/Microsoft.AspNetCore.SignalR.Specification.Tests/Microsoft.AspNetCore.SignalR.Specification.Tests.csproj
@@ -19,7 +19,6 @@
 
   <ItemGroup>
     <PackageReference Include="Internal.AspNetCore.Sdk" PrivateAssets="All" Version="$(InternalAspNetCoreSdkPackageVersion)" />
-    <PackageReference Include="Moq" Version="$(MoqPackageVersion)" />
     <PackageReference Include="xunit.extensibility.core" Version="$(XunitExtensibilityCorePackageVersion)" />
     <PackageReference Include="xunit.assert" Version="$(XunitAssertPackageVersion)" />
   </ItemGroup>

--- a/src/Microsoft.AspNetCore.SignalR.Specification.Tests/Microsoft.AspNetCore.SignalR.Specification.Tests.csproj
+++ b/src/Microsoft.AspNetCore.SignalR.Specification.Tests/Microsoft.AspNetCore.SignalR.Specification.Tests.csproj
@@ -2,16 +2,7 @@
 
   <PropertyGroup>
     <Description>Tests for users to verify their own implementations of SignalR types</Description>
-    <!-- Temporarily suppress packing this project until we can fix issues in its dependencies. -->
-    <IsPackable>false</IsPackable>
     <TargetFramework>netcoreapp2.2</TargetFramework>
-    <StandardTestTfms>$(DeveloperBuildTestTfms)</StandardTestTfms>
-    <StandardTestTfms Condition=" '$(DeveloperBuild)' != 'true' AND '$(OS)' == 'Windows_NT' ">$(StandardTestTfms);net461</StandardTestTfms>
-    <RuntimeIdentifier Condition="'$(TargetFramework)' == 'net461'">win7-x86</RuntimeIdentifier>
-  </PropertyGroup>
-  
-  <PropertyGroup>
-    <TargetFrameworks>$(StandardTestTfms)</TargetFrameworks>
   </PropertyGroup>
   
   <ItemGroup>
@@ -30,8 +21,8 @@
     <PackageReference Include="Internal.AspNetCore.Sdk" PrivateAssets="All" Version="$(InternalAspNetCoreSdkPackageVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
     <PackageReference Include="Moq" Version="$(MoqPackageVersion)" />
-    <PackageReference Include="xunit.extensibility.core" Version="$(XunitPackageVersion)" />
-    <PackageReference Include="xunit.assert" Version="$(XunitPackageVersion)" />
+    <PackageReference Include="xunit.extensibility.core" Version="$(XunitExtensibilityCorePackageVersion)" />
+    <PackageReference Include="xunit.assert" Version="$(XunitAssertPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.AspNetCore.SignalR.Specification.Tests/Microsoft.AspNetCore.SignalR.Specification.Tests.csproj
+++ b/src/Microsoft.AspNetCore.SignalR.Specification.Tests/Microsoft.AspNetCore.SignalR.Specification.Tests.csproj
@@ -19,7 +19,6 @@
 
   <ItemGroup>
     <PackageReference Include="Internal.AspNetCore.Sdk" PrivateAssets="All" Version="$(InternalAspNetCoreSdkPackageVersion)" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
     <PackageReference Include="Moq" Version="$(MoqPackageVersion)" />
     <PackageReference Include="xunit.extensibility.core" Version="$(XunitExtensibilityCorePackageVersion)" />
     <PackageReference Include="xunit.assert" Version="$(XunitAssertPackageVersion)" />

--- a/src/Microsoft.AspNetCore.SignalR.Specification.Tests/ScaleoutHubLifetimeManagerTests.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Specification.Tests/ScaleoutHubLifetimeManagerTests.cs
@@ -6,7 +6,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR.Protocol;
 using Microsoft.AspNetCore.SignalR.Tests;
-using Moq;
 using Xunit;
 
 namespace Microsoft.AspNetCore.SignalR.Specification.Tests
@@ -297,14 +296,12 @@ namespace Microsoft.AspNetCore.SignalR.Specification.Tests
             {
                 // Force an exception when writing to connection
                 var connectionMock = HubConnectionContextUtils.CreateMock(client.Connection);
-                connectionMock.Setup(m => m.WriteAsync(It.IsAny<HubMessage>(), It.IsAny<CancellationToken>())).Throws(new Exception());
-                var connection = connectionMock.Object;
 
-                await manager2.OnConnectedAsync(connection).OrTimeout();
+                await manager2.OnConnectedAsync(connectionMock).OrTimeout();
 
                 // This doesn't throw because there is no connection.ConnectionId on this server so it has to publish to the backplane.
                 // And once that happens there is no way to know if the invocation was successful or not.
-                await manager1.SendConnectionAsync(connection.ConnectionId, "Hello", new object[] { "World" }).OrTimeout();
+                await manager1.SendConnectionAsync(connectionMock.ConnectionId, "Hello", new object[] { "World" }).OrTimeout();
             }
         }
 
@@ -319,9 +316,8 @@ namespace Microsoft.AspNetCore.SignalR.Specification.Tests
             {
                 // Force an exception when writing to connection
                 var connectionMock = HubConnectionContextUtils.CreateMock(client1.Connection);
-                connectionMock.Setup(m => m.WriteAsync(It.IsAny<HubMessage>(), It.IsAny<CancellationToken>())).Throws(new Exception());
 
-                var connection1 = connectionMock.Object;
+                var connection1 = connectionMock;
                 var connection2 = HubConnectionContextUtils.Create(client2.Connection);
 
                 await manager.OnConnectedAsync(connection1).OrTimeout();

--- a/test/Microsoft.AspNetCore.SignalR.Tests.Utils/HubConnectionContextUtils.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests.Utils/HubConnectionContextUtils.cs
@@ -2,10 +2,12 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.SignalR.Protocol;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using Moq;
 
 namespace Microsoft.AspNetCore.SignalR.Tests
 {
@@ -25,13 +27,24 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             };
         }
 
-        public static Mock<HubConnectionContext> CreateMock(ConnectionContext connection)
+        public static MockHubConnectionContext CreateMock(ConnectionContext connection)
         {
-            var mock = new Mock<HubConnectionContext>(connection, TimeSpan.FromSeconds(15), NullLoggerFactory.Instance, TimeSpan.FromSeconds(15)) { CallBase = true };
-            var protocol = new JsonHubProtocol();
-            mock.SetupGet(m => m.Protocol).Returns(protocol);
-            return mock;
+            return new MockHubConnectionContext(connection, TimeSpan.FromSeconds(15), NullLoggerFactory.Instance, TimeSpan.FromSeconds(15));
+        }
 
+        public class MockHubConnectionContext : HubConnectionContext
+        {
+            public MockHubConnectionContext(ConnectionContext connectionContext, TimeSpan keepAliveInterval, ILoggerFactory loggerFactory, TimeSpan clientTimeoutInterval)
+                : base(connectionContext, keepAliveInterval, loggerFactory, clientTimeoutInterval)
+            {
+
+            }
+
+            public override ValueTask WriteAsync(HubMessage message, CancellationToken cancellationToken = default)
+            {
+                throw new Exception();
+            }
         }
     }
+
 }


### PR DESCRIPTION
Updated the dependencies of the Specification Tests package. 
 - Removed AspNetCore.Testing
 - Used the Xunit extensibility packages

This still depends on Moq because of  `HubConnectionContextUtils`