### PR TITLE
Add more redis logs

### DIFF
--- a/test/Microsoft.AspNetCore.SignalR.Redis.Tests/Docker.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Redis.Tests/Docker.cs
@@ -93,6 +93,9 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
 
         public void Stop(ILogger logger)
         {
+            // Get logs from Redis container before stopping the container
+            RunProcessAndThrowIfFailed(_path, $"logs {_dockerContainerName}", logger, TimeSpan.FromSeconds(5));
+
             logger.LogInformation("Stopping docker container");
             RunProcessAndThrowIfFailed(_path, $"stop {_dockerContainerName}", logger, TimeSpan.FromSeconds(5));
         }


### PR DESCRIPTION
Doing this because of https://github.com/aspnet/SignalR/issues/2917

Added one log in production https://github.com/aspnet/SignalR/pull/2936/files#diff-43747ccefdb3a6d796ece10fe906a62eR438 and added the `docker logs redisContainer` command on close to the test to collect any logs from the redis instance.

Also removed a bunch of unnecessary `async`