### PR TITLE
Bind the IObservable subscription in the AsChannelReader extension method to the connection livetime

### DIFF
--- a/samples/SignalRSamples/Hubs/Streaming.cs
+++ b/samples/SignalRSamples/Hubs/Streaming.cs
@@ -17,7 +17,7 @@ namespace SignalRSamples.Hubs
                              .Select((_, index) => index)
                              .Take(count);
 
-            return observable.AsChannelReader();
+            return observable.AsChannelReader(Context.ConnectionAborted);
         }
 
         public ChannelReader<int> ChannelCounter(int count, int delay)


### PR DESCRIPTION
These are the changes I made to the extension method in my project to bind the observable subscription to the connection livetime.

Fixes #2456 