### PR TITLE
Ignore failures from sending ping

### DIFF
--- a/clients/ts/signalr/src/HubConnection.ts
+++ b/clients/ts/signalr/src/HubConnection.ts
@@ -408,7 +408,13 @@ export class HubConnection {
         this.cleanupPingTimer();
         this.pingServerHandle = setTimeout(async () => {
             if (this.connectionState === HubConnectionState.Connected) {
-                await this.sendMessage(this.cachedPingMessage);
+                try {
+                    await this.sendMessage(this.cachedPingMessage);
+                } catch {
+                    // We don't care about the error. It should be seen elsewhere in the client.
+                    // The connection is probably in a bad or closed state now, cleanup the timer so it stops triggering
+                    this.cleanupPingTimer();
+                }
             }
         }, this.keepAliveIntervalInMilliseconds);
     }


### PR DESCRIPTION
There is a race in the ping timer where the connection can close after the `sendMessage` call goes async and then it will throw inside `sendMessage` with a connection closed error and that can trigger unhandledexception handlers which is bad.

Should fix PR #2823