### PR TITLE
Check connection state before start stop and send

### DIFF
--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/HubConnection.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/HubConnection.java
@@ -196,7 +196,7 @@ public class HubConnection {
      */
     public void send(String method, Object... args) throws Exception {
         if (connectionState != HubConnectionState.CONNECTED) {
-            throw new Exception("The 'send' method cannot be called if the connection is not active");
+            throw new HubException("The 'send' method cannot be called if the connection is not active");
         }
 
         InvocationMessage invocationMessage = new InvocationMessage(method, args);

--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/HubConnection.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/HubConnection.java
@@ -142,6 +142,10 @@ public class HubConnection {
      * @throws Exception An error occurred while connecting.
      */
     public void start() throws Exception {
+        if (connectionState != HubConnectionState.DISCONNECTED) {
+            return;
+        }
+        
         logger.log(LogLevel.Debug, "Starting HubConnection");
         transport.setOnReceive(this.callback);
         transport.start();
@@ -155,7 +159,11 @@ public class HubConnection {
      * Stops a connection to the server.
      */
     private void stop(String errorMessage) {
-        if(errorMessage != null){
+        if (connectionState == HubConnectionState.DISCONNECTED) {
+            return;
+        }
+
+        if(errorMessage != null) {
             logger.log(LogLevel.Error , "HubConnection disconnected with an error %s.", errorMessage);
         } else {
             logger.log(LogLevel.Debug, "Stopping HubConnection.");
@@ -187,6 +195,10 @@ public class HubConnection {
      * @throws Exception If there was an error while sending.
      */
     public void send(String method, Object... args) throws Exception {
+        if (connectionState != HubConnectionState.CONNECTED) {
+            throw new Exception("Cannot send data if the connection is not in the 'Connected' State.");
+        }
+
         InvocationMessage invocationMessage = new InvocationMessage(method, args);
         String message = protocol.writeMessage(invocationMessage);
         logger.log(LogLevel.Debug, "Sending message");

--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/HubConnection.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/HubConnection.java
@@ -145,7 +145,7 @@ public class HubConnection {
         if (connectionState != HubConnectionState.DISCONNECTED) {
             return;
         }
-        
+
         logger.log(LogLevel.Debug, "Starting HubConnection");
         transport.setOnReceive(this.callback);
         transport.start();
@@ -196,7 +196,7 @@ public class HubConnection {
      */
     public void send(String method, Object... args) throws Exception {
         if (connectionState != HubConnectionState.CONNECTED) {
-            throw new Exception("Cannot send data if the connection is not in the 'Connected' State.");
+            throw new Exception("The 'send' method cannot be called if the connection is not active");
         }
 
         InvocationMessage invocationMessage = new InvocationMessage(method, args);

--- a/clients/java/signalr/src/test/java/HubConnectionTest.java
+++ b/clients/java/signalr/src/test/java/HubConnectionTest.java
@@ -677,7 +677,7 @@ public class HubConnectionTest {
     public ExpectedException exceptionRule = ExpectedException.none();
 
     @Test
-    public void CantSendBeforeStart() throws Exception {
+    public void CannotSendBeforeStart() throws Exception {
         exceptionRule.expect(Exception.class);
         exceptionRule.expectMessage("Cannot send data if the connection is not in the 'Connected' State.");
 

--- a/clients/java/signalr/src/test/java/HubConnectionTest.java
+++ b/clients/java/signalr/src/test/java/HubConnectionTest.java
@@ -678,8 +678,8 @@ public class HubConnectionTest {
 
     @Test
     public void CannotSendBeforeStart() throws Exception {
-        exceptionRule.expect(Exception.class);
-        exceptionRule.expectMessage("Cannot send data if the connection is not in the 'Connected' State.");
+        exceptionRule.expect(HubException.class);
+        exceptionRule.expectMessage("The 'send' method cannot be called if the connection is not active");
 
         Transport mockTransport = new MockTransport();
         HubConnection hubConnection = new HubConnection("http://example.com", mockTransport);


### PR DESCRIPTION
The PR makes sure that the client is in the correct connection state before doing the operations in the start stop and send methods.