### PR TITLE
Making all the things Package Private in the Java Client

### DIFF
--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/CallbackMap.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/CallbackMap.java
@@ -8,7 +8,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 
-public class CallbackMap {
+ class CallbackMap {
     private ConcurrentHashMap<String, List<ActionBase>> handlers = new ConcurrentHashMap<>();
 
     public void put(String target, ActionBase action) {

--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/CallbackMap.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/CallbackMap.java
@@ -8,7 +8,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 
- class CallbackMap {
+class CallbackMap {
     private ConcurrentHashMap<String, List<ActionBase>> handlers = new ConcurrentHashMap<>();
 
     public void put(String target, ActionBase action) {

--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/CloseMessage.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/CloseMessage.java
@@ -3,7 +3,7 @@
 
 package com.microsoft.aspnet.signalr;
 
-public class CloseMessage extends HubMessage {
+ class CloseMessage extends HubMessage {
     String error;
 
     @Override

--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/CloseMessage.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/CloseMessage.java
@@ -3,7 +3,7 @@
 
 package com.microsoft.aspnet.signalr;
 
- class CloseMessage extends HubMessage {
+class CloseMessage extends HubMessage {
     String error;
 
     @Override

--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/HandshakeProtocol.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/HandshakeProtocol.java
@@ -5,7 +5,7 @@ package com.microsoft.aspnet.signalr;
 
 import com.google.gson.Gson;
 
-public class HandshakeProtocol {
+ class HandshakeProtocol {
     public static Gson gson = new Gson();
     private static final String RECORD_SEPARATOR = "\u001e";
 

--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/HandshakeProtocol.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/HandshakeProtocol.java
@@ -5,7 +5,7 @@ package com.microsoft.aspnet.signalr;
 
 import com.google.gson.Gson;
 
- class HandshakeProtocol {
+class HandshakeProtocol {
     public static Gson gson = new Gson();
     private static final String RECORD_SEPARATOR = "\u001e";
 

--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/HandshakeRequestMessage.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/HandshakeRequestMessage.java
@@ -3,7 +3,7 @@
 
 package com.microsoft.aspnet.signalr;
 
-public class HandshakeRequestMessage {
+ class HandshakeRequestMessage {
     String protocol;
     int version;
 

--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/HandshakeRequestMessage.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/HandshakeRequestMessage.java
@@ -3,7 +3,7 @@
 
 package com.microsoft.aspnet.signalr;
 
- class HandshakeRequestMessage {
+class HandshakeRequestMessage {
     String protocol;
     int version;
 

--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/HandshakeResponseMessage.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/HandshakeResponseMessage.java
@@ -3,7 +3,7 @@
 
 package com.microsoft.aspnet.signalr;
 
- class HandshakeResponseMessage {
+class HandshakeResponseMessage {
     public String error;
 
     public HandshakeResponseMessage() {

--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/HandshakeResponseMessage.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/HandshakeResponseMessage.java
@@ -3,7 +3,7 @@
 
 package com.microsoft.aspnet.signalr;
 
-public class HandshakeResponseMessage {
+ class HandshakeResponseMessage {
     public String error;
 
     public HandshakeResponseMessage() {

--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/HubMessage.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/HubMessage.java
@@ -6,6 +6,6 @@ package com.microsoft.aspnet.signalr;
 /**
  * A base class for hub messages.
  */
-public abstract class HubMessage {
+ abstract class HubMessage {
     public abstract HubMessageType getMessageType();
 }

--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/HubProtocol.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/HubProtocol.java
@@ -6,7 +6,7 @@ package com.microsoft.aspnet.signalr;
 /**
  * A protocol abstraction for communicating with SignalR hubs.
  */
-public interface HubProtocol {
+ interface HubProtocol {
     String getName();
     int getVersion();
     TransferFormat getTransferFormat();

--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/HubProtocol.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/HubProtocol.java
@@ -6,7 +6,7 @@ package com.microsoft.aspnet.signalr;
 /**
  * A protocol abstraction for communicating with SignalR hubs.
  */
- interface HubProtocol {
+interface HubProtocol {
     String getName();
     int getVersion();
     TransferFormat getTransferFormat();

--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/InvocationMessage.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/InvocationMessage.java
@@ -3,7 +3,7 @@
 
 package com.microsoft.aspnet.signalr;
 
- class InvocationMessage extends HubMessage {
+class InvocationMessage extends HubMessage {
     int type = HubMessageType.INVOCATION.value;
     String invocationId;
     String target;

--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/InvocationMessage.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/InvocationMessage.java
@@ -3,7 +3,7 @@
 
 package com.microsoft.aspnet.signalr;
 
-public class InvocationMessage extends HubMessage {
+ class InvocationMessage extends HubMessage {
     int type = HubMessageType.INVOCATION.value;
     String invocationId;
     String target;

--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/JsonHubProtocol.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/JsonHubProtocol.java
@@ -11,7 +11,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 
- class JsonHubProtocol implements HubProtocol {
+class JsonHubProtocol implements HubProtocol {
     private final JsonParser jsonParser = new JsonParser();
     private final Gson gson = new Gson();
     private static final String RECORD_SEPARATOR = "\u001e";

--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/JsonHubProtocol.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/JsonHubProtocol.java
@@ -11,7 +11,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 
-public class JsonHubProtocol implements HubProtocol {
+ class JsonHubProtocol implements HubProtocol {
     private final JsonParser jsonParser = new JsonParser();
     private final Gson gson = new Gson();
     private static final String RECORD_SEPARATOR = "\u001e";

--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/Negotiate.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/Negotiate.java
@@ -10,7 +10,7 @@ import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
 
- class Negotiate {
+class Negotiate {
 
     public static NegotiateResponse processNegotiate(String url) throws IOException {
         return processNegotiate(url, null);

--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/Negotiate.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/Negotiate.java
@@ -10,7 +10,7 @@ import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
 
-public class Negotiate {
+ class Negotiate {
 
     public static NegotiateResponse processNegotiate(String url) throws IOException {
         return processNegotiate(url, null);

--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/NegotiateResponse.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/NegotiateResponse.java
@@ -10,7 +10,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 
-public class NegotiateResponse {
+ class NegotiateResponse {
     private String connectionId;
     private Set<String> availableTransports = new HashSet<>();
     private String redirectUrl;

--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/NegotiateResponse.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/NegotiateResponse.java
@@ -10,7 +10,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 
- class NegotiateResponse {
+class NegotiateResponse {
     private String connectionId;
     private Set<String> availableTransports = new HashSet<>();
     private String redirectUrl;

--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/NullLogger.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/NullLogger.java
@@ -3,7 +3,7 @@
 
 package com.microsoft.aspnet.signalr;
 
- class NullLogger implements Logger {
+class NullLogger implements Logger {
     @Override
     public void log(LogLevel logLevel, String message) { }
 

--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/NullLogger.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/NullLogger.java
@@ -3,7 +3,7 @@
 
 package com.microsoft.aspnet.signalr;
 
-public class NullLogger implements Logger {
+ class NullLogger implements Logger {
     @Override
     public void log(LogLevel logLevel, String message) { }
 

--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/OnReceiveCallBack.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/OnReceiveCallBack.java
@@ -3,6 +3,6 @@
 
 package com.microsoft.aspnet.signalr;
 
- interface OnReceiveCallBack {
+interface OnReceiveCallBack {
     void invoke(String message) throws Exception;
 }

--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/OnReceiveCallBack.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/OnReceiveCallBack.java
@@ -3,6 +3,6 @@
 
 package com.microsoft.aspnet.signalr;
 
-public interface OnReceiveCallBack {
+ interface OnReceiveCallBack {
     void invoke(String message) throws Exception;
 }

--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/PingMessage.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/PingMessage.java
@@ -3,7 +3,7 @@
 
 package com.microsoft.aspnet.signalr;
 
- class PingMessage extends HubMessage {
+class PingMessage extends HubMessage {
 
     int type = HubMessageType.PING.value;
 

--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/PingMessage.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/PingMessage.java
@@ -3,7 +3,7 @@
 
 package com.microsoft.aspnet.signalr;
 
-public class PingMessage extends HubMessage {
+ class PingMessage extends HubMessage {
 
     int type = HubMessageType.PING.value;
 

--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/Transport.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/Transport.java
@@ -3,7 +3,7 @@
 
 package com.microsoft.aspnet.signalr;
 
- interface Transport {
+interface Transport {
     void start() throws Exception;
     void send(String message) throws Exception;
     void setOnReceive(OnReceiveCallBack callback);

--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/Transport.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/Transport.java
@@ -3,7 +3,7 @@
 
 package com.microsoft.aspnet.signalr;
 
-public interface Transport {
+ interface Transport {
     void start() throws Exception;
     void send(String message) throws Exception;
     void setOnReceive(OnReceiveCallBack callback);

--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/WebSocketTransport.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/WebSocketTransport.java
@@ -10,7 +10,7 @@ import java.util.Map;
 import org.java_websocket.client.WebSocketClient;
 import org.java_websocket.handshake.ServerHandshake;
 
- class WebSocketTransport implements Transport {
+class WebSocketTransport implements Transport {
     private WebSocketClient webSocketClient;
     private OnReceiveCallBack onReceiveCallBack;
     private URI url;

--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/WebSocketTransport.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/WebSocketTransport.java
@@ -10,7 +10,7 @@ import java.util.Map;
 import org.java_websocket.client.WebSocketClient;
 import org.java_websocket.handshake.ServerHandshake;
 
-public class WebSocketTransport implements Transport {
+ class WebSocketTransport implements Transport {
     private WebSocketClient webSocketClient;
     private OnReceiveCallBack onReceiveCallBack;
     private URI url;

--- a/clients/java/signalr/src/test/java/com/microsoft/aspnet/signalr/HandshakeProtocolTest.java
+++ b/clients/java/signalr/src/test/java/com/microsoft/aspnet/signalr/HandshakeProtocolTest.java
@@ -1,15 +1,11 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-package com.microsoft.aspnet.signalr.test;
+package com.microsoft.aspnet.signalr;
 
 import static org.junit.Assert.*;
 
 import org.junit.Test;
-
-import com.microsoft.aspnet.signalr.HandshakeProtocol;
-import com.microsoft.aspnet.signalr.HandshakeRequestMessage;
-import com.microsoft.aspnet.signalr.HandshakeResponseMessage;
 
 public class HandshakeProtocolTest {
 

--- a/clients/java/signalr/src/test/java/com/microsoft/aspnet/signalr/HubConnectionTest.java
+++ b/clients/java/signalr/src/test/java/com/microsoft/aspnet/signalr/HubConnectionTest.java
@@ -12,7 +12,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import com.microsoft.aspnet.signalr.*;
 
 public class HubConnectionTest {
     private static final String RECORD_SEPARATOR = "\u001e";

--- a/clients/java/signalr/src/test/java/com/microsoft/aspnet/signalr/HubConnectionTest.java
+++ b/clients/java/signalr/src/test/java/com/microsoft/aspnet/signalr/HubConnectionTest.java
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-package com.microsoft.aspnet.signalr.test;
+package com.microsoft.aspnet.signalr;
 
 import static org.junit.Assert.*;
 

--- a/clients/java/signalr/src/test/java/com/microsoft/aspnet/signalr/HubExceptionTest.java
+++ b/clients/java/signalr/src/test/java/com/microsoft/aspnet/signalr/HubExceptionTest.java
@@ -1,13 +1,11 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-package com.microsoft.aspnet.signalr.test;
+package com.microsoft.aspnet.signalr;
 
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
-
-import com.microsoft.aspnet.signalr.HubException;
 
 public class HubExceptionTest {
     @Test

--- a/clients/java/signalr/src/test/java/com/microsoft/aspnet/signalr/JsonHubProtocolTest.java
+++ b/clients/java/signalr/src/test/java/com/microsoft/aspnet/signalr/JsonHubProtocolTest.java
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-package com.microsoft.aspnet.signalr.test;
+package com.microsoft.aspnet.signalr;
 
 import static org.junit.Assert.*;
 

--- a/clients/java/signalr/src/test/java/com/microsoft/aspnet/signalr/JsonHubProtocolTest.java
+++ b/clients/java/signalr/src/test/java/com/microsoft/aspnet/signalr/JsonHubProtocolTest.java
@@ -10,7 +10,6 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import com.google.gson.JsonArray;
-import com.microsoft.aspnet.signalr.*;
 
 public class JsonHubProtocolTest {
     private JsonHubProtocol jsonHubProtocol = new JsonHubProtocol();

--- a/clients/java/signalr/src/test/java/com/microsoft/aspnet/signalr/NegotiateResponseTest.java
+++ b/clients/java/signalr/src/test/java/com/microsoft/aspnet/signalr/NegotiateResponseTest.java
@@ -7,7 +7,6 @@ import static org.junit.Assert.*;
 
 import org.junit.Test;
 
-import com.microsoft.aspnet.signalr.NegotiateResponse;
 
 public class NegotiateResponseTest {
 

--- a/clients/java/signalr/src/test/java/com/microsoft/aspnet/signalr/NegotiateResponseTest.java
+++ b/clients/java/signalr/src/test/java/com/microsoft/aspnet/signalr/NegotiateResponseTest.java
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-package com.microsoft.aspnet.signalr.test;
+package com.microsoft.aspnet.signalr;
 
 import static org.junit.Assert.*;
 

--- a/clients/java/signalr/src/test/java/com/microsoft/aspnet/signalr/ResolveNegotiateUrlTest.java
+++ b/clients/java/signalr/src/test/java/com/microsoft/aspnet/signalr/ResolveNegotiateUrlTest.java
@@ -12,7 +12,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import com.microsoft.aspnet.signalr.Negotiate;
 
 @RunWith(Parameterized.class)
 public class ResolveNegotiateUrlTest {

--- a/clients/java/signalr/src/test/java/com/microsoft/aspnet/signalr/ResolveNegotiateUrlTest.java
+++ b/clients/java/signalr/src/test/java/com/microsoft/aspnet/signalr/ResolveNegotiateUrlTest.java
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-package com.microsoft.aspnet.signalr.test;
+package com.microsoft.aspnet.signalr;
 
 import static org.junit.Assert.assertEquals;
 

--- a/clients/java/signalr/src/test/java/com/microsoft/aspnet/signalr/WebSocketTransportTest.java
+++ b/clients/java/signalr/src/test/java/com/microsoft/aspnet/signalr/WebSocketTransportTest.java
@@ -1,15 +1,11 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-package com.microsoft.aspnet.signalr.test;
+package com.microsoft.aspnet.signalr;
 
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-
-import com.microsoft.aspnet.signalr.NullLogger;
-import com.microsoft.aspnet.signalr.Transport;
-import com.microsoft.aspnet.signalr.WebSocketTransport;
 
 public class WebSocketTransportTest {
 

--- a/clients/java/signalr/src/test/java/com/microsoft/aspnet/signalr/WebSocketTransportUrlFormatTest.java
+++ b/clients/java/signalr/src/test/java/com/microsoft/aspnet/signalr/WebSocketTransportUrlFormatTest.java
@@ -13,8 +13,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import com.microsoft.aspnet.signalr.NullLogger;
-import com.microsoft.aspnet.signalr.WebSocketTransport;
 
 @RunWith(Parameterized.class)
 public class WebSocketTransportUrlFormatTest {

--- a/clients/java/signalr/src/test/java/com/microsoft/aspnet/signalr/WebSocketTransportUrlFormatTest.java
+++ b/clients/java/signalr/src/test/java/com/microsoft/aspnet/signalr/WebSocketTransportUrlFormatTest.java
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-package com.microsoft.aspnet.signalr.test;
+package com.microsoft.aspnet.signalr;
 
 import static org.junit.Assert.*;
 


### PR DESCRIPTION
Part 1 of API review PRs
The default access level in Java if package private. So everything in the same package has access to it. This is the closest we can get to internal. 
I've made most of the types package private and moved the test code into the same package as the source, `com.microsoft.src`, but they are still in their own directories.
Also, Spotless is awesome 😄 