### PR TITLE
Remove test dependency on Microsoft.Extensions.Buffers.Testing.Sources

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -37,7 +37,6 @@
     <MicrosoftEntityFrameworkCoreDesignPackageVersion>2.1.1</MicrosoftEntityFrameworkCoreDesignPackageVersion>
     <MicrosoftEntityFrameworkCoreSqlServerPackageVersion>2.1.1</MicrosoftEntityFrameworkCoreSqlServerPackageVersion>
     <MicrosoftEntityFrameworkCoreToolsPackageVersion>2.1.1</MicrosoftEntityFrameworkCoreToolsPackageVersion>
-    <MicrosoftExtensionsBuffersTestingSourcesPackageVersion>2.1.1</MicrosoftExtensionsBuffersTestingSourcesPackageVersion>
     <MicrosoftExtensionsClosedGenericMatcherSourcesPackageVersion>2.1.1</MicrosoftExtensionsClosedGenericMatcherSourcesPackageVersion>
     <MicrosoftExtensionsCommandLineUtilsSourcesPackageVersion>2.1.1</MicrosoftExtensionsCommandLineUtilsSourcesPackageVersion>
     <MicrosoftExtensionsConfigurationCommandLinePackageVersion>2.1.1</MicrosoftExtensionsConfigurationCommandLinePackageVersion>

--- a/test/Microsoft.AspNetCore.Http.Connections.Tests/BufferSegment.cs
+++ b/test/Microsoft.AspNetCore.Http.Connections.Tests/BufferSegment.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Buffers
+{
+    internal class BufferSegment : ReadOnlySequenceSegment<byte>
+    {
+        public BufferSegment(Memory<byte> memory)
+        {
+            Memory = memory;
+        }
+
+        public BufferSegment Append(Memory<byte> memory)
+        {
+            var segment = new BufferSegment(memory)
+            {
+                RunningIndex = RunningIndex + Memory.Length
+            };
+            Next = segment;
+            return segment;
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Http.Connections.Tests/Microsoft.AspNetCore.Http.Connections.Tests.csproj
+++ b/test/Microsoft.AspNetCore.Http.Connections.Tests/Microsoft.AspNetCore.Http.Connections.Tests.csproj
@@ -19,7 +19,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Core" Version="$(MicrosoftAspNetCoreAuthenticationCorePackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="$(MicrosoftAspNetCoreHttpPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Buffers.Testing.Sources" Version="$(MicrosoftExtensionsBuffersTestingSourcesPackageVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
   </ItemGroup>
 

--- a/test/Microsoft.AspNetCore.Http.Connections.Tests/ReadOnlySequenceFactory.cs
+++ b/test/Microsoft.AspNetCore.Http.Connections.Tests/ReadOnlySequenceFactory.cs
@@ -1,0 +1,86 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Text;
+
+namespace System.Buffers
+{
+    internal abstract class ReadOnlySequenceFactory
+    {
+        public static ReadOnlySequenceFactory SegmentPerByteFactory { get; } = new BytePerSegmentTestSequenceFactory();
+
+        public abstract ReadOnlySequence<byte> CreateOfSize(int size);
+        public abstract ReadOnlySequence<byte> CreateWithContent(byte[] data);
+
+        public ReadOnlySequence<byte> CreateWithContent(string data)
+        {
+            return CreateWithContent(Encoding.ASCII.GetBytes(data));
+        }
+
+        internal class BytePerSegmentTestSequenceFactory : ReadOnlySequenceFactory
+        {
+            public override ReadOnlySequence<byte> CreateOfSize(int size)
+            {
+                return CreateWithContent(new byte[size]);
+            }
+
+            public override ReadOnlySequence<byte> CreateWithContent(byte[] data)
+            {
+                var segments = new List<byte[]>();
+
+                segments.Add(Array.Empty<byte>());
+                foreach (var b in data)
+                {
+                    segments.Add(new[] { b });
+                    segments.Add(Array.Empty<byte>());
+                }
+
+                return CreateSegments(segments.ToArray());
+            }
+        }
+
+        public static ReadOnlySequence<byte> CreateSegments(params byte[][] inputs)
+        {
+            if (inputs == null || inputs.Length == 0)
+            {
+                throw new InvalidOperationException();
+            }
+
+            int i = 0;
+
+            BufferSegment last = null;
+            BufferSegment first = null;
+
+            do
+            {
+                byte[] s = inputs[i];
+                int length = s.Length;
+                int dataOffset = length;
+                var chars = new byte[length * 2];
+
+                for (int j = 0; j < length; j++)
+                {
+                    chars[dataOffset + j] = s[j];
+                }
+
+                // Create a segment that has offset relative to the OwnedMemory and OwnedMemory itself has offset relative to array
+                var memory = new Memory<byte>(chars).Slice(length, length);
+
+                if (first == null)
+                {
+                    first = new BufferSegment(memory);
+                    last = first;
+                }
+                else
+                {
+                    last = last.Append(memory);
+                }
+                i++;
+            } while (i < inputs.Length);
+
+            return new ReadOnlySequence<byte>(first, 0, last, last.Memory.Length);
+        }
+    }
+}


### PR DESCRIPTION
This source code use to live in common. This puts a copy of the source code here instead of pulling it via package reference.

cref https://github.com/aspnet/Common/pull/386