### PR TITLE
Formatting urls properly when using websockets

### DIFF
--- a/clients/java/signalr/src/main/java/WebSocketTransport.java
+++ b/clients/java/signalr/src/main/java/WebSocketTransport.java
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-import com.google.gson.Gson;
 import org.java_websocket.client.WebSocketClient;
 import org.java_websocket.handshake.ServerHandshake;
 
@@ -9,25 +8,39 @@ import java.net.URI;
 import java.net.URISyntaxException;
 
 public class WebSocketTransport implements Transport {
-    private WebSocketClient _webSocket;
+    private WebSocketClient webSocketClient;
     private OnReceiveCallBack onReceiveCallBack;
-    private URI _url;
+    private URI url;
+    private static final String HTTP = "http";
+    private static final String HTTPS = "https";
+    private static final String WS = "ws";
+    private static final String WSS = "wss";
 
     public WebSocketTransport(String url) throws URISyntaxException {
         // To Do: Format the  incoming URL for a websocket connection.
-        _url = new URI(url);
-        _webSocket = createWebSocket();
+        this.url = formatUrl(url);
+        this.webSocketClient = createWebSocket();
+    }
+
+    private URI formatUrl(String url) throws URISyntaxException {
+        if(url.startsWith(HTTPS)){
+            url = WSS + url.substring(HTTPS.length());
+        }
+        else if(url.startsWith(HTTP)){
+            url = WS + url.substring(HTTP.length());
+        }
+        return new URI(url);
     }
 
     @Override
     public void start() throws InterruptedException {
-        _webSocket.connectBlocking();
-        _webSocket.send((new DefaultJsonProtocolHandShakeMessage()).createHandshakeMessage());
+        webSocketClient.connectBlocking();
+        webSocketClient.send((new DefaultJsonProtocolHandShakeMessage()).createHandshakeMessage());
     }
 
     @Override
     public void send(String message) {
-        _webSocket.send(message);
+        webSocketClient.send(message);
     }
 
     @Override
@@ -42,14 +55,14 @@ public class WebSocketTransport implements Transport {
 
     @Override
     public void stop() {
-        _webSocket.closeConnection(0, "HubConnection Stopped");
+        webSocketClient.closeConnection(0, "HubConnection Stopped");
     }
 
     private WebSocketClient createWebSocket() {
-        return new WebSocketClient(_url) {
+        return new WebSocketClient(url) {
              @Override
              public void onOpen(ServerHandshake handshakedata) {
-                 System.out.println("Connected to " + _url);
+                 System.out.println("Connected to " + url);
              }
 
              @Override

--- a/clients/java/signalr/src/main/java/WebSocketTransport.java
+++ b/clients/java/signalr/src/main/java/WebSocketTransport.java
@@ -11,15 +11,18 @@ public class WebSocketTransport implements Transport {
     private WebSocketClient webSocketClient;
     private OnReceiveCallBack onReceiveCallBack;
     private URI url;
+
     private static final String HTTP = "http";
     private static final String HTTPS = "https";
     private static final String WS = "ws";
     private static final String WSS = "wss";
 
     public WebSocketTransport(String url) throws URISyntaxException {
-        // To Do: Format the  incoming URL for a websocket connection.
         this.url = formatUrl(url);
-        this.webSocketClient = createWebSocket();
+    }
+
+    public URI getUrl(){
+        return url;
     }
 
     private URI formatUrl(String url) throws URISyntaxException {
@@ -34,6 +37,7 @@ public class WebSocketTransport implements Transport {
 
     @Override
     public void start() throws InterruptedException {
+        webSocketClient = createWebSocket();
         webSocketClient.connectBlocking();
         webSocketClient.send((new DefaultJsonProtocolHandShakeMessage()).createHandshakeMessage());
     }

--- a/clients/java/signalr/src/test/java/WebSocketTransportTest.java
+++ b/clients/java/signalr/src/test/java/WebSocketTransportTest.java
@@ -1,0 +1,33 @@
+import org.junit.Test;
+
+import java.net.URISyntaxException;
+
+import static org.junit.Assert.*;
+
+public class WebSocketTransportTest {
+
+    @Test
+    public void checkThatWsIsUnchanged() throws URISyntaxException {
+        WebSocketTransport webSocketTransport = new WebSocketTransport("ws://example.com");
+        assertEquals("ws://example.com", webSocketTransport.getUrl().toString());
+    }
+
+    @Test
+    public void checkThatWssIsUnchanged() throws URISyntaxException {
+        WebSocketTransport webSocketTransport = new WebSocketTransport("wss://example.com");
+        assertEquals("wss://example.com", webSocketTransport.getUrl().toString());
+    }
+
+    @Test
+    public void checkThatHttpIsChangedToWs() throws URISyntaxException {
+        WebSocketTransport webSocketTransport = new WebSocketTransport("http://example.com");
+        assertEquals("ws://example.com", webSocketTransport.getUrl().toString());
+    }
+
+    @Test
+    public void checkThatHttpsIsChangedToWss() throws URISyntaxException {
+        WebSocketTransport webSocketTransport = new WebSocketTransport("https://example.com");
+        assertEquals("wss://example.com", webSocketTransport.getUrl().toString());
+    }
+
+}

--- a/clients/java/signalr/src/test/java/WebSocketTransportTest.java
+++ b/clients/java/signalr/src/test/java/WebSocketTransportTest.java
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 import org.junit.Test;
 
 import java.net.URISyntaxException;

--- a/clients/java/signalr/src/test/java/WebSocketTransportTest.java
+++ b/clients/java/signalr/src/test/java/WebSocketTransportTest.java
@@ -2,35 +2,34 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.Collection;
 
 import static org.junit.Assert.*;
 
+@RunWith(Parameterized.class)
 public class WebSocketTransportTest {
+    private String url;
+    private String expectedUrl;
 
-    @Test
-    public void checkThatWsIsUnchanged() throws URISyntaxException {
-        WebSocketTransport webSocketTransport = new WebSocketTransport("ws://example.com");
-        assertEquals("ws://example.com", webSocketTransport.getUrl().toString());
+    public WebSocketTransportTest(String url, String expectedProtocol){
+        this.url = url;
+        this.expectedUrl = expectedProtocol;
+    }
+
+    @Parameterized.Parameters
+    public static Collection protocols(){
+        return Arrays.asList(new String[][] {{"http://example.com", "ws://example.com"}, {"https://example.com", "wss://example.com"},
+                {"ws://example.com", "ws://example.com"}, {"wss://example.com", "wss://example.com"}});
     }
 
     @Test
-    public void checkThatWssIsUnchanged() throws URISyntaxException {
-        WebSocketTransport webSocketTransport = new WebSocketTransport("wss://example.com");
-        assertEquals("wss://example.com", webSocketTransport.getUrl().toString());
+    public void checkWebsocketUrlProtocol() throws URISyntaxException {
+        WebSocketTransport webSocketTransport = new WebSocketTransport(this.url);
+        assertEquals(this.expectedUrl, webSocketTransport.getUrl().toString());
     }
-
-    @Test
-    public void checkThatHttpIsChangedToWs() throws URISyntaxException {
-        WebSocketTransport webSocketTransport = new WebSocketTransport("http://example.com");
-        assertEquals("ws://example.com", webSocketTransport.getUrl().toString());
-    }
-
-    @Test
-    public void checkThatHttpsIsChangedToWss() throws URISyntaxException {
-        WebSocketTransport webSocketTransport = new WebSocketTransport("https://example.com");
-        assertEquals("wss://example.com", webSocketTransport.getUrl().toString());
-    }
-
 }

--- a/clients/java/signalr/src/test/java/WebSocketTransportTest.java
+++ b/clients/java/signalr/src/test/java/WebSocketTransportTest.java
@@ -23,8 +23,11 @@ public class WebSocketTransportTest {
 
     @Parameterized.Parameters
     public static Collection protocols(){
-        return Arrays.asList(new String[][] {{"http://example.com", "ws://example.com"}, {"https://example.com", "wss://example.com"},
-                {"ws://example.com", "ws://example.com"}, {"wss://example.com", "wss://example.com"}});
+        return Arrays.asList(new String[][] {
+                {"http://example.com", "ws://example.com"},
+                {"https://example.com", "wss://example.com"},
+                {"ws://example.com", "ws://example.com"},
+                {"wss://example.com", "wss://example.com"}});
     }
 
     @Test


### PR DESCRIPTION
The web sockets transport should format urls to establish web sockets connections properly.

Issue: https://github.com/aspnet/SignalR/issues/2570