### PR TITLE
Wait for the Handshake Response Java

### DIFF
--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/HubConnection.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/HubConnection.java
@@ -57,6 +57,7 @@ public class HubConnection {
                     throw new HubException(errorMessage);
                 }
                 handshakeReceived = true;
+                hubConnectionState = HubConnectionState.CONNECTED;
 
                 payload = payload.substring(handshakeLength);
                 // The payload only contained the handshake response so we can return.
@@ -214,7 +215,7 @@ public class HubConnection {
             return transport.send(handshake).thenRun(() -> {
                 hubConnectionStateLock.lock();
                 try {
-                    hubConnectionState = HubConnectionState.CONNECTED;
+                    hubConnectionState = HubConnectionState.CONNECTING;
                     connectionState = new ConnectionState(this);
                     logger.log(LogLevel.Information, "HubConnected started.");
                 } finally {

--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/HubConnectionState.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/HubConnectionState.java
@@ -5,5 +5,6 @@ package com.microsoft.aspnet.signalr;
 
 public enum HubConnectionState {
     CONNECTED,
+    CONNECTING,
     DISCONNECTED,
 }

--- a/clients/java/signalr/src/test/java/com/microsoft/aspnet/signalr/HubConnectionTest.java
+++ b/clients/java/signalr/src/test/java/com/microsoft/aspnet/signalr/HubConnectionTest.java
@@ -19,9 +19,12 @@ class HubConnectionTest {
 
     @Test
     public void checkHubConnectionState() throws Exception {
-        Transport mockTransport = new MockTransport();
+        MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = new HubConnection("http://example.com", mockTransport, true);
         hubConnection.start();
+        assertEquals(HubConnectionState.CONNECTING, hubConnection.getConnectionState());
+
+        mockTransport.receiveMessage("{}" + RECORD_SEPARATOR);
         assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
 
         hubConnection.stop();
@@ -826,9 +829,12 @@ class HubConnectionTest {
 
     @Test
     public void callingStartOnStartedHubConnectionNoOps() throws Exception {
-        Transport mockTransport = new MockTransport();
+        MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = new HubConnection("http://example.com", mockTransport, true);
         hubConnection.start();
+        assertEquals(HubConnectionState.CONNECTING, hubConnection.getConnectionState());
+
+        mockTransport.receiveMessage("{}" + RECORD_SEPARATOR);
         assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
 
         hubConnection.start();


### PR DESCRIPTION
Waiting for the `Handshake Response` in the Java client before entering the `CONNECTED` state. I added an intermediate `CONNECTING` state as well.