### PR TITLE
Add build definition for deploying samples

### DIFF
--- a/.vsts-pipelines/builds/slow-tests-internal.yml
+++ b/.vsts-pipelines/builds/slow-tests-internal.yml
@@ -14,7 +14,7 @@ phases:
         checkLatest: true
 
     - task: BatchScript@1
-      displayName: Restore Packages
+      displayName: Build
       inputs:
         filename: './build.cmd'
         arguments: '/p:SkipTests=true'

--- a/.vsts-pipelines/builds/slow-tests-internal.yml
+++ b/.vsts-pipelines/builds/slow-tests-internal.yml
@@ -1,0 +1,46 @@
+trigger:
+- dev
+- release/*
+
+phases:
+  - phase: "Build"
+    queue:
+      name: Hosted VS2017
+    steps:
+    - task: NodeTool@0
+      displayName: Use Node >=9.11.1
+      inputs:
+        versionSpec: '>=9.11.1'
+        checkLatest: true
+
+    - task: BatchScript@1
+      displayName: Restore Packages
+      inputs:
+        filename: './build.cmd'
+        arguments: '/p:SkipTests=true'
+        modifyEnvironment: false
+
+    - task: PowerShell@1
+      displayName: Publish Samples
+      inputs:
+        scriptName: './build/publish-apps.ps1'
+        arguments: '-RootDirectory $(Build.SourcesDirectory) -CommitHash $(Build.SourceVersion) -BranchName $(Build.SourceBranch) -BuildNumber $(Build.BuildNumber)'
+
+    - task: AzureRmWebAppDeployment@3
+      displayName: Deploy FunctionalTests
+      inputs:
+        azureSubscription: SignalR Functional Testing Azure Connection
+        WebAppName: '$(Parameters.FunctionalTestAppName)'
+        Package: '$(Build.SourcesDirectory)/artifacts/apps/FunctionalTests'
+        TakeAppOfflineFlag: true
+      continueOnError: true
+
+    - task: AzureRmWebAppDeployment@3
+      displayName: Deploy SignalRSamples
+      inputs:
+        azureSubscription: SignalR Functional Testing Azure Connection
+        WebAppName: '$(Parameters.SamplesAppName)'
+        Package: '$(Build.SourcesDirectory)/artifacts/apps/SignalRSamples'
+        TakeAppOfflineFlag: true
+      continueOnError: true
+


### PR DESCRIPTION
Adds a build script that deploys the samples and functional tests to an
Azure App Service. The specific App Service name is parameterized and
kept internal.

This is also where some of our Browser Functional Test automation (via SauceLabs) and Xamarin automation will live, but that's not ready yet.