### PR TITLE
Update ts-jest

### DIFF
--- a/clients/ts/package-lock.json
+++ b/clients/ts/package-lock.json
@@ -517,9 +517,9 @@
       "dev": true
     },
     "atob": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/atob/-/atob-2.0.3.tgz",
-      "integrity": "sha1-GcenYEc3dEaPILLS0DNyrX1Mv10=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.1.tgz",
+      "integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio=",
       "dev": true
     },
     "aws-sign2": {
@@ -611,16 +611,6 @@
       "requires": {
         "babel-runtime": "^6.22.0",
         "babel-template": "^6.24.1"
-      }
-    },
-    "babel-jest": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-22.4.3.tgz",
-      "integrity": "sha512-BgSjmtl3mW3i+VeVHEr9d2zFSAT66G++pJcHQiUjd00pkW+voYXFctIm/indcqOWWXw5a1nUpR1XWszD9fJ1qg==",
-      "dev": true,
-      "requires": {
-        "babel-plugin-istanbul": "^4.1.5",
-        "babel-preset-jest": "^22.4.3"
       }
     },
     "babel-messages": {
@@ -1686,14 +1676,14 @@
       }
     },
     "fill-range": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-      "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+      "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
       "dev": true,
       "requires": {
         "is-number": "^2.1.0",
         "isobject": "^2.0.0",
-        "randomatic": "^1.1.3",
+        "randomatic": "^3.0.0",
         "repeat-element": "^1.1.2",
         "repeat-string": "^1.5.2"
       }
@@ -1761,9 +1751,9 @@
       }
     },
     "fs-extra": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
-      "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.0.tgz",
+      "integrity": "sha512-lk2cUCo8QzbiEWEbt7Cw3m27WMiRG321xsssbcIpfMhpRjrlC08WBOVQqj1/nQYYNnPtyIhP1oqLO3QwT2tPCw==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -3093,10 +3083,36 @@
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
+        "babel-jest": {
+          "version": "22.4.4",
+          "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-22.4.4.tgz",
+          "integrity": "sha512-A9NB6/lZhYyypR9ATryOSDcqBaqNdzq4U+CN+/wcMsLcmKkPxQEoTKLajGfd3IkxNyVBT8NewUK2nWyGbSzHEQ==",
+          "dev": true,
+          "requires": {
+            "babel-plugin-istanbul": "^4.1.5",
+            "babel-preset-jest": "^22.4.4"
+          }
+        },
+        "babel-plugin-jest-hoist": {
+          "version": "22.4.4",
+          "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.4.4.tgz",
+          "integrity": "sha512-DUvGfYaAIlkdnygVIEl0O4Av69NtuQWcrjMOv6DODPuhuGLDnbsARz3AwiiI/EkIMMlxQDUcrZ9yoyJvTNjcVQ==",
+          "dev": true
+        },
+        "babel-preset-jest": {
+          "version": "22.4.4",
+          "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-22.4.4.tgz",
+          "integrity": "sha512-+dxMtOFwnSYWfum0NaEc0O03oSdwBsjx4tMSChRDPGwu/4wSY6Q6ANW3wkjKpJzzguaovRs/DODcT4hbSN8yiA==",
+          "dev": true,
+          "requires": {
+            "babel-plugin-jest-hoist": "^22.4.4",
+            "babel-plugin-syntax-object-rest-spread": "^6.13.0"
+          }
+        },
         "jest-cli": {
-          "version": "22.4.3",
-          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-22.4.3.tgz",
-          "integrity": "sha512-IiHybF0DJNqZPsbjn4Cy4vcqcmImpoFwNFnkehzVw8lTUSl4axZh5DHewu5bdpZF2Y5gUqFKYzH0FH4Qx2k+UA==",
+          "version": "22.4.4",
+          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-22.4.4.tgz",
+          "integrity": "sha512-I9dsgkeyjVEEZj9wrGrqlH+8OlNob9Iptyl+6L5+ToOLJmHm4JwOPatin1b2Bzp5R5YRQJ+oiedx7o1H7wJzhA==",
           "dev": true,
           "requires": {
             "ansi-escapes": "^3.0.0",
@@ -3110,20 +3126,20 @@
             "istanbul-lib-coverage": "^1.1.1",
             "istanbul-lib-instrument": "^1.8.0",
             "istanbul-lib-source-maps": "^1.2.1",
-            "jest-changed-files": "^22.4.3",
-            "jest-config": "^22.4.3",
-            "jest-environment-jsdom": "^22.4.3",
-            "jest-get-type": "^22.4.3",
-            "jest-haste-map": "^22.4.3",
-            "jest-message-util": "^22.4.3",
-            "jest-regex-util": "^22.4.3",
-            "jest-resolve-dependencies": "^22.4.3",
-            "jest-runner": "^22.4.3",
-            "jest-runtime": "^22.4.3",
-            "jest-snapshot": "^22.4.3",
-            "jest-util": "^22.4.3",
-            "jest-validate": "^22.4.3",
-            "jest-worker": "^22.4.3",
+            "jest-changed-files": "^22.2.0",
+            "jest-config": "^22.4.4",
+            "jest-environment-jsdom": "^22.4.1",
+            "jest-get-type": "^22.1.0",
+            "jest-haste-map": "^22.4.2",
+            "jest-message-util": "^22.4.0",
+            "jest-regex-util": "^22.1.0",
+            "jest-resolve-dependencies": "^22.1.0",
+            "jest-runner": "^22.4.4",
+            "jest-runtime": "^22.4.4",
+            "jest-snapshot": "^22.4.0",
+            "jest-util": "^22.4.1",
+            "jest-validate": "^22.4.4",
+            "jest-worker": "^22.2.2",
             "micromatch": "^2.3.11",
             "node-notifier": "^5.2.1",
             "realpath-native": "^1.0.0",
@@ -3133,6 +3149,106 @@
             "strip-ansi": "^4.0.0",
             "which": "^1.2.12",
             "yargs": "^10.0.3"
+          },
+          "dependencies": {
+            "jest-config": {
+              "version": "22.4.4",
+              "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-22.4.4.tgz",
+              "integrity": "sha512-9CKfo1GC4zrXSoMLcNeDvQBfgtqGTB1uP8iDIZ97oB26RCUb886KkKWhVcpyxVDOUxbhN+uzcBCeFe7w+Iem4A==",
+              "dev": true,
+              "requires": {
+                "chalk": "^2.0.1",
+                "glob": "^7.1.1",
+                "jest-environment-jsdom": "^22.4.1",
+                "jest-environment-node": "^22.4.1",
+                "jest-get-type": "^22.1.0",
+                "jest-jasmine2": "^22.4.4",
+                "jest-regex-util": "^22.1.0",
+                "jest-resolve": "^22.4.2",
+                "jest-util": "^22.4.1",
+                "jest-validate": "^22.4.4",
+                "pretty-format": "^22.4.0"
+              }
+            },
+            "jest-runner": {
+              "version": "22.4.4",
+              "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-22.4.4.tgz",
+              "integrity": "sha512-5S/OpB51igQW9xnkM5Tgd/7ZjiAuIoiJAVtvVTBcEBiXBIFzWM3BAMPBM19FX68gRV0KWyFuGKj0EY3M3aceeQ==",
+              "dev": true,
+              "requires": {
+                "exit": "^0.1.2",
+                "jest-config": "^22.4.4",
+                "jest-docblock": "^22.4.0",
+                "jest-haste-map": "^22.4.2",
+                "jest-jasmine2": "^22.4.4",
+                "jest-leak-detector": "^22.4.0",
+                "jest-message-util": "^22.4.0",
+                "jest-runtime": "^22.4.4",
+                "jest-util": "^22.4.1",
+                "jest-worker": "^22.2.2",
+                "throat": "^4.0.0"
+              }
+            },
+            "jest-runtime": {
+              "version": "22.4.4",
+              "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-22.4.4.tgz",
+              "integrity": "sha512-WRTj9m///npte1YjuphCYX7GRY/c2YvJImU9t7qOwFcqHr4YMzmX6evP/3Sehz5DKW2Vi8ONYPCFWe36JVXxfw==",
+              "dev": true,
+              "requires": {
+                "babel-core": "^6.0.0",
+                "babel-jest": "^22.4.4",
+                "babel-plugin-istanbul": "^4.1.5",
+                "chalk": "^2.0.1",
+                "convert-source-map": "^1.4.0",
+                "exit": "^0.1.2",
+                "graceful-fs": "^4.1.11",
+                "jest-config": "^22.4.4",
+                "jest-haste-map": "^22.4.2",
+                "jest-regex-util": "^22.1.0",
+                "jest-resolve": "^22.4.2",
+                "jest-util": "^22.4.1",
+                "jest-validate": "^22.4.4",
+                "json-stable-stringify": "^1.0.1",
+                "micromatch": "^2.3.11",
+                "realpath-native": "^1.0.0",
+                "slash": "^1.0.0",
+                "strip-bom": "3.0.0",
+                "write-file-atomic": "^2.1.0",
+                "yargs": "^10.0.3"
+              }
+            },
+            "jest-validate": {
+              "version": "22.4.4",
+              "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-22.4.4.tgz",
+              "integrity": "sha512-dmlf4CIZRGvkaVg3fa0uetepcua44DHtktHm6rcoNVtYlpwe6fEJRkMFsaUVcFHLzbuBJ2cPw9Gl9TKfnzMVwg==",
+              "dev": true,
+              "requires": {
+                "chalk": "^2.0.1",
+                "jest-config": "^22.4.4",
+                "jest-get-type": "^22.1.0",
+                "leven": "^2.1.0",
+                "pretty-format": "^22.4.0"
+              }
+            }
+          }
+        },
+        "jest-jasmine2": {
+          "version": "22.4.4",
+          "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-22.4.4.tgz",
+          "integrity": "sha512-nK3vdUl50MuH7vj/8at7EQVjPGWCi3d5+6aCi7Gxy/XMWdOdbH1qtO/LjKbqD8+8dUAEH+BVVh7HkjpCWC1CSw==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.0.1",
+            "co": "^4.6.0",
+            "expect": "^22.4.0",
+            "graceful-fs": "^4.1.11",
+            "is-generator-fn": "^1.0.0",
+            "jest-diff": "^22.4.0",
+            "jest-matcher-utils": "^22.4.0",
+            "jest-message-util": "^22.4.0",
+            "jest-snapshot": "^22.4.0",
+            "jest-util": "^22.4.1",
+            "source-map-support": "^0.5.0"
           }
         },
         "strip-ansi": {
@@ -3143,6 +3259,12 @@
           "requires": {
             "ansi-regex": "^3.0.0"
           }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
         }
       }
     },
@@ -3318,61 +3440,6 @@
       "dev": true,
       "requires": {
         "jest-regex-util": "^22.4.3"
-      }
-    },
-    "jest-runner": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-22.4.3.tgz",
-      "integrity": "sha512-U7PLlQPRlWNbvOHWOrrVay9sqhBJmiKeAdKIkvX4n1G2tsvzLlf77nBD28GL1N6tGv4RmuTfI8R8JrkvCa+IBg==",
-      "dev": true,
-      "requires": {
-        "exit": "^0.1.2",
-        "jest-config": "^22.4.3",
-        "jest-docblock": "^22.4.3",
-        "jest-haste-map": "^22.4.3",
-        "jest-jasmine2": "^22.4.3",
-        "jest-leak-detector": "^22.4.3",
-        "jest-message-util": "^22.4.3",
-        "jest-runtime": "^22.4.3",
-        "jest-util": "^22.4.3",
-        "jest-worker": "^22.4.3",
-        "throat": "^4.0.0"
-      }
-    },
-    "jest-runtime": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-22.4.3.tgz",
-      "integrity": "sha512-Eat/esQjevhx9BgJEC8udye+FfoJ2qvxAZfOAWshYGS22HydHn5BgsvPdTtt9cp0fSl5LxYOFA1Pja9Iz2Zt8g==",
-      "dev": true,
-      "requires": {
-        "babel-core": "^6.0.0",
-        "babel-jest": "^22.4.3",
-        "babel-plugin-istanbul": "^4.1.5",
-        "chalk": "^2.0.1",
-        "convert-source-map": "^1.4.0",
-        "exit": "^0.1.2",
-        "graceful-fs": "^4.1.11",
-        "jest-config": "^22.4.3",
-        "jest-haste-map": "^22.4.3",
-        "jest-regex-util": "^22.4.3",
-        "jest-resolve": "^22.4.3",
-        "jest-util": "^22.4.3",
-        "jest-validate": "^22.4.3",
-        "json-stable-stringify": "^1.0.1",
-        "micromatch": "^2.3.11",
-        "realpath-native": "^1.0.0",
-        "slash": "^1.0.0",
-        "strip-bom": "3.0.0",
-        "write-file-atomic": "^2.1.0",
-        "yargs": "^10.0.3"
-      },
-      "dependencies": {
-        "strip-bom": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-          "dev": true
-        }
       }
     },
     "jest-serializer": {
@@ -3702,6 +3769,12 @@
       "requires": {
         "object-visit": "^1.0.0"
       }
+    },
+    "math-random": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
+      "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
+      "dev": true
     },
     "mem": {
       "version": "1.1.0",
@@ -4307,43 +4380,27 @@
       "dev": true
     },
     "randomatic": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
+      "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
       "dev": true,
       "requires": {
-        "is-number": "^3.0.0",
-        "kind-of": "^4.0.0"
+        "is-number": "^4.0.0",
+        "kind-of": "^6.0.0",
+        "math-random": "^1.0.1"
       },
       "dependencies": {
         "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+          "dev": true
         },
         "kind-of": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-          "dev": true,
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
         }
       }
     },
@@ -5823,19 +5880,21 @@
       "dev": true
     },
     "ts-jest": {
-      "version": "22.4.4",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-22.4.4.tgz",
-      "integrity": "sha512-v9pO7u4HNMDSBCN9IEvlR6taDAGm2mo7nHEDLWyoFDgYeZ4aHm8JHEPrthd8Pmcl4eCM8J4Ata4ROR/cwFRV2A==",
+      "version": "22.4.6",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-22.4.6.tgz",
+      "integrity": "sha512-kYQ6g1G1AU+bOO9rv+SSQXg4WTcni6Wx3AM48iHni0nP1vIuhdNRjKTE9Cxx36Ix/IOV7L85iKu07dgXJzH2pQ==",
       "dev": true,
       "requires": {
-        "babel-core": "^6.26.0",
-        "babel-plugin-istanbul": "^4.1.4",
-        "babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",
-        "babel-preset-jest": "^22.4.0",
+        "babel-core": "^6.26.3",
+        "babel-plugin-istanbul": "^4.1.6",
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.26.2",
+        "babel-preset-jest": "^22.4.3",
         "cpx": "^1.5.0",
-        "fs-extra": "4.0.3",
-        "jest-config": "^22.4.2",
+        "fs-extra": "6.0.0",
+        "jest-config": "^22.4.3",
+        "lodash": "^4.17.10",
         "pkg-dir": "^2.0.0",
+        "source-map-support": "^0.5.5",
         "yargs": "^11.0.0"
       },
       "dependencies": {
@@ -5844,6 +5903,33 @@
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
+        },
+        "babel-core": {
+          "version": "6.26.3",
+          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
+          "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
+          "dev": true,
+          "requires": {
+            "babel-code-frame": "^6.26.0",
+            "babel-generator": "^6.26.0",
+            "babel-helpers": "^6.24.1",
+            "babel-messages": "^6.23.0",
+            "babel-register": "^6.26.0",
+            "babel-runtime": "^6.26.0",
+            "babel-template": "^6.26.0",
+            "babel-traverse": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "convert-source-map": "^1.5.1",
+            "debug": "^2.6.9",
+            "json5": "^0.5.1",
+            "lodash": "^4.17.4",
+            "minimatch": "^3.0.4",
+            "path-is-absolute": "^1.0.1",
+            "private": "^0.1.8",
+            "slash": "^1.0.0",
+            "source-map": "^0.5.7"
+          }
         },
         "camelcase": {
           "version": "4.1.0",

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -20,7 +20,7 @@
     "rollup-plugin-commonjs": "^8.2.6",
     "rollup-plugin-node-resolve": "^3.0.2",
     "rollup-plugin-sourcemaps": "^0.4.2",
-    "ts-jest": "^22.4.4",
+    "ts-jest": "^22.4.6",
     "tslint": "^5.9.1",
     "typescript": "^2.7.1",
     "uglify-js": "^3.3.5"


### PR DESCRIPTION
`npm audit` says we should update. This is **not** a dependency that ever ships to customers, it's purely used in our testing code. `ts-jest` wasn't the source of the issues, but it was the source of all the dependencies that needed to be updated ;)