### PR TITLE
Remove old Websockets dependency

### DIFF
--- a/clients/java/signalr/build.gradle
+++ b/clients/java/signalr/build.gradle
@@ -31,7 +31,6 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.3.1'
     testCompile 'org.junit.jupiter:junit-jupiter-params:5.3.1'
     testRuntime 'org.junit.jupiter:junit-jupiter-engine:5.3.1'
-    implementation "org.java-websocket:Java-WebSocket:1.3.8"
     implementation 'com.google.code.gson:gson:2.8.5'
     implementation 'com.squareup.okhttp3:okhttp:3.11.0'
 }


### PR DESCRIPTION
We've moved to using Squares OkHttp Websockets implementation. 