### PR TITLE
Add timestamp to logs TS client

### DIFF
--- a/clients/ts/signalr/src/Utils.ts
+++ b/clients/ts/signalr/src/Utils.ts
@@ -166,17 +166,17 @@ export class ConsoleLogger implements ILogger {
             switch (logLevel) {
                 case LogLevel.Critical:
                 case LogLevel.Error:
-                    console.error(`${LogLevel[logLevel]}: ${message}`);
+                    console.error(`[${new Date().toISOString()}] ${LogLevel[logLevel]}: ${message}`);
                     break;
                 case LogLevel.Warning:
-                    console.warn(`${LogLevel[logLevel]}: ${message}`);
+                    console.warn(`[${new Date().toISOString()}] ${LogLevel[logLevel]}: ${message}`);
                     break;
                 case LogLevel.Information:
-                    console.info(`${LogLevel[logLevel]}: ${message}`);
+                    console.info(`[${new Date().toISOString()}] ${LogLevel[logLevel]}: ${message}`);
                     break;
                 default:
                     // console.debug only goes to attached debuggers in Node, so we use console.log for Trace and Debug
-                    console.log(`${LogLevel[logLevel]}: ${message}`);
+                    console.log(`[${new Date().toISOString()}] ${LogLevel[logLevel]}: ${message}`);
                     break;
             }
         }


### PR DESCRIPTION
Part of https://github.com/aspnet/SignalR/issues/2750

Example:
```
[2018-08-08T17:35:52.658Z] Trace: (LongPolling transport) polling: http://localhost:5000/default?id=z2RQ4Y77tS5uIUaRP_Qhqw&_=1533749752658
[2018-08-08T17:35:52.730Z] Trace: (LongPolling transport) data received. String data of length 73
[2018-08-08T17:35:52.732Z] Trace: (LongPolling transport) polling: http://localhost:5000/default?id=z2RQ4Y77tS5uIUaRP_Qhqw&_=1533749752732
[2018-08-08T17:36:07.562Z] Trace: (LongPolling transport) sending data. String data of length 11.
[2018-08-08T17:36:07.567Z] Trace: (LongPolling transport) request complete. Response status: **200.**
```