### PR TITLE
Remove extra reference to Internal.AspNetCore.Sdk to Fix CI Warning

### DIFF
--- a/src/Microsoft.AspNetCore.SignalR.Specification.Tests/Microsoft.AspNetCore.SignalR.Specification.Tests.csproj
+++ b/src/Microsoft.AspNetCore.SignalR.Specification.Tests/Microsoft.AspNetCore.SignalR.Specification.Tests.csproj
@@ -18,7 +18,6 @@
   
 
   <ItemGroup>
-    <PackageReference Include="Internal.AspNetCore.Sdk" PrivateAssets="All" Version="$(InternalAspNetCoreSdkPackageVersion)" />
     <PackageReference Include="xunit.extensibility.core" Version="$(XunitExtensibilityCorePackageVersion)" />
     <PackageReference Include="xunit.assert" Version="$(XunitAssertPackageVersion)" />
   </ItemGroup>


### PR DESCRIPTION
We're getting this warning on the CI because of an extra reference to `Internal.AspNetCore.Sdk`. 
```
C:\projects\universe\modules\SignalR\src\Microsoft.AspNetCore.SignalR.Specification.Tests\Microsoft.AspNetCore.SignalR.Specification.Tests.csproj : warning KRB2003: Found a duplicate PackageReference for Internal.AspNetCore.Sdk. Restore results may be unpredictable. [C:\Users\appveyor\.dotnet\buildtools\korebuild\2.2.0-preview1-17089\KoreBuild.proj]
C:\projects\universe\modules\SignalR\src\Microsoft.AspNetCore.SignalR.Specification.Tests\Microsoft.AspNetCore.SignalR.Specification.Tests.csproj : warning KRB2003: Found a duplicate PackageReference for Internal.AspNetCore.Sdk. Restore results may be unpredictable. [C:\Users\appveyor\.dotnet\buildtools\korebuild\2.2.0-preview1-17089\KoreBuild.proj]
    2 Warning(s)
    0 Error(s)
```
https://ci.appveyor.com/project/aspnetci/universe/build/1.0.2341

This change should resolve it

Issue: https://github.com/aspnet/SignalR/issues/2473