### PR TITLE
Corrige los fallos cuando las pruebas se ejecutan en máquinas que usan castellano como lenguaje.

### DIFF
--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.ConnectionLifecycle.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.ConnectionLifecycle.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.ConnectionLifecycle.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.ConnectionLifecycle.cs
@@ -508,11 +508,9 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                 try
                 {
                     var startTask = hubConnection.StartAsync(cts.Token);
-                    var exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(() => startTask.OrTimeout());
+                    await Assert.ThrowsAnyAsync<OperationCanceledException>(() => startTask.OrTimeout());
 
-                    // REVIEW: Alternatively, we could just not assert the message...
-                    // We need the localized version of the default message
-                    Assert.Equal(new OperationCanceledException().Message, exception.Message);
+                    // We aren't worried about the exact message and it's localized so asserting it is non-trivial.
                 }
                 finally
                 {

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.ConnectionLifecycle.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.ConnectionLifecycle.cs
@@ -509,7 +509,10 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                 {
                     var startTask = hubConnection.StartAsync(cts.Token);
                     var exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(() => startTask.OrTimeout());
-                    Assert.Equal("The operation was canceled.", exception.Message);
+
+                    // REVIEW: Alternatively, we could just not assert the message...
+                    // We need the localized version of the default message
+                    Assert.Equal(new OperationCanceledException().Message, exception.Message);
                 }
                 finally
                 {

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.cs
@@ -114,7 +114,9 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
             await hubConnection.StartAsync().OrTimeout();
 
             var exception = Assert.IsType<TimeoutException>(await closeTcs.Task.OrTimeout());
-            Assert.Equal("Server timeout (100.00ms) elapsed without receiving a message from the server.", exception.Message);
+
+            // We use an interpolated string so the tests are accurate on non-US machines.
+            Assert.Equal($"Server timeout ({hubConnection.ServerTimeout.TotalMilliseconds:0.00}ms) elapsed without receiving a message from the server.", exception.Message);
         }
 
         [Fact]
@@ -137,7 +139,9 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                 var invokeTask = hubConnection.InvokeAsync("Method").OrTimeout();
 
                 var exception = await Assert.ThrowsAsync<TimeoutException>(() => invokeTask);
-                Assert.Equal("Server timeout (2000.00ms) elapsed without receiving a message from the server.", exception.Message);
+
+                // We use an interpolated string so the tests are accurate on non-US machines.
+                Assert.Equal($"Server timeout ({hubConnection.ServerTimeout.TotalMilliseconds:0.00}ms) elapsed without receiving a message from the server.", exception.Message);
             }
         }
 

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/ServerSentEventsTransportTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/ServerSentEventsTransportTests.cs
@@ -363,7 +363,9 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                 var sseTransport = new ServerSentEventsTransport(httpClient, loggerFactory);
 
                 var ex = await Assert.ThrowsAsync<ArgumentException>(() => sseTransport.StartAsync(new Uri("http://fakeuri.org"), TransferFormat.Binary).OrTimeout());
-                Assert.Equal($"The 'Binary' transfer format is not supported by this transport.{Environment.NewLine}Parameter name: transferFormat", ex.Message);
+
+                Assert.Equal("transferFormat", ex.ParamName);
+                Assert.Equal($"The 'Binary' transfer format is not supported by this transport.", ex.GetLocalizationSafeMessage());
             }
         }
 

--- a/test/Microsoft.AspNetCore.SignalR.Tests.Utils/ExceptionMessageExtensions.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests.Utils/ExceptionMessageExtensions.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 
 namespace Microsoft.AspNetCore.SignalR.Tests

--- a/test/Microsoft.AspNetCore.SignalR.Tests.Utils/ExceptionMessageExtensions.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests.Utils/ExceptionMessageExtensions.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace Microsoft.AspNetCore.SignalR.Tests
+{
+    public static class ExceptionMessageExtensions
+    {
+        public static string GetLocalizationSafeMessage(this ArgumentException argex)
+        {
+            // Strip off the last line since it's "Parameter Name: [parameterName]" and:
+            // 1. We verify the parameter name separately
+            // 2. It is localized, so we don't want our tests to break in non-US environments
+            var message = argex.Message;
+            var lastNewline = message.LastIndexOf(Environment.NewLine, StringComparison.Ordinal);
+            if (lastNewline < 0)
+            {
+                return message;
+            }
+
+            return message.Substring(0, lastNewline);
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.SignalR.Tests.Utils/ExceptionMessageExtensions.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests.Utils/ExceptionMessageExtensions.cs
@@ -4,7 +4,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
 {
     public static class ExceptionMessageExtensions
     {
-        public static string GetLocalizationSafeMessage(this ArgumentException argex)
+        public static string GetLocalizationSafeMessage(this ArgumentException argEx)
         {
             // Strip off the last line since it's "Parameter Name: [parameterName]" and:
             // 1. We verify the parameter name separately

--- a/test/Microsoft.AspNetCore.SignalR.Tests.Utils/ExceptionMessageExtensions.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests.Utils/ExceptionMessageExtensions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             // Strip off the last line since it's "Parameter Name: [parameterName]" and:
             // 1. We verify the parameter name separately
             // 2. It is localized, so we don't want our tests to break in non-US environments
-            var message = argex.Message;
+            var message = argEx.Message;
             var lastNewline = message.LastIndexOf(Environment.NewLine, StringComparison.Ordinal);
             if (lastNewline < 0)
             {


### PR DESCRIPTION
... I hope Google Translate didn't make me look too stupid there ;).

This should fix the issues with the Spanish build. Just a few places where we hard-coded asserts of things that end up getting localized.

Fixes #1967 