### PR TITLE
Try renaming spanish build

### DIFF
--- a/build/buildpipeline/pipeline.groovy
+++ b/build/buildpipeline/pipeline.groovy
@@ -12,7 +12,7 @@ def parameters = [
 windowsPipeline.triggerPipelineOnEveryGithubPR("Windows ${configuration} x64 Build", parameters)
 windowsPipeline.triggerPipelineOnGithubPush(parameters)
 
-windowsESPipeline.triggerPipelineOnEveryGithubPR("Windows ${configuration} (Spanish Language) x64 Build", parameters)
+windowsESPipeline.triggerPipelineOnEveryGithubPR("Windows ${configuration} Spanish Language x64 Build", parameters)
 windowsESPipeline.triggerPipelineOnGithubPush(parameters)
 
 linuxPipeline.triggerPipelineOnEveryGithubPR("Ubuntu 16.04 ${configuration} Build", parameters)

--- a/build/buildpipeline/pipeline.groovy
+++ b/build/buildpipeline/pipeline.groovy
@@ -12,7 +12,7 @@ def parameters = [
 windowsPipeline.triggerPipelineOnEveryGithubPR("Windows ${configuration} x64 Build", parameters)
 windowsPipeline.triggerPipelineOnGithubPush(parameters)
 
-windowsESPipeline.triggerPipelineOnEveryGithubPR("Windows ${configuration} x64 Build (Spanish language image) ", parameters)
+windowsESPipeline.triggerPipelineOnEveryGithubPR("Windows ${configuration} (Spanish Language) x64 Build", parameters)
 windowsESPipeline.triggerPipelineOnGithubPush(parameters)
 
 linuxPipeline.triggerPipelineOnEveryGithubPR("Ubuntu 16.04 ${configuration} Build", parameters)


### PR DESCRIPTION
dotnetbot doesn't like it when you have builds that have a matching substring at the start, it's hard to re-run them. This should make the spanish build different enough.