### PR TITLE
Update build.gradle to not use depricated compile

### DIFF
--- a/clients/java/signalr/build.gradle
+++ b/clients/java/signalr/build.gradle
@@ -13,6 +13,6 @@ repositories {
 
 dependencies {
     testImplementation group: 'junit', name: 'junit', version: '4.12'
-    compile "org.java-websocket:Java-WebSocket:1.3.8"
+    implementation "org.java-websocket:Java-WebSocket:1.3.8"
     implementation 'com.google.code.gson:gson:2.8.5'
 }


### PR DESCRIPTION
`compile` is now depricated 
From the [gradle docs](https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_configurations_graph)

> The compile, testCompile, runtime and testRuntime configurations inherited from the Java plugin are still available but are deprecated. You should avoid using them, as they are only kept for backwards compatibility.