### PR TITLE
Throw if the Websocket cant connect

### DIFF
--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/Transport.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/Transport.java
@@ -4,7 +4,7 @@
 package com.microsoft.aspnet.signalr;
 
 public interface Transport {
-    void start() throws InterruptedException;
+    void start() throws Exception;
     void send(String message) throws Exception;
     void setOnReceive(OnReceiveCallBack callback);
     void onReceive(String message) throws Exception;

--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/WebSocketTransport.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/WebSocketTransport.java
@@ -40,10 +40,10 @@ public class WebSocketTransport implements Transport {
 
     @Override
     public void start() throws Exception {
-        logger.log(LogLevel.Debug, "Starting Websocket connection");
+        logger.log(LogLevel.Debug, "Starting Websocket connection.");
         webSocketClient = createWebSocket();
         if (!webSocketClient.connectBlocking()) {
-            String errorMessage = "There was an error starting the Websockets transport";
+            String errorMessage = "There was an error starting the Websockets transport.";
             logger.log(LogLevel.Debug, errorMessage);
             throw new Exception(errorMessage);
         }

--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/WebSocketTransport.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/WebSocketTransport.java
@@ -39,10 +39,14 @@ public class WebSocketTransport implements Transport {
     }
 
     @Override
-    public void start() throws InterruptedException {
+    public void start() throws Exception {
         logger.log(LogLevel.Debug, "Starting Websocket connection");
         webSocketClient = createWebSocket();
-        webSocketClient.connectBlocking();
+        if (!webSocketClient.connectBlocking()) {
+            String errorMessage = "There was an error starting the Websockets transport";
+            logger.log(LogLevel.Debug, errorMessage);
+            throw new Exception(errorMessage);
+        }
         logger.log(LogLevel.Information, "WebSocket transport connected to: %s", webSocketClient.getURI());
     }
 

--- a/clients/java/signalr/src/test/java/WebSocketTransportTest.java
+++ b/clients/java/signalr/src/test/java/WebSocketTransportTest.java
@@ -2,38 +2,22 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 import com.microsoft.aspnet.signalr.NullLogger;
+import com.microsoft.aspnet.signalr.Transport;
 import com.microsoft.aspnet.signalr.WebSocketTransport;
-import java.net.URISyntaxException;
-import java.util.Arrays;
-import java.util.Collection;
+import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.rules.ExpectedException;
 
-import static org.junit.Assert.*;
-
-@RunWith(Parameterized.class)
 public class WebSocketTransportTest {
-    private String url;
-    private String expectedUrl;
 
-    public WebSocketTransportTest(String url, String expectedProtocol){
-        this.url = url;
-        this.expectedUrl = expectedProtocol;
-    }
-
-    @Parameterized.Parameters
-    public static Collection protocols(){
-        return Arrays.asList(new String[][] {
-                {"http://example.com", "ws://example.com"},
-                {"https://example.com", "wss://example.com"},
-                {"ws://example.com", "ws://example.com"},
-                {"wss://example.com", "wss://example.com"}});
-    }
+    @Rule
+    public ExpectedException expectedEx = ExpectedException.none();
 
     @Test
-    public void checkWebsocketUrlProtocol() throws URISyntaxException {
-        WebSocketTransport webSocketTransport = new WebSocketTransport(this.url, new NullLogger());
-        assertEquals(this.expectedUrl, webSocketTransport.getUrl().toString());
+    public void WebsocketThrowsIIfItCantConnect() throws Exception {
+        expectedEx.expect(Exception.class);
+        expectedEx.expectMessage("There was an error starting the Websockets transport");
+        Transport transport = new WebSocketTransport("www.notarealurl12345.fake", new NullLogger());
+        transport.start();
     }
 }

--- a/clients/java/signalr/src/test/java/WebSocketTransportTest.java
+++ b/clients/java/signalr/src/test/java/WebSocketTransportTest.java
@@ -14,7 +14,7 @@ public class WebSocketTransportTest {
     public ExpectedException expectedEx = ExpectedException.none();
 
     @Test
-    public void WebsocketThrowsIIfItCantConnect() throws Exception {
+    public void WebsocketThrowsIfItCantConnect() throws Exception {
         expectedEx.expect(Exception.class);
         expectedEx.expectMessage("There was an error starting the Websockets transport");
         Transport transport = new WebSocketTransport("www.notarealurl12345.fake", new NullLogger());

--- a/clients/java/signalr/src/test/java/WebSocketTransportUrlFormatTest.java
+++ b/clients/java/signalr/src/test/java/WebSocketTransportUrlFormatTest.java
@@ -1,0 +1,39 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+import com.microsoft.aspnet.signalr.NullLogger;
+import com.microsoft.aspnet.signalr.WebSocketTransport;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.Collection;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static org.junit.Assert.*;
+
+@RunWith(Parameterized.class)
+public class WebSocketTransportUrlFormatTest {
+    private String url;
+    private String expectedUrl;
+
+    public WebSocketTransportUrlFormatTest(String url, String expectedProtocol){
+        this.url = url;
+        this.expectedUrl = expectedProtocol;
+    }
+
+    @Parameterized.Parameters
+    public static Collection protocols(){
+        return Arrays.asList(new String[][] {
+                {"http://example.com", "ws://example.com"},
+                {"https://example.com", "wss://example.com"},
+                {"ws://example.com", "ws://example.com"},
+                {"wss://example.com", "wss://example.com"}});
+    }
+
+    @Test
+    public void checkWebsocketUrlProtocol() throws URISyntaxException {
+        WebSocketTransport webSocketTransport = new WebSocketTransport(this.url, new NullLogger());
+        assertEquals(this.expectedUrl, webSocketTransport.getUrl().toString());
+    }
+}

--- a/clients/java/signalr/src/test/java/WebSocketTransportUrlFormatTest.java
+++ b/clients/java/signalr/src/test/java/WebSocketTransportUrlFormatTest.java
@@ -3,9 +3,11 @@
 
 import com.microsoft.aspnet.signalr.NullLogger;
 import com.microsoft.aspnet.signalr.WebSocketTransport;
+
 import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.Collection;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -17,14 +19,14 @@ public class WebSocketTransportUrlFormatTest {
     private String url;
     private String expectedUrl;
 
-    public WebSocketTransportUrlFormatTest(String url, String expectedProtocol){
+    public WebSocketTransportUrlFormatTest(String url, String expectedProtocol) {
         this.url = url;
         this.expectedUrl = expectedProtocol;
     }
 
     @Parameterized.Parameters
-    public static Collection protocols(){
-        return Arrays.asList(new String[][] {
+    public static Collection protocols() {
+        return Arrays.asList(new String[][]{
                 {"http://example.com", "ws://example.com"},
                 {"https://example.com", "wss://example.com"},
                 {"ws://example.com", "ws://example.com"},


### PR DESCRIPTION
Issue: https://github.com/aspnet/SignalR/issues/2781
Currently the Websockets transport doesn't fail immediately if it can't connect. It fails right after when it tries to send the handshake response. This ensures that the websocket was able to connect before continuing. 