### PR TITLE
[Java] Clean up WebSockets Transport

### DIFF
--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/HttpClient.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/HttpClient.java
@@ -109,7 +109,7 @@ abstract class HttpClient {
         request.setMethod("DELETE");
         return this.send(request);
     }
-    
+
     public CompletableFuture<HttpResponse> delete(String url, HttpRequest options) {
         options.setUrl(url);
         options.setMethod("DELETE");

--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/HubConnection.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/HubConnection.java
@@ -197,7 +197,7 @@ public class HubConnection {
 
             logger.log(LogLevel.Debug, "Starting HubConnection");
             if (transport == null) {
-                    transport = new WebSocketTransport(url, headers, httpClient, logger);
+                transport = new WebSocketTransport(url, headers, httpClient, logger);
             }
 
             transport.setOnReceive(this.callback);

--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/HubConnection.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/HubConnection.java
@@ -4,7 +4,6 @@
 package com.microsoft.aspnet.signalr;
 
 import java.io.IOException;
-import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;

--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/HubConnection.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/HubConnection.java
@@ -198,11 +198,7 @@ public class HubConnection {
 
             logger.log(LogLevel.Debug, "Starting HubConnection");
             if (transport == null) {
-                try {
                     transport = new WebSocketTransport(url, headers, httpClient, logger);
-                } catch (URISyntaxException e) {
-                    throw new RuntimeException(e);
-                }
             }
 
             transport.setOnReceive(this.callback);

--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/WebSocketTransport.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/WebSocketTransport.java
@@ -3,7 +3,6 @@
 
 package com.microsoft.aspnet.signalr;
 
-import java.net.URISyntaxException;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
@@ -20,7 +19,7 @@ class WebSocketTransport implements Transport {
     private static final String WS = "ws";
     private static final String WSS = "wss";
 
-    public WebSocketTransport(String url, Map<String, String> headers, HttpClient client, Logger logger) throws URISyntaxException {
+    public WebSocketTransport(String url, Map<String, String> headers, HttpClient client, Logger logger) {
         this.url = formatUrl(url);
         this.logger = logger;
         this.client = client;
@@ -31,7 +30,7 @@ class WebSocketTransport implements Transport {
         return url;
     }
 
-    private String formatUrl(String url) throws URISyntaxException {
+    private String formatUrl(String url) {
         if (url.startsWith(HTTPS)) {
             url = WSS + url.substring(HTTPS.length());
         } else if (url.startsWith(HTTP)) {
@@ -44,7 +43,7 @@ class WebSocketTransport implements Transport {
     @Override
     public CompletableFuture<Void> start() {
         logger.log(LogLevel.Debug, "Starting Websocket connection.");
-        this.webSocketClient = client.createWebSocket(this.url.toString(), this.headers);
+        this.webSocketClient = client.createWebSocket(this.url, this.headers);
         this.webSocketClient.setOnReceive((message) -> onReceive(message));
         this.webSocketClient.setOnClose((code, reason) -> onClose(code, reason));
         return webSocketClient.start().thenRun(() -> logger.log(LogLevel.Information, "WebSocket transport connected to: %s.", this.url));

--- a/clients/java/signalr/src/test/java/com/microsoft/aspnet/signalr/TestHttpClient.java
+++ b/clients/java/signalr/src/test/java/com/microsoft/aspnet/signalr/TestHttpClient.java
@@ -66,5 +66,5 @@ class TestHttpClient extends HttpClient {
     @Override
     public WebSocketWrapper createWebSocket(String url, Map<String, String> headers) {
         throw new RuntimeException("WebSockets isn't supported in testing currently.");
-	}
+    }
 }


### PR DESCRIPTION
We updated the Webosckets transport to use a string to internally represent the url that we use to create the underlying transport. There was some clean up that needed to happen.