### PR TITLE
Typos/spelling errors in XML doc comments and source. #Hacktoberfest

### DIFF
--- a/benchmarkapps/Crankier/Worker.cs
+++ b/benchmarkapps/Crankier/Worker.cs
@@ -68,7 +68,7 @@ namespace Microsoft.AspNetCore.SignalR.Crankier
                 await client.CreateAndStartConnectionAsync(targetAddress, transportType);
             }
 
-            Log("Connections connected succesfully");
+            Log("Connections connected successfully");
         }
 
         public Task StartTestAsync(TimeSpan sendInterval, int sendBytes)
@@ -80,7 +80,7 @@ namespace Microsoft.AspNetCore.SignalR.Crankier
                 client.StartTest(sendBytes, sendInterval);
             }
 
-            Log("Test started succesfully");
+            Log("Test started successfully");
             return Task.CompletedTask;
         }
 
@@ -98,7 +98,7 @@ namespace Microsoft.AspNetCore.SignalR.Crankier
             }
 
             _sendStatusCts.Cancel();
-            Log("Connections stopped succesfully");
+            Log("Connections stopped successfully");
             _targetConnectionCount = 0;
 
             return Task.CompletedTask;

--- a/src/Common/BinaryMessageParser.cs
+++ b/src/Common/BinaryMessageParser.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNetCore.Internal
             // remaining bits (%x0000000) are the lowest bits of the value. The most significant bit of the second
             // byte is 0 meaning this is last byte of the VarInt. The actual value bits (%x0101001) need to be
             // prepended to the bits we already read so the values is %01010010000000 i.e. 0x1480 (5248)
-            // We support paylads up to 2GB so the biggest number we support is 7fffffff which when encoded as
+            // We support payloads up to 2GB so the biggest number we support is 7fffffff which when encoded as
             // VarInt is 0xFF 0xFF 0xFF 0xFF 0x07 - hence the maximum length prefix is 5 bytes.
 
             var length = 0U;

--- a/src/Common/JsonUtils.cs
+++ b/src/Common/JsonUtils.cs
@@ -155,7 +155,7 @@ namespace Microsoft.AspNetCore.Internal
 
         public static bool ReadForType(JsonTextReader reader, Type type)
         {
-            // Explicity read values as dates from JSON with reader.
+            // Explicitly read values as dates from JSON with reader.
             // We do this because otherwise dates are read as strings
             // and the JsonSerializer will use a conversion method that won't
             // preserve UTC in DateTime.Kind for UTC ISO8601 dates

--- a/src/Common/Utf8BufferTextReader.cs
+++ b/src/Common/Utf8BufferTextReader.cs
@@ -34,7 +34,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal
                 reader = new Utf8BufferTextReader();
             }
 
-            // Taken off the the thread static
+            // Taken off the thread static
             _cachedInstance = null;
 #if DEBUG
             if (reader._inUse)

--- a/src/Common/Utf8BufferTextWriter.cs
+++ b/src/Common/Utf8BufferTextWriter.cs
@@ -43,7 +43,7 @@ namespace Microsoft.AspNetCore.Internal
                 writer = new Utf8BufferTextWriter();
             }
 
-            // Taken off the the thread static
+            // Taken off the thread static
             _cachedInstance = null;
 #if DEBUG
             if (writer._inUse)

--- a/src/Microsoft.AspNetCore.Http.Connections.Client/HttpConnection.cs
+++ b/src/Microsoft.AspNetCore.Http.Connections.Client/HttpConnection.cs
@@ -529,7 +529,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
                 httpMessageHandler = new AccessTokenHttpMessageHandler(httpMessageHandler, this);
             }
 
-            // Wrap message handler after HttpMessageHandlerFactory to ensure not overriden
+            // Wrap message handler after HttpMessageHandlerFactory to ensure not overridden
             httpMessageHandler = new LoggingHttpMessageHandler(httpMessageHandler, _loggerFactory);
 
             var httpClient = new HttpClient(httpMessageHandler);

--- a/src/Microsoft.AspNetCore.Http.Connections/Internal/HttpConnectionDispatcher.cs
+++ b/src/Microsoft.AspNetCore.Http.Connections/Internal/HttpConnectionDispatcher.cs
@@ -299,7 +299,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
                         // If the status code is a 204 it means the connection is done
                         if (context.Response.StatusCode == StatusCodes.Status204NoContent)
                         {
-                            // Cancel current request to release any waiting poll and let dispose aquire the lock
+                            // Cancel current request to release any waiting poll and let dispose acquire the lock
                             currentRequestTcs.TrySetCanceled();
 
                             // We should be able to safely dispose because there's no more data being written
@@ -312,7 +312,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
                     }
                     else if (resultTask.IsFaulted)
                     {
-                        // Cancel current request to release any waiting poll and let dispose aquire the lock
+                        // Cancel current request to release any waiting poll and let dispose acquire the lock
                         currentRequestTcs.TrySetCanceled();
 
                         // transport task was faulted, we should remove the connection

--- a/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnection.cs
@@ -714,7 +714,7 @@ namespace Microsoft.AspNetCore.SignalR.Client
                                 {
                                     // Adjust consumed and examined to point to the end of the handshake
                                     // response, this handles the case where invocations are sent in the same payload
-                                    // as the the negotiate response.
+                                    // as the negotiate response.
                                     consumed = buffer.Start;
                                     examined = consumed;
 

--- a/src/Microsoft.AspNetCore.SignalR.Common/Protocol/HandshakeResponseMessage.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Common/Protocol/HandshakeResponseMessage.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
         /// <summary>
         /// Initializes a new instance of the <see cref="HandshakeResponseMessage"/> class.
         /// </summary>
-        /// <param name="error">An optional response error message. A <c>null</c> error message indicates a succesful handshake.</param>
+        /// <param name="error">An optional response error message. A <c>null</c> error message indicates a successful handshake.</param>
         public HandshakeResponseMessage(string error)
         {
             // Note that a response with an empty string for error in the JSON is considered an errored response

--- a/src/Microsoft.AspNetCore.SignalR.Core/IUserIdProvider.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/IUserIdProvider.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AspNetCore.SignalR
         /// <summary>
         /// Gets the user ID for the specified connection.
         /// </summary>
-        /// <param name="connection">The connection get get the user ID for.</param>
+        /// <param name="connection">The connection to get the user ID for.</param>
         /// <returns>The user ID for the specified connection.</returns>
         string GetUserId(HubConnectionContext connection);
     }

--- a/test/Microsoft.AspNetCore.SignalR.Client.Tests/ServerSentEventsTransportTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Client.Tests/ServerSentEventsTransportTests.cs
@@ -327,7 +327,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
 
                 await sseTransport.Output.WriteAsync(new byte[] { 0x42 });
 
-                // For for send request to be in progress
+                // For send request to be in progress
                 await sendSyncPoint.WaitForSyncPoint();
 
                 var stopTask = sseTransport.StopAsync();

--- a/test/Microsoft.AspNetCore.SignalR.Redis.Tests/Docker.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Redis.Tests/Docker.cs
@@ -81,7 +81,7 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
             // create and run docker container, remove automatically when stopped, map 6379 from the container to 6379 localhost
             // use static name 'redisTestContainer' so if the container doesn't get removed we don't keep adding more
             // use redis base docker image
-            // 20 second timeout to allow redis image to be downloaded, should be a rare occurance, only happening when a new version is released
+            // 20 second timeout to allow redis image to be downloaded, should be a rare occurrence, only happening when a new version is released
             RunProcessAndThrowIfFailed(_path, $"run --rm -p 6379:6379 --name {_dockerContainerName} -d redis", "redis", logger, TimeSpan.FromSeconds(20));
 
             // inspect the redis docker image and extract the IPAddress. Necessary when running tests from inside a docker container, spinning up a new docker container for redis


### PR DESCRIPTION
Going for a nice t-shirt.

Here's some typos/spelling errors I found in this repo.

Happy #Hacktoberfest :smiley_cat: :fearful: :skull_and_crossbones: :moon: :bat: 

Thanks,
Brian

:boom: :fire: ***["Set it ablaze like a candle wick... Light it up, light it up..."](https://www.youtube.com/watch?v=qDcFryDXQ7U)***