### PR TITLE
Update Console Logger

### DIFF
--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/ConsoleLogger.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/ConsoleLogger.java
@@ -19,7 +19,7 @@ public class ConsoleLogger implements Logger {
     public void log(LogLevel logLevel, String message) {
         if (logLevel.value >= this.logLevel.value) {
             String timeStamp = dateFormat.format(new Date());
-            message = String.format("[%s] [%s] %s", timeStamp, logLevel, message);
+            message = String.format("[%s] [%s] %s%n", timeStamp, logLevel, message);
             switch (logLevel) {
                 case Debug:
                 case Information:


### PR DESCRIPTION
Small thing I noticed in the ConsoleLogger implementation. The formatted string needs a newline