### PR TITLE
Remove logging from flaky SSE tests

### DIFF
--- a/clients/ts/signalr-protocol-msgpack/package-lock.json
+++ b/clients/ts/signalr-protocol-msgpack/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@aspnet/signalr-protocol-msgpack",
-  "version": "1.1.0-preview1-t000",
+  "version": "1.1.0-preview2-t000",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/clients/ts/signalr/package-lock.json
+++ b/clients/ts/signalr/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@aspnet/signalr",
-  "version": "1.1.0-preview1-t000",
+  "version": "1.1.0-preview2-t000",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/ServerSentEventsTransportTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/ServerSentEventsTransportTests.cs
@@ -164,12 +164,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
         [Fact]
         public async Task SSETransportStopsWithErrorIfSendingMessageFails()
         {
-            bool ExpectedErrors(WriteContext writeContext)
-            {
-                return writeContext.LoggerName == typeof(ServerSentEventsTransport).FullName &&
-                       writeContext.EventId.Name == "ErrorSending";
-            }
-
+            // TODO: Add logging https://github.com/aspnet/SignalR/issues/2879
             var eventStreamTcs = new TaskCompletionSource<object>();
             var copyToAsyncTcs = new TaskCompletionSource<int>();
 
@@ -198,9 +193,8 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                 });
 
             using (var httpClient = new HttpClient(mockHttpHandler.Object))
-            using (StartVerifiableLog(out var loggerFactory, expectedErrorsFilter: ExpectedErrors))
             {
-                var sseTransport = new ServerSentEventsTransport(httpClient, loggerFactory);
+                var sseTransport = new ServerSentEventsTransport(httpClient);
 
                 await sseTransport.StartAsync(
                     new Uri("http://fakeuri.org"), TransferFormat.Text).OrTimeout();


### PR DESCRIPTION
#2832 #2835 

https://github.com/aspnet/SignalR/issues/2879 tracking re-enabling logging