### PR TITLE
Adding MinorVersion field to HandshakeResponse in TS client

### DIFF
--- a/clients/ts/signalr/src/HandshakeProtocol.ts
+++ b/clients/ts/signalr/src/HandshakeProtocol.ts
@@ -10,6 +10,7 @@ export interface HandshakeRequestMessage {
 
 export interface HandshakeResponseMessage {
     readonly error: string;
+    readonly minorVersion: number;
 }
 
 export class HandshakeProtocol {


### PR DESCRIPTION
Just adding the field to the interface for 3.0. Both this client and the C# client don't actually utilize it yet.