### PR TITLE
Fix race when connection is canceled and new poll comes in

### DIFF
--- a/src/Microsoft.AspNetCore.Http.Connections/Internal/HttpConnectionContext.cs
+++ b/src/Microsoft.AspNetCore.Http.Connections/Internal/HttpConnectionContext.cs
@@ -88,6 +88,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
 
         public Task TransportTask { get; set; }
 
+        public Task PreviousPollTask { get; set; } = Task.CompletedTask;
+
         public Task ApplicationTask { get; set; }
 
         public DateTime LastSeenUtc { get; set; }

--- a/src/Microsoft.AspNetCore.Http.Connections/Internal/HttpConnectionDispatcher.cs
+++ b/src/Microsoft.AspNetCore.Http.Connections/Internal/HttpConnectionDispatcher.cs
@@ -217,6 +217,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
 
                         // Always wait for the previous request to drain
                         await connection.PreviousPollTask;
+                        connection.PreviousPollTask = currentRequestTcs.Task;
                     }
 
                     // Mark the connection as active
@@ -256,8 +257,6 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
 
                         // Start the transport
                         connection.TransportTask = longPolling.ProcessRequestAsync(context, tokenSource.Token);
-
-                        connection.PreviousPollTask = currentRequestTcs.Task;
 
                         // Start the timeout after we return from creating the transport task
                         timeoutSource.CancelAfter(options.LongPolling.PollTimeout);

--- a/src/Microsoft.AspNetCore.Http.Connections/Internal/HttpConnectionDispatcher.cs
+++ b/src/Microsoft.AspNetCore.Http.Connections/Internal/HttpConnectionDispatcher.cs
@@ -217,6 +217,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
 
                         // Always wait for the previous request to drain
                         await connection.PreviousPollTask;
+
                         connection.PreviousPollTask = currentRequestTcs.Task;
                     }
 

--- a/src/Microsoft.AspNetCore.Http.Connections/Internal/HttpConnectionDispatcher.cs
+++ b/src/Microsoft.AspNetCore.Http.Connections/Internal/HttpConnectionDispatcher.cs
@@ -188,6 +188,9 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
                     return;
                 }
 
+                // Create a new Tcs every poll to keep track of the poll finishing, so we can properly wait on previous polls
+                var currentRequestTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+
                 await connection.StateLock.WaitAsync();
                 try
                 {
@@ -205,17 +208,15 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
                     {
                         var existing = connection.GetHttpContext();
                         Log.ConnectionAlreadyActive(_logger, connection.ConnectionId, existing.TraceIdentifier);
+                    }
 
-                        using (connection.Cancellation)
-                        {
-                            // Cancel the previous request
-                            connection.Cancellation?.Cancel();
+                    using (connection.Cancellation)
+                    {
+                        // Cancel the previous request
+                        connection.Cancellation?.Cancel();
 
-                            // Wait for the previous request to drain
-                            await connection.TransportTask;
-
-                            Log.PollCanceled(_logger, connection.ConnectionId, existing.TraceIdentifier);
-                        }
+                        // Always wait for the previous request to drain
+                        await connection.PreviousPollTask;
                     }
 
                     // Mark the connection as active
@@ -256,6 +257,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
                         // Start the transport
                         connection.TransportTask = longPolling.ProcessRequestAsync(context, tokenSource.Token);
 
+                        connection.PreviousPollTask = currentRequestTcs.Task;
+
                         // Start the timeout after we return from creating the transport task
                         timeoutSource.CancelAfter(options.LongPolling.PollTimeout);
                     }
@@ -267,64 +270,61 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
 
                 var resultTask = await Task.WhenAny(connection.ApplicationTask, connection.TransportTask);
 
-                var pollAgain = true;
-
-                // If the application ended before the transport task then we potentially need to end the connection
-                if (resultTask == connection.ApplicationTask)
+                try
                 {
-                    // Complete the transport (notifying it of the application error if there is one)
-                    connection.Transport.Output.Complete(connection.ApplicationTask.Exception);
+                    var pollAgain = true;
 
-                    // Wait for the transport to run
-                    await connection.TransportTask;
-
-                    // If the status code is a 204 it means the connection is done
-                    if (context.Response.StatusCode == StatusCodes.Status204NoContent)
+                    // If the application ended before the transport task then we potentially need to end the connection
+                    if (resultTask == connection.ApplicationTask)
                     {
-                        // We should be able to safely dispose because there's no more data being written
-                        // We don't need to wait for close here since we've already waited for both sides
-                        await _manager.DisposeAndRemoveAsync(connection, closeGracefully: false);
+                        // Complete the transport (notifying it of the application error if there is one)
+                        connection.Transport.Output.Complete(connection.ApplicationTask.Exception);
 
-                        // Don't poll again if we've removed the connection completely
-                        pollAgain = false;
-                    }
-                }
-                else if (resultTask.IsFaulted)
-                {
-                    // transport task was faulted, we should remove the connection
-                    await _manager.DisposeAndRemoveAsync(connection, closeGracefully: false);
+                        // Wait for the transport to run
+                        await connection.TransportTask;
 
-                    pollAgain = false;
-                }
-                else if (context.Response.StatusCode == StatusCodes.Status204NoContent)
-                {
-                    // Don't poll if the transport task was canceled
-                    pollAgain = false;
-                }
-
-                if (pollAgain)
-                {
-                    // Otherwise, we update the state to inactive again and wait for the next poll
-                    await connection.StateLock.WaitAsync();
-                    try
-                    {
-                        if (connection.Status == HttpConnectionStatus.Active)
+                        // If the status code is a 204 it means the connection is done
+                        if (context.Response.StatusCode == StatusCodes.Status204NoContent)
                         {
-                            // Mark the connection as inactive
-                            connection.LastSeenUtc = DateTime.UtcNow;
+                            // We should be able to safely dispose because there's no more data being written
+                            // We don't need to wait for close here since we've already waited for both sides
+                            await _manager.DisposeAndRemoveAsync(connection, closeGracefully: false);
 
-                            connection.Status = HttpConnectionStatus.Inactive;
-
-                            // Dispose the cancellation token
-                            connection.Cancellation?.Dispose();
-
-                            connection.Cancellation = null;
+                            // Don't poll again if we've removed the connection completely
+                            pollAgain = false;
                         }
                     }
-                    finally
+                    else if (resultTask.IsFaulted)
                     {
-                        connection.StateLock.Release();
+                        // transport task was faulted, we should remove the connection
+                        await _manager.DisposeAndRemoveAsync(connection, closeGracefully: false);
+
+                        pollAgain = false;
                     }
+                    else if (context.Response.StatusCode == StatusCodes.Status204NoContent)
+                    {
+                        // Don't poll if the transport task was canceled
+                        pollAgain = false;
+                    }
+
+                    if (pollAgain)
+                    {
+                        // Mark the connection as inactive
+                        connection.LastSeenUtc = DateTime.UtcNow;
+
+                        connection.Status = HttpConnectionStatus.Inactive;
+
+                        // Dispose the cancellation token
+                        connection.Cancellation?.Dispose();
+
+                        connection.Cancellation = null;
+                    }
+                }
+                finally
+                {
+                    // Artificial task queue
+                    // This will cause incoming polls to wait until the previous poll has finished updating internal state info
+                    currentRequestTcs.TrySetResult(null);
                 }
             }
         }


### PR DESCRIPTION
#2700
There was a race where we could set the connection state to `Inactive` even though there was an active poll which could cause the connection to be closed by the server.

The fix was to add a "task queue" so all new poll requests would wait until the previous poll finished all state updates before starting the new poll state updates.


Details:
Browser could abort the http request (normal timeout behavior) and then send a new poll, on the server we might start processing the poll and see that there is an active poll which we could proceed to cancel and wait for the transport task to finish. The transport task would get an operation canceled exception and see that the http request was aborted so would just return normally, Then it would proceed to wait for the state lock which the new poll is currently holding, the new poll would see the transport task is finished and set the status as active and start the new transport task and then release the lock. Now the previous poll can aquire the lock, see that the connection is active (which it assumed was from when it polled) and set it to inactive. Then our heartbeat would come along 5 seconds later and clean the connection up.

TLDR:
Poll is canceled by client, client sends new poll, race between previous poll and new poll where status could be set as inactive and heartbeat could clean up connection.