### PR TITLE
[TS Client] Properly wait for WebSocket close

### DIFF
--- a/clients/ts/signalr/src/HttpConnection.ts
+++ b/clients/ts/signalr/src/HttpConnection.ts
@@ -317,7 +317,7 @@ export class HttpConnection implements IConnection {
         return false;
     }
 
-    private async stopConnection(error?: Error): Promise<void> {
+    private stopConnection(error?: Error): void {
         this.transport = undefined;
 
         // If we have a stopError, it takes precedence over the error from the transport

--- a/clients/ts/signalr/src/WebSocketTransport.ts
+++ b/clients/ts/signalr/src/WebSocketTransport.ts
@@ -68,17 +68,7 @@ export class WebSocketTransport implements ITransport {
                 }
             };
 
-            webSocket.onclose = (event: CloseEvent) => {
-                // webSocket will be null if the transport did not start successfully
-                this.logger.log(LogLevel.Trace, "(WebSockets transport) socket closed.");
-                if (this.onclose) {
-                    if (event && (event.wasClean === false || event.code !== 1000)) {
-                        this.onclose(new Error(`Websocket closed with status code: ${event.code} (${event.reason})`));
-                    } else {
-                        this.onclose();
-                    }
-                }
-            };
+            webSocket.onclose = (event: CloseEvent) => this.close(event);
         });
     }
 
@@ -94,8 +84,6 @@ export class WebSocketTransport implements ITransport {
 
     public stop(): Promise<void> {
         if (this.webSocket) {
-            // Capture close callback and invoke it manually after clearing it
-            const close = this.webSocket.onclose;
             // Clear websocket handlers because we are considering the socket closed now
             this.webSocket.onclose = () => {};
             this.webSocket.onmessage = () => {};
@@ -105,9 +93,21 @@ export class WebSocketTransport implements ITransport {
 
             // Manually invoke onclose callback inline so we know the HttpConnection was closed properly before returning
             // This also solves an issue where websocket.onclose could take 18+ seconds to trigger during network disconnects
-            close!.call(this.webSocket, undefined);
+            this.close(undefined);
         }
 
         return Promise.resolve();
+    }
+
+    private close(event?: CloseEvent): void {
+        // webSocket will be null if the transport did not start successfully
+        this.logger.log(LogLevel.Trace, "(WebSockets transport) socket closed.");
+        if (this.onclose) {
+            if (event && (event.wasClean === false || event.code !== 1000)) {
+                this.onclose(new Error(`Websocket closed with status code: ${event.code} (${event.reason})`));
+            } else {
+                this.onclose();
+            }
+        }
     }
 }


### PR DESCRIPTION
There was a race between the `WebSocket.onclose` callback being called and `HubConnection.start` being called after `HubConnection.stop` returned. This was because we didn't wait for the `onclose` callback, which called `HttpConnection.stopConnection`, to finish before we returned from `WebSocket.close` which completed the `HubConnection.stop` call.

The fix is to call the `onclose` callback manually if `stop` is called, which conveniently fixed another issue we had.

Original issue: https://github.com/aspnet/SignalR/issues/2783
Bonus issue: https://github.com/aspnet/SignalR/issues/2557

No tests because we don't test race conditions.