### PR TITLE
Show detailed error message if exception is of type HubException

### DIFF
--- a/src/Microsoft.AspNetCore.SignalR.Core/Internal/ErrorMessageHelper.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/Internal/ErrorMessageHelper.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal
         {
             if (exception is HubException || includeExceptionDetails)
             {
-                return message + $" {exception.GetType().Name}: {exception.Message}";
+                return $"{message} {exception.GetType().Name}: {exception.Message}";
 
             }
 

--- a/src/Microsoft.AspNetCore.SignalR.Core/Internal/ErrorMessageHelper.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/Internal/ErrorMessageHelper.cs
@@ -9,12 +9,13 @@ namespace Microsoft.AspNetCore.SignalR.Internal
     {
         internal static string BuildErrorMessage(string message, Exception exception, bool includeExceptionDetails)
         {
-            if (!includeExceptionDetails)
+            if (exception is HubException || includeExceptionDetails)
             {
-                return message;
+                return message + $" {exception.GetType().Name}: {exception.Message}";
+
             }
 
-            return message + $" {exception.GetType().Name}: {exception.Message}";
+            return message;
         }
     }
 }

--- a/test/Microsoft.AspNetCore.SignalR.Tests/HubConnectionHandlerTestUtils/Hubs.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/HubConnectionHandlerTestUtils/Hubs.cs
@@ -121,6 +121,11 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             throw new InvalidOperationException("BOOM!");
         }
 
+        public void ThrowHubException()
+        {
+            throw new HubException("This is a hub exception");
+        }
+
         public Task MethodThatYieldsFailedTask()
         {
             return Task.FromException(new InvalidOperationException("BOOM!"));

--- a/test/Microsoft.AspNetCore.SignalR.Tests/HubConnectionHandlerTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/HubConnectionHandlerTests.cs
@@ -543,10 +543,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
         [Fact]
         public async Task DetailedExceptionEvenWhenNotExplicitlySet()
         {
-            var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider(builder =>
-            {
-                builder.AddSignalR();
-            });
+            var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider();
 
             var methodName = nameof(MethodHub.ThrowHubException);
 
@@ -558,9 +555,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
 
                 var message = await client.InvokeAsync(methodName).OrTimeout();
 
-                {
-                    Assert.Equal($"An unexpected error occurred invoking '{methodName}' on the server. HubException: This is a hub exception", message.Error);
-                }
+                Assert.Equal($"An unexpected error occurred invoking '{methodName}' on the server. HubException: This is a hub exception", message.Error);
 
                 // kill the connection
                 client.Dispose();

--- a/test/Microsoft.AspNetCore.SignalR.Tests/HubConnectionHandlerTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/HubConnectionHandlerTests.cs
@@ -541,6 +541,35 @@ namespace Microsoft.AspNetCore.SignalR.Tests
         }
 
         [Fact]
+        public async Task DetailedExceptionEvenWhenNotExplicitlySet()
+        {
+            var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider(builder =>
+            {
+                builder.AddSignalR();
+            });
+
+            var methodName = nameof(MethodHub.ThrowHubException);
+
+            var connectionHandler = serviceProvider.GetService<HubConnectionHandler<MethodHub>>();
+
+            using (var client = new TestClient())
+            {
+                var connectionHandlerTask = await client.ConnectAsync(connectionHandler);
+
+                var message = await client.InvokeAsync(methodName).OrTimeout();
+
+                {
+                    Assert.Equal($"An unexpected error occurred invoking '{methodName}' on the server. HubException: This is a hub exception", message.Error);
+                }
+
+                // kill the connection
+                client.Dispose();
+
+                await connectionHandlerTask.OrTimeout();
+            }
+        }
+
+        [Fact]
         public async Task HubMethodDoesNotSendResultWhenInvocationIsNonBlocking()
         {
             var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider();


### PR DESCRIPTION
This PR  enables showing a detailed error message on the client regardless of the state of the `EnabledDetailedErrors `flag  if a `HubException `was thrown on the server side. 
This is the functionality in ASP.NET SignalR.

Issue: https://github.com/aspnet/SignalR/issues/2439