### PR TITLE
HubConnection state enum

### DIFF
--- a/clients/java/signalr/src/main/java/HubConnection.java
+++ b/clients/java/signalr/src/main/java/HubConnection.java
@@ -16,7 +16,7 @@ public class HubConnection {
     private HubProtocol protocol;
     private Gson gson = new Gson();
 
-    public Boolean connected = false;
+    public HubConnectionState connectionState = HubConnectionState.DISCONNECTED;
 
     public HubConnection(String url, Transport transport){
         this.url = url;
@@ -71,12 +71,12 @@ public class HubConnection {
     public void start() throws InterruptedException {
         transport.setOnReceive(this.callback);
         transport.start();
-        connected = true;
+        connectionState = HubConnectionState.CONNECTED;
     }
 
     public void stop(){
         transport.stop();
-        connected = false;
+        connectionState = HubConnectionState.DISCONNECTED;
     }
 
     public void send(String method, Object... args) throws Exception {

--- a/clients/java/signalr/src/main/java/HubConnection.java
+++ b/clients/java/signalr/src/main/java/HubConnection.java
@@ -15,8 +15,7 @@ public class HubConnection {
     private CallbackMap handlers = new CallbackMap();
     private HubProtocol protocol;
     private Gson gson = new Gson();
-
-    public HubConnectionState connectionState = HubConnectionState.DISCONNECTED;
+    private HubConnectionState connectionState = HubConnectionState.DISCONNECTED;
 
     public HubConnection(String url, Transport transport){
         this.url = url;
@@ -66,6 +65,10 @@ public class HubConnection {
 
     public HubConnection(String url) {
         this(url, null);
+    }
+
+    public HubConnectionState getConnectionState() {
+        return connectionState;
     }
 
     public void start() throws InterruptedException {

--- a/clients/java/signalr/src/main/java/HubConnectionState.java
+++ b/clients/java/signalr/src/main/java/HubConnectionState.java
@@ -1,0 +1,7 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+public enum HubConnectionState {
+    CONNECTED,
+    DISCONNECTED,
+}

--- a/clients/java/signalr/src/test/java/HubConnectionTest.java
+++ b/clients/java/signalr/src/test/java/HubConnectionTest.java
@@ -13,10 +13,10 @@ public class HubConnectionTest {
         Transport mockTransport = new MockEchoTransport();
         HubConnection hubConnection = new HubConnection("http://example.com", mockTransport);
         hubConnection.start();
-        assertTrue(hubConnection.connected);
+        assertEquals(HubConnectionState.CONNECTED, hubConnection.connectionState);
 
         hubConnection.stop();
-        assertFalse(hubConnection.connected);
+        assertEquals(HubConnectionState.DISCONNECTED, hubConnection.connectionState);
     }
 
     @Test

--- a/clients/java/signalr/src/test/java/HubConnectionTest.java
+++ b/clients/java/signalr/src/test/java/HubConnectionTest.java
@@ -13,10 +13,10 @@ public class HubConnectionTest {
         Transport mockTransport = new MockEchoTransport();
         HubConnection hubConnection = new HubConnection("http://example.com", mockTransport);
         hubConnection.start();
-        assertEquals(HubConnectionState.CONNECTED, hubConnection.connectionState);
+        assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
 
         hubConnection.stop();
-        assertEquals(HubConnectionState.DISCONNECTED, hubConnection.connectionState);
+        assertEquals(HubConnectionState.DISCONNECTED, hubConnection.getConnectionState());
     }
 
     @Test


### PR DESCRIPTION
Changing how we expose the HubConnection connection status from a bool to an enum