### PR TITLE
Ping Cleanup

### DIFF
--- a/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.cs
@@ -925,6 +925,11 @@ namespace Microsoft.AspNetCore.SignalR.Client
 
         private async Task PingServer()
         {
+            if (Debugger.IsAttached)
+            {
+                return;
+            }
+
             if (_disposed || !_connectionLock.Wait(0))
             {
                 Log.UnableToAcquireConnectionLockForPing(_logger);

--- a/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.cs
@@ -925,11 +925,6 @@ namespace Microsoft.AspNetCore.SignalR.Client
 
         private async Task PingServer()
         {
-            if (Debugger.IsAttached)
-            {
-                return;
-            }
-
             if (_disposed || !_connectionLock.Wait(0))
             {
                 Log.UnableToAcquireConnectionLockForPing(_logger);

--- a/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionContext.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionContext.cs
@@ -452,14 +452,11 @@ namespace Microsoft.AspNetCore.SignalR
 
             if (currentTime - Volatile.Read(ref _lastSendTimeStamp) > _keepAliveInterval)
             {
-                if (!Debugger.IsAttached)
-                {
-                    // Haven't sent a message for the entire keep-alive duration, so send a ping.
-                    // If the transport channel is full, this will fail, but that's OK because
-                    // adding a Ping message when the transport is full is unnecessary since the
-                    // transport is still in the process of sending frames.
-                    _ = TryWritePingAsync();
-                }
+                // Haven't sent a message for the entire keep-alive duration, so send a ping.
+                // If the transport channel is full, this will fail, but that's OK because
+                // adding a Ping message when the transport is full is unnecessary since the
+                // transport is still in the process of sending frames.
+                _ = TryWritePingAsync();
 
                 // We only update the timestamp here, because updating on each sent message is bad for performance
                 // There can be a lot of sent messages per 15 seconds


### PR DESCRIPTION
Changed a potentially misleading comment on the c# client, moved the `ResetPing` call to a more obvious location.

Both client and server skip sending pings.