### PR TITLE
Add HubConnectionBuilder to Java client

### DIFF
--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/Chat.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/Chat.java
@@ -13,8 +13,8 @@ public class Chat {
             input = reader.nextLine();
 
             HubConnection hubConnection = new HubConnectionBuilder()
-                    .setUrl(input)
-                    .setLogLevel(LogLevel.Information).build();
+                    .withUrl(input)
+                    .configureLogging(LogLevel.Information).build();
 
             hubConnection.on("Send", (message) -> {
                 System.out.println("REGISTERED HANDLER: " + message);

--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/Chat.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/Chat.java
@@ -3,8 +3,6 @@
 
 package com.microsoft.aspnet.signalr;
 
-import com.microsoft.aspnet.signalr.HubConnection;
-
 import java.util.Scanner;
 
 public class Chat {
@@ -13,7 +11,10 @@ public class Chat {
             Scanner reader = new Scanner(System.in);  // Reading from System.in
             String input;
             input = reader.nextLine();
-            HubConnection hubConnection = new HubConnection(input, LogLevel.Information);
+
+            HubConnection hubConnection = new HubConnectionBuilder()
+                    .setUrl(input)
+                    .setLogLevel(LogLevel.Information).build();
 
             hubConnection.on("Send", (message) -> {
                 System.out.println("REGISTERED HANDLER: " + message);

--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/HubConnection.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/HubConnection.java
@@ -24,7 +24,13 @@ public class HubConnection {
     public HubConnection(String url, Transport transport, Logger logger){
         this.url = url;
         this.protocol = new JsonHubProtocol();
-        this.logger = logger;
+
+        if(logger != null) {
+            this.logger = logger;
+        } else {
+            this.logger = new NullLogger();
+        }
+
         this.callback = (payload) -> {
 
             if (!handshakeReceived) {

--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/HubConnection.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/HubConnection.java
@@ -25,7 +25,7 @@ public class HubConnection {
         this.url = url;
         this.protocol = new JsonHubProtocol();
 
-        if(logger != null) {
+        if (logger != null) {
             this.logger = logger;
         } else {
             this.logger = new NullLogger();

--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/HubConnectionBuilder.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/HubConnectionBuilder.java
@@ -1,0 +1,39 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+package com.microsoft.aspnet.signalr;
+
+public class HubConnectionBuilder {
+    private boolean built = false;
+    private String url;
+    private Transport transport;
+    private Logger logger;
+
+    public HubConnectionBuilder setUrl(String url){
+        this.url = url;
+        return this;
+    }
+
+    public HubConnectionBuilder setTransport(Transport transport) {
+        this.transport = transport;
+        return this;
+    }
+
+    public HubConnectionBuilder setLogLevel(LogLevel logLevel) {
+        this.logger = new ConsoleLogger(logLevel);
+        return this;
+    }
+
+    public HubConnectionBuilder setLogger(Logger logger){
+        this.logger = logger;
+        return this;
+    }
+
+    public HubConnection build() throws Exception {
+        if(!built){
+            built = true;
+            return new HubConnection(url , transport, logger);
+        }
+        throw new Exception("HubConnectionBuilder allows creation only of a single instance of HubConnection.");
+    }
+}

--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/HubConnectionBuilder.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/HubConnectionBuilder.java
@@ -14,7 +14,8 @@ public class HubConnectionBuilder {
         return this;
     }
 
-    public HubConnectionBuilder withTransport(Transport transport) {
+    public HubConnectionBuilder withUrl(String url, Transport transport){
+        this.url = url;
         this.transport = transport;
         return this;
     }

--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/HubConnectionBuilder.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/HubConnectionBuilder.java
@@ -9,22 +9,22 @@ public class HubConnectionBuilder {
     private Transport transport;
     private Logger logger;
 
-    public HubConnectionBuilder setUrl(String url){
+    public HubConnectionBuilder withUrl(String url){
         this.url = url;
         return this;
     }
 
-    public HubConnectionBuilder setTransport(Transport transport) {
+    public HubConnectionBuilder withTransport(Transport transport) {
         this.transport = transport;
         return this;
     }
 
-    public HubConnectionBuilder setLogLevel(LogLevel logLevel) {
+    public HubConnectionBuilder configureLogging(LogLevel logLevel) {
         this.logger = new ConsoleLogger(logLevel);
         return this;
     }
 
-    public HubConnectionBuilder setLogger(Logger logger){
+    public HubConnectionBuilder configureLogging(Logger logger){
         this.logger = logger;
         return this;
     }

--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/HubConnectionBuilder.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/HubConnectionBuilder.java
@@ -32,7 +32,7 @@ public class HubConnectionBuilder {
     public HubConnection build() throws Exception {
         if(!built){
             built = true;
-            return new HubConnection(url , transport, logger);
+            return new HubConnection(url, transport, logger);
         }
         throw new Exception("HubConnectionBuilder allows creation only of a single instance of HubConnection.");
     }

--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/HubConnectionBuilder.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/HubConnectionBuilder.java
@@ -4,17 +4,17 @@
 package com.microsoft.aspnet.signalr;
 
 public class HubConnectionBuilder {
-    private boolean built = false;
+    private boolean built;
     private String url;
     private Transport transport;
     private Logger logger;
 
-    public HubConnectionBuilder withUrl(String url){
+    public HubConnectionBuilder withUrl(String url) {
         this.url = url;
         return this;
     }
 
-    public HubConnectionBuilder withUrl(String url, Transport transport){
+    public HubConnectionBuilder withUrl(String url, Transport transport) {
         this.url = url;
         this.transport = transport;
         return this;
@@ -25,13 +25,13 @@ public class HubConnectionBuilder {
         return this;
     }
 
-    public HubConnectionBuilder configureLogging(Logger logger){
+    public HubConnectionBuilder configureLogging(Logger logger) {
         this.logger = logger;
         return this;
     }
 
     public HubConnection build() throws Exception {
-        if(!built){
+        if (!built) {
             built = true;
             return new HubConnection(url, transport, logger);
         }


### PR DESCRIPTION
Adding `HubConnectionBuilder` to Java client.
It currently lets you configure the url, transport, loglevel, or logger. 