### PR TITLE
Registering multiple handlers

### DIFF
--- a/clients/java/signalr/src/main/java/CallbackMap.java
+++ b/clients/java/signalr/src/main/java/CallbackMap.java
@@ -1,0 +1,28 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class CallbackMap {
+    private ConcurrentHashMap<String, List<ActionBase>> handlers = new ConcurrentHashMap<>();
+
+    public void put(String target, ActionBase action) {
+        handlers.computeIfPresent(target, (methodName, handlerList) -> {
+            handlerList.add(action);
+            return handlerList;
+        });
+        handlers.computeIfAbsent(target, (ac) -> new ArrayList<>(Arrays.asList(action)));
+    }
+
+    public Boolean containsKey(String key){
+        return handlers.containsKey(key);
+    }
+
+    public List<ActionBase> get(String key){
+        return handlers.get(key);
+    }
+}
+

--- a/clients/java/signalr/src/main/java/HubConnection.java
+++ b/clients/java/signalr/src/main/java/HubConnection.java
@@ -6,13 +6,13 @@ import com.google.gson.JsonArray;
 
 import java.net.URISyntaxException;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.List;
 
 public class HubConnection {
     private String url;
     private Transport transport;
     private OnReceiveCallBack callback;
-    private HashMap<String, ActionBase> handlers = new HashMap<>();
+    private CallbackMap handlers = new CallbackMap();
     private HubProtocol protocol;
     private Gson gson = new Gson();
 
@@ -29,9 +29,11 @@ public class HubConnection {
             // Adding this to avoid getting error messages on pings for now.
             for (InvocationMessage message : messages) {
                 if (message != null && handlers.containsKey(message.target)) {
-                    ArrayList<Object> types = gson.fromJson((JsonArray)message.arguments[0], (new ArrayList<Object>()).getClass());
-
-                    handlers.get(message.target).invoke(types.toArray());
+                    ArrayList<Object> args = gson.fromJson((JsonArray)message.arguments[0], (new ArrayList<Object>()).getClass());
+                    List<ActionBase> actions = handlers.get(message.target);
+                    for (ActionBase action: actions) {
+                        action.invoke(args.toArray());
+                    }
                 }
             }
         };

--- a/clients/java/signalr/src/test/java/HubConnectionTest.java
+++ b/clients/java/signalr/src/test/java/HubConnectionTest.java
@@ -19,6 +19,46 @@ public class HubConnectionTest {
         assertFalse(hubConnection.connected);
     }
 
+    @Test
+    public void RegisteringMultipleHandlersAndBothGetTriggered() throws Exception {
+
+        AtomicReference<Double> value = new AtomicReference<>(0.0);
+        Transport mockTransport = new MockEchoTransport();
+        HubConnection hubConnection = new HubConnection("http://example.com", mockTransport);
+        Action action = () -> value.getAndSet(value.get() + 1);
+
+        hubConnection.on("inc", action);
+        hubConnection.on("inc", action);
+
+        assertEquals(0.0, value.get(), 0);
+
+        hubConnection.start();
+        hubConnection.send("inc");
+
+        // Confirming that our handler was called and that the counter property was incremented.
+        assertEquals(2, value.get(), 0);
+    }
+
+    @Test
+    public void RegisteringMultipleHandlersThatTakeParamsAndBothGetTriggered() throws Exception {
+        AtomicReference<Double> value = new AtomicReference<>(0.0);
+        Transport mockTransport = new MockEchoTransport();
+        HubConnection hubConnection = new HubConnection("http://example.com", mockTransport);
+
+        Action1<Double>  action= (number) -> value.getAndSet(value.get() + number);
+
+        hubConnection.on("add", action, Double.class);
+        hubConnection.on("add", action, Double.class);
+
+        assertEquals(0, value.get(), 0);
+        hubConnection.start();
+        hubConnection.send("add", 12);
+
+        // Confirming that our handler was called and the correct message was passed in.
+        assertEquals(24, value.get(), 0);
+    }
+
+
     // We're using AtomicReference<Double> in the send tests instead of int here because Gson has trouble deserializing to Integer
     @Test
     public void SendWithNoParamsTriggersOnHandler() throws Exception {


### PR DESCRIPTION
Issue: https://github.com/aspnet/SignalR/issues/2588

This allows you to do 
```java
hubConnection.on("target", () -> { /* Do something */}, example.class);
hubConnection.on("target", () -> { /*Do something else */}, example2.class);
```
And both actions will be run when we receive and invocation for "target"

Was going to add the `Remove` in another PR