### PR TITLE
Move Java chat sample to a samples package

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
             "cwd": "${workspaceFolder}/clients/java/",
             "console": "externalTerminal",
             "stopOnEntry": false,
-            "mainClass": "com.microsoft.aspnet.signalr.Chat",
+            "mainClass": "com.microsoft.aspnet.signalr.sample.Chat",
             "args": ""
         },
         {

--- a/clients/java/signalr/src/test/java/com/microsoft/aspnet/signalr/sample/Chat.java
+++ b/clients/java/signalr/src/test/java/com/microsoft/aspnet/signalr/sample/Chat.java
@@ -1,7 +1,11 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-package com.microsoft.aspnet.signalr;
+package com.microsoft.aspnet.signalr.sample;
+
+import com.microsoft.aspnet.signalr.HubConnection;
+import com.microsoft.aspnet.signalr.HubConnectionBuilder;
+import com.microsoft.aspnet.signalr.LogLevel;
 
 import java.util.Scanner;
 

--- a/clients/java/signalr/src/test/java/com/microsoft/aspnet/signalr/sample/Chat.java
+++ b/clients/java/signalr/src/test/java/com/microsoft/aspnet/signalr/sample/Chat.java
@@ -3,11 +3,11 @@
 
 package com.microsoft.aspnet.signalr.sample;
 
+import java.util.Scanner;
+
 import com.microsoft.aspnet.signalr.HubConnection;
 import com.microsoft.aspnet.signalr.HubConnectionBuilder;
 import com.microsoft.aspnet.signalr.LogLevel;
-
-import java.util.Scanner;
 
 public class Chat {
     public static void main(String[] args) throws Exception {


### PR DESCRIPTION
Moving the chat sample into a samples package.
It's also good because now only the fully public types, not the package private types, are exposed to the sample. 
