### PR TITLE
Remove handlers from HubConnection

### DIFF
--- a/clients/java/signalr/src/main/java/CallbackMap.java
+++ b/clients/java/signalr/src/main/java/CallbackMap.java
@@ -24,5 +24,8 @@ public class CallbackMap {
     public List<ActionBase> get(String key){
         return handlers.get(key);
     }
+
+    public void remove(String key) { handlers.remove(key); }
+
 }
 

--- a/clients/java/signalr/src/main/java/CallbackMap.java
+++ b/clients/java/signalr/src/main/java/CallbackMap.java
@@ -17,11 +17,11 @@ public class CallbackMap {
         handlers.computeIfAbsent(target, (ac) -> new ArrayList<>(Arrays.asList(action)));
     }
 
-    public Boolean containsKey(String key){
+    public Boolean containsKey(String key) {
         return handlers.containsKey(key);
     }
 
-    public List<ActionBase> get(String key){
+    public List<ActionBase> get(String key) {
         return handlers.get(key);
     }
 

--- a/clients/java/signalr/src/main/java/CallbackMap.java
+++ b/clients/java/signalr/src/main/java/CallbackMap.java
@@ -25,7 +25,8 @@ public class CallbackMap {
         return handlers.get(key);
     }
 
-    public void remove(String key) { handlers.remove(key); }
-
+    public void remove(String key) {
+        handlers.remove(key);
+    }
 }
 

--- a/clients/java/signalr/src/main/java/HubConnection.java
+++ b/clients/java/signalr/src/main/java/HubConnection.java
@@ -127,7 +127,7 @@ public class HubConnection {
         handlers.put(target, action);
     }
 
-    public void remove(String name){
+    public void remove(String name) {
         handlers.remove(name);
     }
 }

--- a/clients/java/signalr/src/main/java/HubConnection.java
+++ b/clients/java/signalr/src/main/java/HubConnection.java
@@ -126,4 +126,8 @@ public class HubConnection {
         };
         handlers.put(target, action);
     }
+
+    public void remove(String name){
+        handlers.remove(name);
+    }
 }

--- a/clients/java/signalr/src/main/java/HubConnection.java
+++ b/clients/java/signalr/src/main/java/HubConnection.java
@@ -17,7 +17,7 @@ public class HubConnection {
     private Gson gson = new Gson();
     private HubConnectionState connectionState = HubConnectionState.DISCONNECTED;
 
-    public HubConnection(String url, Transport transport){
+    public HubConnection(String url, Transport transport) {
         this.url = url;
         this.protocol = new JsonHubProtocol();
         this.callback = (payload) -> {

--- a/clients/java/signalr/src/test/java/HubConnectionTest.java
+++ b/clients/java/signalr/src/test/java/HubConnectionTest.java
@@ -40,6 +40,76 @@ public class HubConnectionTest {
     }
 
     @Test
+    public void RemoveHandlerByName() throws Exception {
+
+        AtomicReference<Double> value = new AtomicReference<>(0.0);
+        Transport mockTransport = new MockEchoTransport();
+        HubConnection hubConnection = new HubConnection("http://example.com", mockTransport);
+        Action action = () -> value.getAndUpdate((val) -> val + 1);
+
+        hubConnection.on("inc", action);
+
+        assertEquals(0.0, value.get(), 0);
+
+        hubConnection.start();
+        hubConnection.send("inc");
+
+        // Confirming that our handler was called and that the counter property was incremented.
+        assertEquals(1, value.get(), 0);
+
+        hubConnection.remove("inc");
+        hubConnection.send("inc");
+        assertEquals(1, value.get(), 0);
+    }
+
+    @Test
+    public void AddAndRemoveHandlerImmediately() throws Exception {
+
+        AtomicReference<Double> value = new AtomicReference<>(0.0);
+        Transport mockTransport = new MockEchoTransport();
+        HubConnection hubConnection = new HubConnection("http://example.com", mockTransport);
+        Action action = () -> value.getAndUpdate((val) -> val + 1);
+
+        hubConnection.on("inc", action);
+        hubConnection.remove("inc");
+
+        assertEquals(0.0, value.get(), 0);
+
+        hubConnection.start();
+        hubConnection.send("inc");
+
+        // Confirming that the handler was removed.
+        assertEquals(0, value.get(), 0);
+    }
+
+    @Test
+    public void RemovingMultipleHandlersWithOneCallToRemove() throws Exception {
+
+        AtomicReference<Double> value = new AtomicReference<>(0.0);
+        Transport mockTransport = new MockEchoTransport();
+        HubConnection hubConnection = new HubConnection("http://example.com", mockTransport);
+        Action action = () -> value.getAndUpdate((val) -> val + 1);
+        Action secondAction = () -> value.getAndUpdate((val) -> val + 2);
+
+        hubConnection.on("inc", action);
+        hubConnection.on("inc", secondAction);
+
+
+        assertEquals(0.0, value.get(), 0);
+
+        hubConnection.start();
+        hubConnection.send("inc");
+
+        assertEquals(3, value.get(), 0);
+
+        hubConnection.remove("inc");
+        hubConnection.send("inc");
+
+        // Confirm that another invocation doesn't change anything because the handlers have been removed.
+        assertEquals(3, value.get(), 0);
+    }
+
+    @Test
     public void RegisteringMultipleHandlersThatTakeParamsAndBothGetTriggered() throws Exception {
         AtomicReference<Double> value = new AtomicReference<>(0.0);
         Transport mockTransport = new MockEchoTransport();

--- a/clients/java/signalr/src/test/java/HubConnectionTest.java
+++ b/clients/java/signalr/src/test/java/HubConnectionTest.java
@@ -41,7 +41,6 @@ public class HubConnectionTest {
 
     @Test
     public void RemoveHandlerByName() throws Exception {
-
         AtomicReference<Double> value = new AtomicReference<>(0.0);
         Transport mockTransport = new MockEchoTransport();
         HubConnection hubConnection = new HubConnection("http://example.com", mockTransport);

--- a/clients/java/signalr/src/test/java/HubConnectionTest.java
+++ b/clients/java/signalr/src/test/java/HubConnectionTest.java
@@ -94,7 +94,6 @@ public class HubConnectionTest {
         hubConnection.on("inc", action);
         hubConnection.on("inc", secondAction);
 
-
         assertEquals(0.0, value.get(), 0);
 
         hubConnection.start();
@@ -127,7 +126,6 @@ public class HubConnectionTest {
         // Confirming that our handler was called and the correct message was passed in.
         assertEquals(24, value.get(), 0);
     }
-
 
     // We're using AtomicReference<Double> in the send tests instead of int here because Gson has trouble deserializing to Integer
     @Test


### PR DESCRIPTION
This pr lets users remove all handlers from a HubConnection for a certain target. 
I'll add the ability to remove specific handlers with a `Subscription` type similar to what I added in the C# where where we dispose that object to remove the associated single handler.
Issue: https://github.com/aspnet/SignalR/issues/2615