### PR TITLE
Don't send WebSocketCloseStatus.Empty, it's invalid

### DIFF
--- a/test/Microsoft.AspNetCore.SignalR.Tests/EndToEndTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/EndToEndTests.cs
@@ -118,10 +118,11 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                     Assert.Equal(bytes, buffer.Array.AsSpan(0, result.Count).ToArray());
 
                     logger.LogInformation("Closing socket");
-                    await ws.CloseOutputAsync(WebSocketCloseStatus.Empty, "", CancellationToken.None).OrTimeout();
+                    await ws.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, "", CancellationToken.None).OrTimeout();
                     logger.LogInformation("Waiting for close");
                     result = await ws.ReceiveAsync(buffer, CancellationToken.None).OrTimeout();
                     Assert.Equal(WebSocketMessageType.Close, result.MessageType);
+                    Assert.Equal(WebSocketCloseStatus.NormalClosure, result.CloseStatus);
                     logger.LogInformation("Closed socket");
                 }
             }
@@ -156,10 +157,11 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                     Assert.Equal(bytes, buffer.Array.AsSpan(0, result.Count).ToArray());
 
                     logger.LogInformation("Closing socket");
-                    await ws.CloseOutputAsync(WebSocketCloseStatus.Empty, "", CancellationToken.None).OrTimeout();
+                    await ws.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, "", CancellationToken.None).OrTimeout();
                     logger.LogInformation("Waiting for close");
                     result = await ws.ReceiveAsync(buffer, CancellationToken.None).OrTimeout();
                     Assert.Equal(WebSocketMessageType.Close, result.MessageType);
+                    Assert.Equal(WebSocketCloseStatus.NormalClosure, result.CloseStatus);
                     logger.LogInformation("Closed socket");
                 }
             }


### PR DESCRIPTION
Turns out this is a protocol violation:

> 1005 is a reserved value and MUST NOT be set as a status code in a
Close control frame by an endpoint.  It is designated for use in applications expecting a status code to indicate that no status code was actually present.

