### PR TITLE
More robust plugin load

### DIFF
--- a/clients/java/signalr/build.gradle
+++ b/clients/java/signalr/build.gradle
@@ -1,8 +1,20 @@
+buildscript {
+    repositories {
+    maven {
+      url "https://plugins.gradle.org/m2/"
+    }
+  }
+  dependencies {
+    classpath "com.diffplug.spotless:spotless-plugin-gradle:3.14.0"
+  }
+}
+
 plugins {
     id 'java'
     id 'maven'
-    id "com.diffplug.gradle.spotless" version "3.14.0"
 }
+
+apply plugin: "com.diffplug.gradle.spotless"
 
 group 'com.microsoft.aspnet'
 


### PR DESCRIPTION
A bunch of our builds are failing because of errors downloading the spotless plugin.
Reading some forums posts it seems the new and improved plugin support in gradle isn't very good. So moving it to the old style for hopefully more successful builds.

See https://discuss.gradle.org/t/timeouts-on-plugins-gradle-org/28336/9