### PR TITLE
Remove a nullref in test logs

### DIFF
--- a/test/Microsoft.AspNetCore.SignalR.Tests.Utils/ServerFixture.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests.Utils/ServerFixture.cs
@@ -116,7 +116,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             _lifetime.ApplicationStopped.Register(() =>
             {
                 _logger.LogInformation("Test server shut down");
-                _logToken.Dispose();
+                _logToken?.Dispose();
             });
         }
 


### PR DESCRIPTION
`_logToken` is only set if a `LoggerFactory` isn't provided to the `ServerFixture` constructor.