### PR TITLE
Use prototype JsonLab Reader and Writer APIs in various protocols

### DIFF
--- a/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/HandshakeProtocolBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/HandshakeProtocolBenchmark.cs
@@ -1,0 +1,127 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Buffers;
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using Microsoft.AspNetCore.Internal;
+using Microsoft.AspNetCore.SignalR.Protocol;
+
+namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
+{
+    public class HandshakeProtocolBenchmark
+    {
+        ReadOnlySequence<byte> _requestMessage1;
+        ReadOnlySequence<byte> _requestMessage2;
+        ReadOnlySequence<byte> _requestMessage3;
+        ReadOnlySequence<byte> _requestMessage4;
+
+        ReadOnlySequence<byte> _responseMessage1;
+        ReadOnlySequence<byte> _responseMessage2;
+        ReadOnlySequence<byte> _responseMessage3;
+        ReadOnlySequence<byte> _responseMessage4;
+        ReadOnlySequence<byte> _responseMessage5;
+        ReadOnlySequence<byte> _responseMessage6;
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            _requestMessage1 = new ReadOnlySequence<byte>(Encoding.UTF8.GetBytes("{\"protocol\":\"dummy\",\"version\":1}\u001e"));
+            _requestMessage2 = new ReadOnlySequence<byte>(Encoding.UTF8.GetBytes("{\"protocol\":\"\",\"version\":10}\u001e"));
+            _requestMessage3 = new ReadOnlySequence<byte>(Encoding.UTF8.GetBytes("{\"protocol\":\"\",\"version\":10,\"unknown\":null}\u001e"));
+            _requestMessage4 = new ReadOnlySequence<byte>(Encoding.UTF8.GetBytes("42"));
+
+            _responseMessage1 = new ReadOnlySequence<byte>(Encoding.UTF8.GetBytes("{\"error\":\"dummy\"}\u001e"));
+            _responseMessage2 = new ReadOnlySequence<byte>(Encoding.UTF8.GetBytes("{\"error\":\"\"}\u001e"));
+            _responseMessage3 = new ReadOnlySequence<byte>(Encoding.UTF8.GetBytes("{}\u001e"));
+            _responseMessage4 = new ReadOnlySequence<byte>(Encoding.UTF8.GetBytes("{\"unknown\":null}\u001e"));
+            _responseMessage5 = new ReadOnlySequence<byte>(Encoding.UTF8.GetBytes("{\"error\":\"\",\"minorVersion\":34}\u001e"));
+            _responseMessage6 = new ReadOnlySequence<byte>(Encoding.UTF8.GetBytes("{\"error\":\"flump flump flump\",\"minorVersion\":112}\u001e"));
+        }
+
+        //[Benchmark]
+        public void HandShakeWriteResponseEmpty_MemoryBufferWriter()
+        {
+            var writer = MemoryBufferWriter.Get();
+            try
+            {
+                HandshakeProtocol.WriteResponseMessage(HandshakeResponseMessage.Empty, writer);
+            }
+            finally
+            {
+                MemoryBufferWriter.Return(writer);
+            }
+        }
+
+        //[Benchmark]
+        public void HandShakeWriteResponse_MemoryBufferWriter()
+        {
+            ReadOnlyMemory<byte> result;
+            var memoryBufferWriter = MemoryBufferWriter.Get();
+            try
+            {
+                HandshakeProtocol.WriteResponseMessage(new HandshakeResponseMessage(1), memoryBufferWriter);
+                result = memoryBufferWriter.ToArray();
+            }
+            finally
+            {
+                MemoryBufferWriter.Return(memoryBufferWriter);
+            }
+        }
+
+        //[Benchmark]
+        public void HandShakeWriteRequest_MemoryBufferWriter()
+        {
+            var memoryBufferWriter = MemoryBufferWriter.Get();
+            try
+            {
+                HandshakeProtocol.WriteRequestMessage(new HandshakeRequestMessage("json", 1), memoryBufferWriter);
+            }
+            finally
+            {
+                MemoryBufferWriter.Return(memoryBufferWriter);
+            }
+        }
+
+        [Benchmark]
+        public void ParsingHandshakeRequestMessage_ValidMessage1()
+            => HandshakeProtocol.TryParseRequestMessage(ref _requestMessage1, out var deserializedMessage);
+
+        [Benchmark]
+        public void ParsingHandshakeRequestMessage_ValidMessage2()
+            => HandshakeProtocol.TryParseRequestMessage(ref _requestMessage2, out var deserializedMessage);
+
+        [Benchmark]
+        public void ParsingHandshakeRequestMessage_ValidMessage3()
+            => HandshakeProtocol.TryParseRequestMessage(ref _requestMessage3, out var deserializedMessage);
+
+        [Benchmark]
+        public void ParsingHandshakeRequestMessage_NotComplete1()
+            => HandshakeProtocol.TryParseRequestMessage(ref _requestMessage4, out _);
+
+        [Benchmark]
+        public void ParsingHandshakeResponseMessage_ValidMessages1()
+            => HandshakeProtocol.TryParseResponseMessage(ref _responseMessage1, out var response);
+
+        [Benchmark]
+        public void ParsingHandshakeResponseMessage_ValidMessages2()
+            => HandshakeProtocol.TryParseResponseMessage(ref _responseMessage2, out var response);
+
+        [Benchmark]
+        public void ParsingHandshakeResponseMessage_ValidMessages3()
+            => HandshakeProtocol.TryParseResponseMessage(ref _responseMessage3, out var response);
+
+        [Benchmark]
+        public void ParsingHandshakeResponseMessage_ValidMessages4() 
+            => HandshakeProtocol.TryParseResponseMessage(ref _responseMessage4, out var response);
+
+        [Benchmark]
+        public void ParsingHandshakeResponseMessage_GivesMinorVersion1()
+            => HandshakeProtocol.TryParseResponseMessage(ref _responseMessage5, out var response);
+
+        [Benchmark]
+        public void ParsingHandshakeResponseMessage_GivesMinorVersion2()
+            => HandshakeProtocol.TryParseResponseMessage(ref _responseMessage6, out var response);
+    }
+}

--- a/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/HandshakeProtocolBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/HandshakeProtocolBenchmark.cs
@@ -40,7 +40,7 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
             _responseMessage6 = new ReadOnlySequence<byte>(Encoding.UTF8.GetBytes("{\"error\":\"flump flump flump\",\"minorVersion\":112}\u001e"));
         }
 
-        //[Benchmark]
+        [Benchmark]
         public void HandShakeWriteResponseEmpty_MemoryBufferWriter()
         {
             var writer = MemoryBufferWriter.Get();
@@ -54,7 +54,7 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
             }
         }
 
-        //[Benchmark]
+        [Benchmark]
         public void HandShakeWriteResponse_MemoryBufferWriter()
         {
             ReadOnlyMemory<byte> result;
@@ -70,7 +70,7 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
             }
         }
 
-        //[Benchmark]
+        [Benchmark]
         public void HandShakeWriteRequest_MemoryBufferWriter()
         {
             var memoryBufferWriter = MemoryBufferWriter.Get();

--- a/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/NegotiateProtocolBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.SignalR.Microbenchmarks/NegotiateProtocolBenchmark.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using Microsoft.AspNetCore.Http.Connections;
@@ -14,6 +15,12 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
     {
         private NegotiationResponse _negotiateResponse;
         private Stream _stream;
+
+        private byte[] _responseData1;
+        private byte[] _responseData2;
+        private byte[] _responseData3;
+        private byte[] _responseData4;
+        private byte[] _responseData5;
 
         [GlobalSetup]
         public void GlobalSetup()
@@ -35,6 +42,15 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
                 }
             };
             _stream = Stream.Null;
+
+            _responseData1 = Encoding.UTF8.GetBytes("{\"connectionId\":\"123\",\"availableTransports\":[]}");
+            _responseData2 = Encoding.UTF8.GetBytes("{\"url\": \"http://foo.com/chat\"}");
+            _responseData3 = Encoding.UTF8.GetBytes("{\"url\": \"http://foo.com/chat\", \"accessToken\": \"token\"}");
+            _responseData4 = Encoding.UTF8.GetBytes("{\"connectionId\":\"123\",\"availableTransports\":[{\"transport\":\"test\",\"transferFormats\":[]}]}");
+
+            var writer = new MemoryBufferWriter();
+            NegotiateProtocol.WriteResponse(_negotiateResponse, writer);
+            _responseData5 = writer.ToArray();
         }
 
         [Benchmark]
@@ -51,5 +67,25 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
                 writer.Reset();
             }
         }
+
+        [Benchmark]
+        public void ParsingNegotiateResponseMessageSuccessForValid1()
+            => NegotiateProtocol.ParseResponse(new MemoryStream(_responseData1));
+
+        [Benchmark]
+        public void ParsingNegotiateResponseMessageSuccessForValid2()
+            => NegotiateProtocol.ParseResponse(new MemoryStream(_responseData2));
+
+        [Benchmark]
+        public void ParsingNegotiateResponseMessageSuccessForValid3()
+            => NegotiateProtocol.ParseResponse(new MemoryStream(_responseData3));
+
+        [Benchmark]
+        public void ParsingNegotiateResponseMessageSuccessForValid4()
+            => NegotiateProtocol.ParseResponse(new MemoryStream(_responseData4));
+
+        [Benchmark]
+        public void ParsingNegotiateResponseMessageSuccessForValid5()
+            => NegotiateProtocol.ParseResponse(new MemoryStream(_responseData5));
     }
 }

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -69,6 +69,7 @@
     <SystemReactiveLinqPackageVersion>3.1.1</SystemReactiveLinqPackageVersion>
     <SystemReflectionEmitPackageVersion>4.3.0</SystemReflectionEmitPackageVersion>
     <SystemRuntimeCompilerServicesUnsafePackageVersion>4.6.0-preview1-26727-04</SystemRuntimeCompilerServicesUnsafePackageVersion>
+    <SystemTextJsonLabPackageVersion>0.1.0-preview2-180804-5</SystemTextJsonLabPackageVersion>
     <SystemThreadingChannelsPackageVersion>4.6.0-preview1-26727-04</SystemThreadingChannelsPackageVersion>
     <SystemThreadingTasksExtensionsPackageVersion>4.6.0-preview1-26727-04</SystemThreadingTasksExtensionsPackageVersion>
     <XunitAssertPackageVersion>2.3.1</XunitAssertPackageVersion>

--- a/build/sources.props
+++ b/build/sources.props
@@ -8,6 +8,7 @@
       https://dotnet.myget.org/F/dotnet-core/api/v3/index.json;
       https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json;
       https://dotnet.myget.org/F/aspnetcore-tools/api/v3/index.json;
+      https://dotnet.myget.org/F/dotnet-corefxlab/api/v3/index.json;
     </RestoreSources>
     <RestoreSources Condition="'$(DotNetBuildOffline)' != 'true'">
       $(RestoreSources);

--- a/src/Common/JsonUtils.cs
+++ b/src/Common/JsonUtils.cs
@@ -3,8 +3,12 @@
 
 using System;
 using System.Buffers;
+using System.Buffers.Text;
 using System.Globalization;
 using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Text.JsonLab;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -80,6 +84,28 @@ namespace Microsoft.AspNetCore.Internal
             return prop.Value<T>();
         }
 
+        public static string GetTokenString(JsonValueType valueType, JsonTokenType tokenType)
+        {
+            switch (valueType)
+            {
+                case JsonValueType.Number:
+                    return "Integer";
+                case JsonValueType.Unknown:
+                    if (tokenType == JsonTokenType.StartArray)
+                    {
+                        return JsonValueType.Array.ToString();
+                    }
+                    if (tokenType == JsonTokenType.StartObject)
+                    {
+                        return JsonValueType.Object.ToString();
+                    }
+                    return tokenType.ToString();
+                default:
+                    break;
+            }
+            return valueType.ToString();
+        }
+
         public static string GetTokenString(JsonToken tokenType)
         {
             switch (tokenType)
@@ -96,6 +122,22 @@ namespace Microsoft.AspNetCore.Internal
                     break;
             }
             return tokenType.ToString();
+        }
+
+        public static void EnsureObjectStart(ref Utf8JsonReader reader)
+        {
+            if (reader.TokenType != JsonTokenType.StartObject)
+            {
+                throw new InvalidDataException($"Unexpected JSON Token Type '{GetTokenString(reader.ValueType, reader.TokenType)}'. Expected a JSON Object.");
+            }
+        }
+
+        public static void EnsureArrayStart(ref Utf8JsonReader reader)
+        {
+            if (reader.TokenType != JsonTokenType.StartArray)
+            {
+                throw new InvalidDataException($"Unexpected JSON Token Type '{GetTokenString(reader.ValueType, reader.TokenType)}'. Expected a JSON Array.");
+            }
         }
 
         public static void EnsureObjectStart(JsonTextReader reader)
@@ -131,6 +173,26 @@ namespace Microsoft.AspNetCore.Internal
             return Convert.ToInt32(reader.Value, CultureInfo.InvariantCulture);
         }
 
+        public static int? ReadAsInt32(ref Utf8JsonReader reader, string propertyName)
+        {
+            reader.Read();
+
+            if (reader.TokenType != JsonTokenType.Value || reader.ValueType != JsonValueType.Number)
+            {
+                throw new InvalidDataException($"Expected '{propertyName}' to be of type {JTokenType.Integer}.");
+            }
+
+            if (reader.Value.IsEmpty)
+            {
+                return null;
+            }
+            if (!Utf8Parser.TryParse(reader.Value, out int value, out _))
+            {
+                throw new InvalidDataException($"Expected '{propertyName}' to be of type {JTokenType.Integer}.");
+            }
+            return value;
+        }
+
         public static string ReadAsString(JsonTextReader reader, string propertyName)
         {
             reader.Read();
@@ -143,7 +205,38 @@ namespace Microsoft.AspNetCore.Internal
             return reader.Value?.ToString();
         }
 
+        public static unsafe string ReadAsString(ref Utf8JsonReader reader, string propertyName)
+        {
+            reader.Read();
+
+            if (reader.TokenType != JsonTokenType.Value || reader.ValueType != JsonValueType.String)
+            {
+                throw new InvalidDataException($"Expected '{propertyName}' to be of type {JTokenType.String}.");
+            }
+
+            if (reader.Value.IsEmpty) return "";
+
+#if NETCOREAPP2_2
+            return Encoding.UTF8.GetString(reader.Value);
+#else
+            fixed (byte* bytes = &MemoryMarshal.GetReference(reader.Value))
+            {
+                return Encoding.UTF8.GetString(bytes, reader.Value.Length);
+            }
+#endif
+        }
+
         public static bool CheckRead(JsonTextReader reader)
+        {
+            if (!reader.Read())
+            {
+                throw new InvalidDataException("Unexpected end when reading JSON.");
+            }
+
+            return true;
+        }
+
+        public static bool CheckRead(ref Utf8JsonReader reader)
         {
             if (!reader.Read())
             {

--- a/src/Microsoft.AspNetCore.Http.Connections.Common/Microsoft.AspNetCore.Http.Connections.Common.csproj
+++ b/src/Microsoft.AspNetCore.Http.Connections.Common/Microsoft.AspNetCore.Http.Connections.Common.csproj
@@ -15,5 +15,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="$(MicrosoftAspNetCoreConnectionsAbstractionsPackageVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
     <PackageReference Include="System.Buffers" Version="$(SystemBuffersPackageVersion)" />
+    <PackageReference Include="System.Text.JsonLab" Version="$(SystemTextJsonLabPackageVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.AspNetCore.Http.Connections.Common/NegotiateProtocol.cs
+++ b/src/Microsoft.AspNetCore.Http.Connections.Common/NegotiateProtocol.cs
@@ -6,8 +6,9 @@ using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
 using Microsoft.AspNetCore.Internal;
-using Newtonsoft.Json;
 using System.Text.JsonLab;
+using System.Threading.Tasks;
+using System.Text;
 
 namespace Microsoft.AspNetCore.Http.Connections
 {
@@ -19,6 +20,13 @@ namespace Microsoft.AspNetCore.Http.Connections
         private const string AvailableTransportsPropertyName = "availableTransports";
         private const string TransportPropertyName = "transport";
         private const string TransferFormatsPropertyName = "transferFormats";
+
+        private static readonly byte[] ConnectionIdPropertyNameUtf8 = Encoding.UTF8.GetBytes("connectionId");
+        private static readonly byte[] UrlPropertyNameUtf8 = Encoding.UTF8.GetBytes("url");
+        private static readonly byte[] AccessTokenPropertyNameUtf8 = Encoding.UTF8.GetBytes("accessToken");
+        private static readonly byte[] AvailableTransportsPropertyNameUtf8 = Encoding.UTF8.GetBytes("availableTransports");
+        private static readonly byte[] TransportPropertyNameUtf8 = Encoding.UTF8.GetBytes("transport");
+        private static readonly byte[] TransferFormatsPropertyNameUtf8 = Encoding.UTF8.GetBytes("transferFormats");
 
         public static void WriteResponse(NegotiationResponse response, IBufferWriter<byte> output)
         {
@@ -70,91 +78,101 @@ namespace Microsoft.AspNetCore.Http.Connections
             jsonWriter.Flush();
         }
 
+        private static async Task<byte[]> ReadFromStreamAsync(Stream stream)
+        {
+            //TODO: Add a max size to limit how much data gets read.
+            var memoryStream = new MemoryStream();
+            await stream.CopyToAsync(memoryStream);
+            return memoryStream.ToArray();
+        }
+
         public static NegotiationResponse ParseResponse(Stream content)
         {
+            byte[] data = ReadFromStreamAsync(content).GetAwaiter().GetResult();
             try
             {
-                using (var reader = JsonUtils.CreateJsonTextReader(new StreamReader(content)))
+                var reader = new Utf8JsonReader(data);
+
+                JsonUtils.CheckRead(ref reader);
+                JsonUtils.EnsureObjectStart(ref reader);
+
+                string connectionId = null;
+                string url = null;
+                string accessToken = null;
+                List<AvailableTransport> availableTransports = null;
+
+                while (JsonUtils.CheckRead(ref reader))
                 {
-                    JsonUtils.CheckRead(reader);
-                    JsonUtils.EnsureObjectStart(reader);
-
-                    string connectionId = null;
-                    string url = null;
-                    string accessToken = null;
-                    List<AvailableTransport> availableTransports = null;
-
-                    var completed = false;
-                    while (!completed && JsonUtils.CheckRead(reader))
+                    if (reader.TokenType == JsonTokenType.PropertyName)
                     {
-                        switch (reader.TokenType)
-                        {
-                            case JsonToken.PropertyName:
-                                var memberName = reader.Value.ToString();
+                        ReadOnlySpan<byte> memberName = reader.Value;
 
-                                switch (memberName)
+                        if (memberName.SequenceEqual(UrlPropertyNameUtf8))
+                        {
+                            url = JsonUtils.ReadAsString(ref reader, UrlPropertyName);
+                        }
+                        else if (memberName.SequenceEqual(AccessTokenPropertyNameUtf8))
+                        {
+                            accessToken = JsonUtils.ReadAsString(ref reader, AccessTokenPropertyName);
+                        }
+                        else if (memberName.SequenceEqual(ConnectionIdPropertyNameUtf8))
+                        {
+                            connectionId = JsonUtils.ReadAsString(ref reader, ConnectionIdPropertyName);
+                        }
+                        else if (memberName.SequenceEqual(AvailableTransportsPropertyNameUtf8))
+                        {
+                            JsonUtils.CheckRead(ref reader);
+                            JsonUtils.EnsureArrayStart(ref reader);
+
+                            availableTransports = new List<AvailableTransport>();
+                            while (JsonUtils.CheckRead(ref reader))
+                            {
+                                if (reader.TokenType == JsonTokenType.StartObject)
                                 {
-                                    case UrlPropertyName:
-                                        url = JsonUtils.ReadAsString(reader, UrlPropertyName);
-                                        break;
-                                    case AccessTokenPropertyName:
-                                        accessToken = JsonUtils.ReadAsString(reader, AccessTokenPropertyName);
-                                        break;
-                                    case ConnectionIdPropertyName:
-                                        connectionId = JsonUtils.ReadAsString(reader, ConnectionIdPropertyName);
-                                        break;
-                                    case AvailableTransportsPropertyName:
-                                        JsonUtils.CheckRead(reader);
-                                        JsonUtils.EnsureArrayStart(reader);
-
-                                        availableTransports = new List<AvailableTransport>();
-                                        while (JsonUtils.CheckRead(reader))
-                                        {
-                                            if (reader.TokenType == JsonToken.StartObject)
-                                            {
-                                                availableTransports.Add(ParseAvailableTransport(reader));
-                                            }
-                                            else if (reader.TokenType == JsonToken.EndArray)
-                                            {
-                                                break;
-                                            }
-                                        }
-                                        break;
-                                    default:
-                                        reader.Skip();
-                                        break;
+                                    availableTransports.Add(ParseAvailableTransport(ref reader));
                                 }
-                                break;
-                            case JsonToken.EndObject:
-                                completed = true;
-                                break;
-                            default:
-                                throw new InvalidDataException($"Unexpected token '{reader.TokenType}' when reading negotiation response JSON.");
+                                else if (reader.TokenType == JsonTokenType.EndArray)
+                                {
+                                    break;
+                                }
+                            }
+                        }
+                        else
+                        {
+                            reader.Skip();
                         }
                     }
-
-                    if (url == null)
+                    else if (reader.TokenType == JsonTokenType.EndObject)
                     {
-                        // if url isn't specified, connectionId and available transports are required
-                        if (connectionId == null)
-                        {
-                            throw new InvalidDataException($"Missing required property '{ConnectionIdPropertyName}'.");
-                        }
-
-                        if (availableTransports == null)
-                        {
-                            throw new InvalidDataException($"Missing required property '{AvailableTransportsPropertyName}'.");
-                        }
+                        break;
                     }
-
-                    return new NegotiationResponse
+                    else
                     {
-                        ConnectionId = connectionId,
-                        Url = url,
-                        AccessToken = accessToken,
-                        AvailableTransports = availableTransports
-                    };
+                        throw new InvalidDataException($"Unexpected token '{reader.TokenType}' when reading negotiation response JSON.");
+                    }
                 }
+
+                if (url == null)
+                {
+                    // if url isn't specified, connectionId and available transports are required
+                    if (connectionId == null)
+                    {
+                        throw new InvalidDataException($"Missing required property '{ConnectionIdPropertyName}'.");
+                    }
+
+                    if (availableTransports == null)
+                    {
+                        throw new InvalidDataException($"Missing required property '{AvailableTransportsPropertyName}'.");
+                    }
+                }
+
+                return new NegotiationResponse
+                {
+                    ConnectionId = connectionId,
+                    Url = url,
+                    AccessToken = accessToken,
+                    AvailableTransports = availableTransports
+                };
             }
             catch (Exception ex)
             {
@@ -162,62 +180,64 @@ namespace Microsoft.AspNetCore.Http.Connections
             }
         }
 
-        private static AvailableTransport ParseAvailableTransport(JsonTextReader reader)
+        private static AvailableTransport ParseAvailableTransport(ref Utf8JsonReader reader)
         {
             var availableTransport = new AvailableTransport();
 
-            while (JsonUtils.CheckRead(reader))
+            while (JsonUtils.CheckRead(ref reader))
             {
-                switch (reader.TokenType)
+                if (reader.TokenType == JsonTokenType.PropertyName)
                 {
-                    case JsonToken.PropertyName:
-                        var memberName = reader.Value.ToString();
+                    ReadOnlySpan<byte> memberName = reader.Value;
 
-                        switch (memberName)
+                    if (memberName.SequenceEqual(TransportPropertyNameUtf8))
+                    {
+                        availableTransport.Transport = JsonUtils.ReadAsString(ref reader, TransportPropertyName);
+                    }
+                    else if (memberName.SequenceEqual(TransferFormatsPropertyNameUtf8))
+                    {
+                        JsonUtils.CheckRead(ref reader);
+                        JsonUtils.EnsureArrayStart(ref reader);
+
+                        availableTransport.TransferFormats = new List<string>();
+                        while (JsonUtils.CheckRead(ref reader))
                         {
-                            case TransportPropertyName:
-                                availableTransport.Transport = JsonUtils.ReadAsString(reader, TransportPropertyName);
+                            if (reader.TokenType == JsonTokenType.Value && reader.ValueType == JsonValueType.String)
+                            {
+                                availableTransport.TransferFormats.Add(JsonUtils.ConvertToString(reader.Value));
+                            }
+                            else if (reader.TokenType == JsonTokenType.EndArray)
+                            {
                                 break;
-                            case TransferFormatsPropertyName:
-                                JsonUtils.CheckRead(reader);
-                                JsonUtils.EnsureArrayStart(reader);
-
-                                var completed = false;
-                                availableTransport.TransferFormats = new List<string>();
-                                while (!completed && JsonUtils.CheckRead(reader))
-                                {
-                                    switch (reader.TokenType)
-                                    {
-                                        case JsonToken.String:
-                                            availableTransport.TransferFormats.Add(reader.Value.ToString());
-                                            break;
-                                        case JsonToken.EndArray:
-                                            completed = true;
-                                            break;
-                                        default:
-                                            throw new InvalidDataException($"Unexpected token '{reader.TokenType}' when reading transfer formats JSON.");
-                                    }
-                                }
-                                break;
-                            default:
-                                reader.Skip();
-                                break;
+                            }
+                            else
+                            {
+                                throw new InvalidDataException($"Unexpected token '{reader.TokenType}' when reading transfer formats JSON.");
+                            }
                         }
-                        break;
-                    case JsonToken.EndObject:
-                        if (availableTransport.Transport == null)
-                        {
-                            throw new InvalidDataException($"Missing required property '{TransportPropertyName}'.");
-                        }
+                    }
+                    else
+                    {
+                        reader.Skip();
+                    }
+                }
+                else if (reader.TokenType == JsonTokenType.EndObject)
+                {
+                    if (availableTransport.Transport == null)
+                    {
+                        throw new InvalidDataException($"Missing required property '{TransportPropertyName}'.");
+                    }
 
-                        if (availableTransport.TransferFormats == null)
-                        {
-                            throw new InvalidDataException($"Missing required property '{TransferFormatsPropertyName}'.");
-                        }
+                    if (availableTransport.TransferFormats == null)
+                    {
+                        throw new InvalidDataException($"Missing required property '{TransferFormatsPropertyName}'.");
+                    }
 
-                        return availableTransport;
-                    default:
-                        throw new InvalidDataException($"Unexpected token '{reader.TokenType}' when reading available transport JSON.");
+                    return availableTransport;
+                }
+                else
+                {
+                    throw new InvalidDataException($"Unexpected token '{reader.TokenType}' when reading available transport JSON.");
                 }
             }
 

--- a/src/Microsoft.AspNetCore.SignalR.Common/Microsoft.AspNetCore.SignalR.Common.csproj
+++ b/src/Microsoft.AspNetCore.SignalR.Common/Microsoft.AspNetCore.SignalR.Common.csproj
@@ -19,6 +19,7 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
     <PackageReference Include="System.Buffers" Version="$(SystemBuffersPackageVersion)" />
+    <PackageReference Include="System.Text.JsonLab" Version="$(SystemTextJsonLabPackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="$(MicrosoftAspNetCoreConnectionsAbstractionsPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="$(MicrosoftExtensionsOptionsPackageVersion)" />
   </ItemGroup>

--- a/src/Microsoft.AspNetCore.SignalR.Common/Protocol/HandshakeProtocol.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Common/Protocol/HandshakeProtocol.cs
@@ -109,9 +109,6 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
 
             var reader = new Utf8JsonReader(payload);
 
-            byte[] temp = payload.ToArray();
-            string payStr = Encoding.UTF8.GetString(temp);
-
             JsonUtils.CheckRead(ref reader);
             JsonUtils.EnsureObjectStart(ref reader);
 
@@ -128,7 +125,6 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
 
                         if (memberName.SequenceEqual(TypePropertyNameUtf8))
                         {
-
                             // a handshake response does not have a type
                             // check the incoming message was not any other type of message
                             throw new InvalidDataException("Handshake response should not have a 'type' value.");

--- a/src/Microsoft.AspNetCore.SignalR.Redis/Microsoft.AspNetCore.SignalR.Redis.csproj
+++ b/src/Microsoft.AspNetCore.SignalR.Redis/Microsoft.AspNetCore.SignalR.Redis.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <Description>Redis for ASP.NET Core SignalR.</Description>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The intention of this PR is to get an initial review of the JsonLab reader/writer APIs and see how user code changes during a port. These APIs are still being prototyped and hence I expect them to change. There are also some semantic & behavioral differences here, and I wanted to discover how this would impact customer code.

Please note that the implementation is not thoroughly tested and there are gaps in functionality (for instance escaping input while writing or proper validation and generating rich error messages while reading are still missing).

**Feedback welcome.**

**TODO:**
- JsonHubProtocol: I tried to go [as far as possible](https://github.com/aspnet/SignalR/commit/1418aee1d707496bac566d43a47b4de3e7f50a9e#diff-12cd032d012d9ed36a88025fbc95c54c) with the new APIs, but this relies on a lot more features, including a [JsonSerializer](https://github.com/aspnet/SignalR/commit/1418aee1d707496bac566d43a47b4de3e7f50a9e#diff-12cd032d012d9ed36a88025fbc95c54cR231) (for reading and [writing](https://github.com/aspnet/SignalR/commit/1418aee1d707496bac566d43a47b4de3e7f50a9e#diff-12cd032d012d9ed36a88025fbc95c54cR581) objects), use of [JToken](https://github.com/aspnet/SignalR/commit/1418aee1d707496bac566d43a47b4de3e7f50a9e#diff-12cd032d012d9ed36a88025fbc95c54cR190), and [Stream-based](https://github.com/aspnet/SignalR/commit/1418aee1d707496bac566d43a47b4de3e7f50a9e#diff-0e5591272fc4a9be570908d247813246R73) reader, none of which exist atm.

``` ini

BenchmarkDotNet=v0.10.13, OS=Windows 10.0.17713
Intel Core i7-6700 CPU 3.40GHz (Skylake), 1 CPU, 8 logical cores and 4 physical cores
.NET Core SDK=2.1.302
  [Host]     : .NET Core 2.2.0-preview1-26618-02 (CoreCLR 4.6.26616.03, CoreFX 4.6.26617.01), 64bit RyuJIT
  Job-QQAEKJ : .NET Core 2.2.0-preview1-26618-02 (CoreCLR 4.6.26616.03, CoreFX 4.6.26617.01), 64bit RyuJIT

Runtime=Core  Server=True  Toolchain=.NET Core 2.2  
RunStrategy=Throughput  

```
**Before:**

|                Method |     Mean |     Error |    StdDev |      Op/s |  Gen 0 | Allocated |
|---------------------- |---------:|----------:|----------:|----------:|-------:|----------:|
| SuccessHandshakeAsync | 2.524 us | 0.0501 us | 0.0492 us | 396,118.5 | 0.0076 |     808 B |
|   ErrorHandshakeAsync | 2.560 us | 0.0527 us | 0.0440 us | 390,608.5 | 0.0076 |     864 B |

|                           Method |     Mean |     Error |    StdDev |      Op/s |  Gen 0 | Allocated |
|--------------------------------- |---------:|----------:|----------:|----------:|-------:|----------:|
| WriteResponse_MemoryBufferWriter | 1.568 us | 0.0130 us | 0.0121 us | 637,800.6 | 0.0038 |     464 B |

**After:**
1.3 - 1.7x faster

|                Method |     Mean |     Error |    StdDev |   Median |      Op/s |  Gen 0 | Allocated |
|---------------------- |---------:|----------:|----------:|---------:|----------:|-------:|----------:|
| SuccessHandshakeAsync | 1.956 us | 0.0184 us | 0.0172 us | 1.951 us | 511,313.2 | 0.0038 |     504 B |
|   ErrorHandshakeAsync | 1.470 us | 0.0293 us | 0.0456 us | 1.448 us | 680,161.4 | 0.0038 |     400 B |

2.8x faster

|                           Method |     Mean |    Error |   StdDev |        Op/s |  Gen 0 | Allocated |
|--------------------------------- |---------:|---------:|---------:|------------:|-------:|----------:|
| WriteResponse_MemoryBufferWriter | 555.2 ns | 10.62 ns | 10.90 ns | 1,801,121.9 | 0.0010 |     144 B |

cc @glennc, @rynowak, @davidfowl, @joshfree 