### PR TITLE
Solve LongPolling races by moving Cts disposal to connection disposal

### DIFF
--- a/src/Microsoft.AspNetCore.Http.Connections/Internal/HttpConnectionDispatcher.cs
+++ b/src/Microsoft.AspNetCore.Http.Connections/Internal/HttpConnectionDispatcher.cs
@@ -313,10 +313,6 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
                         connection.LastSeenUtc = DateTime.UtcNow;
 
                         connection.Status = HttpConnectionStatus.Inactive;
-
-                        connection.Cancellation?.Cancel();
-
-                        connection.Cancellation = null;
                     }
                 }
                 finally

--- a/src/Microsoft.AspNetCore.Http.Connections/Internal/HttpConnectionManager.cs
+++ b/src/Microsoft.AspNetCore.Http.Connections/Internal/HttpConnectionManager.cs
@@ -194,6 +194,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
         {
             try
             {
+                connection.Cancellation?.Dispose();
+
                 await connection.DisposeAsync(closeGracefully);
             }
             catch (IOException ex)


### PR DESCRIPTION
When we changed the code to be cancel we started hitting https://github.com/dotnet/corefx/issues/31587

But we realized we could move the cts disposal to only dispose on connection closure because new polls already dispose the previous token.