### PR TITLE
Fix Groovy script to have correct Queue ID

### DIFF
--- a/build/buildpipeline/windows-es.groovy
+++ b/build/buildpipeline/windows-es.groovy
@@ -1,8 +1,8 @@
 @Library('dotnet-ci') _
 
-// 'node' indicates to Jenkins that the enclosed block runs on a node that matches
-// the label 'windows-with-vs'
-simpleNode('Windows.10.Amd64.ClientRS4.ES') {
+// 'simpleNode' indicates to Jenkins that the enclosed block runs on a node that matches
+// the label 'Windows.10.Amd64.ClientRS4.ES.Open'
+simpleNode('Windows.10.Amd64.ClientRS4.ES.Open') {
     stage ('Checking out source') {
         checkout scm
     }


### PR DESCRIPTION
@dseefeld FYI.

The queue listed didn't exist and would be blocked for this if it did (Jenkins jobs can only run on special ".Open" queues)