### PR TITLE
Should skip negotiate in tests that use fake urls

### DIFF
--- a/clients/java/signalr/src/test/java/HubConnectionTest.java
+++ b/clients/java/signalr/src/test/java/HubConnectionTest.java
@@ -49,10 +49,10 @@ public class HubConnectionTest {
         exceptionRule.expectMessage("Requested protocol 'messagepack' is not available.");
 
         MockTransport mockTransport = new MockTransport();
-        HubConnection hubConnection = new HubConnection("http://example.com", mockTransport);
+        HubConnection hubConnection = new HubConnection("http://example.com", mockTransport, true);
 
         hubConnection.start();
-        mockTransport.receiveMessage("{\"error\": \"Requested protocol 'messagepack' is not available.\"}" + RECORD_SEPARATOR);
+        mockTransport.receiveMessage("{\"error\":\"Requested protocol 'messagepack' is not available.\"}" + RECORD_SEPARATOR);
     }
 
     @Test


### PR DESCRIPTION
The problem with blocking branches and PRs piling up. Getting them all back in is never easy.

Now that negotiate functionality is in the client we have to make sure to set the `skipNegotiate` flag  for tests that "start" HubConnections  fake urls. 
This skips negotiate and should get our builds green again.