### PR TITLE
fix #2474 by adding some transitive dependencies as top-level

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -1,4 +1,4 @@
-﻿<Project>
+<Project>
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>

--- a/src/Microsoft.AspNetCore.SignalR.Client.Core/Microsoft.AspNetCore.SignalR.Client.Core.csproj
+++ b/src/Microsoft.AspNetCore.SignalR.Client.Core/Microsoft.AspNetCore.SignalR.Client.Core.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>Client for ASP.NET Core SignalR</Description>
@@ -21,6 +21,8 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingPackageVersion)" />
     <PackageReference Include="System.Threading.Channels" Version="$(SystemThreadingChannelsPackageVersion)" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="$(SystemThreadingTasksExtensionsPackageVersion)" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="$(SystemRuntimeCompilerServicesUnsafePackageVersion)" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixes #2474 

This is a fix being considered for 2.1.3. The 2.1.1 patch contained fixes for these `System.*` packages to make them work properly on UWP and Xamarin. However, since we get them transitively through `System.Threading.Channels` users don't see that they need to update them, and updating our package alone is insufficient. NuGet doesn't advertise transitive updates, so they have no way of knowing they need the fix.

This change adds these dependencies (which are already present transitively) as direct dependencies so that when users update our package (which NuGet should advertise as users will be directly depending on our package), they get the fix.