### PR TITLE
Honor InherentKeepAliveFeature for server timeout

### DIFF
--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.cs
@@ -121,7 +121,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
         }
 
         [Fact]
-        public async Task InherentKeepAliveFeatureCanPreventServerTimeout()
+        public async Task ServerTimeoutIsDisabledWhenUsingTransportWithInherentKeepAlive()
         {
             using (StartVerifiableLog(out var loggerFactory))
             {
@@ -139,7 +139,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                     return Task.CompletedTask;
                 };
 
-                await Task.Delay(1000);
+                await hubConnection.RunTimerActions().OrTimeout();
 
                 Assert.False(closeTcs.Task.IsCompleted);
 

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/HubConnectionTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Buffers;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Connections.Features;
 using Microsoft.AspNetCore.SignalR.Protocol;
 using Microsoft.AspNetCore.SignalR.Tests;
 using Microsoft.Extensions.DependencyInjection;
@@ -120,6 +121,33 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
         }
 
         [Fact]
+        public async Task InherentKeepAliveFeatureCanPreventServerTimeout()
+        {
+            using (StartVerifiableLog(out var loggerFactory))
+            {
+                var testConnection = new TestConnection();
+                testConnection.Features.Set<IConnectionInherentKeepAliveFeature>(new TestKeepAliveFeature() { HasInherentKeepAlive = true });
+                var hubConnection = CreateHubConnection(testConnection, loggerFactory: loggerFactory);
+                hubConnection.ServerTimeout = TimeSpan.FromMilliseconds(1);
+
+                await hubConnection.StartAsync().OrTimeout();
+
+                var closeTcs = new TaskCompletionSource<Exception>();
+                hubConnection.Closed += ex =>
+                {
+                    closeTcs.TrySetResult(ex);
+                    return Task.CompletedTask;
+                };
+
+                await Task.Delay(1000);
+
+                Assert.False(closeTcs.Task.IsCompleted);
+
+                await hubConnection.DisposeAsync().OrTimeout();
+            }
+        }
+
+        [Fact]
         public async Task PendingInvocationsAreTerminatedIfServerTimeoutIntervalElapsesWithNoMessages()
         {
             bool ExpectedErrors(WriteContext writeContext)
@@ -143,6 +171,11 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                 // We use an interpolated string so the tests are accurate on non-US machines.
                 Assert.Equal($"Server timeout ({hubConnection.ServerTimeout.TotalMilliseconds:0.00}ms) elapsed without receiving a message from the server.", exception.Message);
             }
+        }
+
+        private struct TestKeepAliveFeature : IConnectionInherentKeepAliveFeature
+        {
+            public bool HasInherentKeepAlive { get; set; }
         }
 
         // Moq really doesn't handle out parameters well, so to make these tests work I added a manual mock -anurse


### PR DESCRIPTION
#2717 

Not a fan of using a delay for a timeout test, but couldn't think of a better way...