### PR TITLE
Transport stop triggers HubConnection stop

### DIFF
--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/HubConnection.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/HubConnection.java
@@ -304,8 +304,6 @@ public class HubConnection {
         HubException hubException = null;
         hubConnectionStateLock.lock();
         try {
-            hubConnectionState = HubConnectionState.DISCONNECTED;
-
             // errorMessage gets passed in from the transport. An already existing stopError value
             // should take precedence.
             if (stopError != null) {
@@ -318,6 +316,7 @@ public class HubConnection {
             connectionState.cancelOutstandingInvocations(hubException);
             connectionState = null;
             logger.log(LogLevel.Information, "HubConnection stopped.");
+            hubConnectionState = HubConnectionState.DISCONNECTED;
         } finally {
             hubConnectionStateLock.unlock();
         }

--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/HubConnection.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/HubConnection.java
@@ -301,7 +301,7 @@ public class HubConnection {
     }
 
     private void stopConnection(String errorMessage) {
-        HubException hubException = null;
+        RuntimeException exception = null;
         hubConnectionStateLock.lock();
         try {
             // errorMessage gets passed in from the transport. An already existing stopError value
@@ -310,10 +310,10 @@ public class HubConnection {
                 errorMessage = stopError;
             }
             if (errorMessage != null) {
-                hubException = new HubException(errorMessage);
+                exception = new RuntimeException(errorMessage);
                 logger.log(LogLevel.Error, "HubConnection disconnected with an error %s.", errorMessage);
             }
-            connectionState.cancelOutstandingInvocations(hubException);
+            connectionState.cancelOutstandingInvocations(exception);
             connectionState = null;
             logger.log(LogLevel.Information, "HubConnection stopped.");
             hubConnectionState = HubConnectionState.DISCONNECTED;
@@ -324,7 +324,7 @@ public class HubConnection {
         // Do not run these callbacks inside the hubConnectionStateLock
         if (onClosedCallbackList != null) {
             for (Consumer<Exception> callback : onClosedCallbackList) {
-                callback.accept(hubException);
+                callback.accept(exception);
             }
         }
     }

--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/HubConnection.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/HubConnection.java
@@ -195,7 +195,7 @@ public class HubConnection {
                     }
                 });
 
-        stopError = null;        
+        stopError = null;
         CompletableFuture<String> negotiate = null;
         if (!skipNegotiate) {
             negotiate = tokenFuture.thenCompose((v) -> startNegotiate(baseUrl, 0));

--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/HubConnection.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/HubConnection.java
@@ -33,6 +33,7 @@ public class HubConnection {
     private Map<String, String> headers = new HashMap<>();
     private ConnectionState connectionState = null;
     private HttpClient httpClient;
+    private String stopError;
 
     private static ArrayList<Class<?>> emptyArray = new ArrayList<>();
     private static int MAX_NEGOTIATE_ATTEMPTS = 100;
@@ -194,6 +195,7 @@ public class HubConnection {
                     }
                 });
 
+        stopError = null;        
         CompletableFuture<String> negotiate = null;
         if (!skipNegotiate) {
             negotiate = tokenFuture.thenCompose((v) -> startNegotiate(baseUrl, 0));
@@ -208,6 +210,7 @@ public class HubConnection {
             }
 
             transport.setOnReceive(this.callback);
+            transport.setOnClose((message) -> stopConnection(message));
 
             try {
                 return transport.start(url).thenCompose((future) -> {
@@ -281,35 +284,13 @@ public class HubConnection {
                 logger.log(LogLevel.Error, "HubConnection disconnected with an error: %s.", errorMessage);
             } else {
                 logger.log(LogLevel.Debug, "Stopping HubConnection.");
+                stopError = errorMessage;
             }
         } finally {
             hubConnectionStateLock.unlock();
         }
 
-        return transport.stop().whenComplete((i, t) -> {
-            HubException hubException = null;
-            hubConnectionStateLock.lock();
-            try {
-                if (errorMessage != null) {
-                    hubException = new HubException(errorMessage);
-                } else if (t != null) {
-                    hubException = new HubException(t.getMessage());
-                }
-                connectionState.cancelOutstandingInvocations(hubException);
-                connectionState = null;
-                logger.log(LogLevel.Information, "HubConnection stopped.");
-                hubConnectionState = HubConnectionState.DISCONNECTED;
-            } finally {
-                hubConnectionStateLock.unlock();
-            }
-
-            // Do not run these callbacks inside the hubConnectionStateLock
-            if (onClosedCallbackList != null) {
-                for (Consumer<Exception> callback : onClosedCallbackList) {
-                    callback.accept(hubException);
-                }
-            }
-        });
+        return transport.stop();
     }
 
     /**
@@ -317,6 +298,36 @@ public class HubConnection {
      */
     public CompletableFuture<Void> stop() {
         return stop(null);
+    }
+
+    private void stopConnection(String errorMessage) {
+        HubException hubException = null;
+        hubConnectionStateLock.lock();
+        try {
+            hubConnectionState = HubConnectionState.DISCONNECTED;
+
+            // errorMessage gets passed in from the transport. An already existing stopError value
+            // should take precedence.
+            if (stopError != null) {
+                errorMessage = stopError;
+            }
+            if (errorMessage != null) {
+                hubException = new HubException(errorMessage);
+                logger.log(LogLevel.Error, "HubConnection disconnected with an error %s.", errorMessage);
+            }
+            connectionState.cancelOutstandingInvocations(hubException);
+            connectionState = null;
+            logger.log(LogLevel.Information, "HubConnection stopped.");
+        } finally {
+            hubConnectionStateLock.unlock();
+        }
+
+        // Do not run these callbacks inside the hubConnectionStateLock
+        if (onClosedCallbackList != null) {
+            for (Consumer<Exception> callback : onClosedCallbackList) {
+                callback.accept(hubException);
+            }
+        }
     }
 
     /**

--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/HubConnection.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/HubConnection.java
@@ -281,10 +281,10 @@ public class HubConnection {
             }
 
             if (errorMessage != null) {
+                stopError = errorMessage;
                 logger.log(LogLevel.Error, "HubConnection disconnected with an error: %s.", errorMessage);
             } else {
                 logger.log(LogLevel.Debug, "Stopping HubConnection.");
-                stopError = errorMessage;
             }
         } finally {
             hubConnectionStateLock.unlock();

--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/OkHttpWebSocketWrapper.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/OkHttpWebSocketWrapper.java
@@ -97,6 +97,7 @@ class OkHttpWebSocketWrapper extends WebSocketWrapper {
         public void onFailure(WebSocket webSocket, Throwable t, Response response) {
             logger.log(LogLevel.Error, "Websocket closed from an error: %s.", t.getMessage());
             closeFuture.completeExceptionally(new RuntimeException(t));
+            onClose.accept(null, t.getMessage());
             checkStartFailure();
         }
 

--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/Transport.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/Transport.java
@@ -4,11 +4,13 @@
 package com.microsoft.aspnet.signalr;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
 
 interface Transport {
     CompletableFuture<Void> start(String url);
     CompletableFuture<Void> send(String message);
     void setOnReceive(OnReceiveCallBack callback);
     void onReceive(String message) throws Exception;
+    void setOnClose(Consumer<String> onCloseCallback);
     CompletableFuture<Void> stop();
 }

--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/WebSocketTransport.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/WebSocketTransport.java
@@ -91,6 +91,5 @@ class WebSocketTransport implements Transport {
         else {
             onClose.accept(null);
         }
-
     }
 }

--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/WebSocketTransport.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/WebSocketTransport.java
@@ -5,10 +5,12 @@ package com.microsoft.aspnet.signalr;
 
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
 
 class WebSocketTransport implements Transport {
     private WebSocketWrapper webSocketClient;
     private OnReceiveCallBack onReceiveCallBack;
+    private Consumer<String> onClose;
     private String url;
     private Logger logger;
     private HttpClient client;
@@ -45,7 +47,12 @@ class WebSocketTransport implements Transport {
         logger.log(LogLevel.Debug, "Starting Websocket connection.");
         this.webSocketClient = client.createWebSocket(this.url, this.headers);
         this.webSocketClient.setOnReceive((message) -> onReceive(message));
-        this.webSocketClient.setOnClose((code, reason) -> onClose(code, reason));
+        this.webSocketClient.setOnClose((code, reason) -> {
+            if (onClose != null) {
+                onClose(code, reason);
+            }
+        });
+
         return webSocketClient.start().thenRun(() -> logger.log(LogLevel.Information, "WebSocket transport connected to: %s.", this.url));
     }
 
@@ -66,6 +73,11 @@ class WebSocketTransport implements Transport {
     }
 
     @Override
+    public void setOnClose(Consumer<String> onCloseCallback) {
+        this.onClose = onCloseCallback;
+    }
+
+    @Override
     public CompletableFuture<Void> stop() {
         return webSocketClient.stop().whenComplete((i, j) -> logger.log(LogLevel.Information, "WebSocket connection stopped."));
     }
@@ -73,5 +85,12 @@ class WebSocketTransport implements Transport {
     void onClose(int code, String reason) {
         logger.log(LogLevel.Information, "WebSocket connection stopping with " +
                 "code %d and reason '%s'.", code, reason);
+        if (code != 1000) {
+            onClose.accept(reason);
+        }
+        else {
+            onClose.accept(null);
+        }
+
     }
 }

--- a/clients/java/signalr/src/test/java/com/microsoft/aspnet/signalr/HubConnectionTest.java
+++ b/clients/java/signalr/src/test/java/com/microsoft/aspnet/signalr/HubConnectionTest.java
@@ -32,7 +32,7 @@ class HubConnectionTest {
     @Test
     public void transportCloseTriggersStopInHubConnection() throws Exception {
         MockTransport mockTransport = new MockTransport();
-        HubConnection hubConnection = new HubConnection("http://example.com", mockTransport, new NullLogger(), true, new TestHttpClient());
+        HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport);
         hubConnection.start();
         assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
         mockTransport.stop();
@@ -43,7 +43,7 @@ class HubConnectionTest {
     @Test
     public void transportCloseWithErrorTriggersStopInHubConnection() throws Exception {
         MockTransport mockTransport = new MockTransport();
-        HubConnection hubConnection = new HubConnection("http://example.com", mockTransport, new NullLogger(), true, new TestHttpClient());
+        HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport);
         String errorMessage = "Example transport error.";
 
         hubConnection.onClosed((error) -> {

--- a/clients/java/signalr/src/test/java/com/microsoft/aspnet/signalr/HubConnectionTest.java
+++ b/clients/java/signalr/src/test/java/com/microsoft/aspnet/signalr/HubConnectionTest.java
@@ -30,6 +30,34 @@ class HubConnectionTest {
     }
 
     @Test
+    public void transportCloseTriggersStopInHubConnection() throws Exception {
+        MockTransport mockTransport = new MockTransport();
+        HubConnection hubConnection = new HubConnection("http://example.com", mockTransport, new NullLogger(), true, new TestHttpClient());
+        hubConnection.start();
+        assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
+        mockTransport.stop();
+
+        assertEquals(HubConnectionState.DISCONNECTED, hubConnection.getConnectionState());
+    }
+
+    @Test
+    public void transportCloseWithErrorTriggersStopInHubConnection() throws Exception {
+        MockTransport mockTransport = new MockTransport();
+        HubConnection hubConnection = new HubConnection("http://example.com", mockTransport, new NullLogger(), true, new TestHttpClient());
+        String errorMessage = "Example transport error.";
+
+        hubConnection.onClosed((error) -> {
+            assertEquals(error.getMessage(), errorMessage);
+        });
+
+        hubConnection.start();
+        assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
+        mockTransport.stopWithError(errorMessage);
+
+        assertEquals(HubConnectionState.DISCONNECTED, hubConnection.getConnectionState());
+    }
+
+    @Test
     public void constructHubConnectionWithHttpConnectionOptions() throws Exception {
         Transport mockTransport = new MockTransport();
         HttpConnectionOptions options = new HttpConnectionOptions();

--- a/clients/java/signalr/src/test/java/com/microsoft/aspnet/signalr/HubConnectionTest.java
+++ b/clients/java/signalr/src/test/java/com/microsoft/aspnet/signalr/HubConnectionTest.java
@@ -33,7 +33,7 @@ class HubConnectionTest {
     public void transportCloseTriggersStopInHubConnection() throws Exception {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport);
-        hubConnection.start();
+        hubConnection.start().get(1000, TimeUnit.MILLISECONDS);
         assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
         mockTransport.stop();
 
@@ -43,17 +43,18 @@ class HubConnectionTest {
     @Test
     public void transportCloseWithErrorTriggersStopInHubConnection() throws Exception {
         MockTransport mockTransport = new MockTransport();
+        AtomicReference<String> message = new AtomicReference<>();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport);
         String errorMessage = "Example transport error.";
 
         hubConnection.onClosed((error) -> {
-            assertEquals(error.getMessage(), errorMessage);
+            message.set(error.getMessage());
         });
 
-        hubConnection.start();
+        hubConnection.start().get(1000, TimeUnit.MILLISECONDS);
         assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
         mockTransport.stopWithError(errorMessage);
-
+        assertEquals(errorMessage, message.get());
         assertEquals(HubConnectionState.DISCONNECTED, hubConnection.getConnectionState());
     }
 

--- a/clients/java/signalr/src/test/java/com/microsoft/aspnet/signalr/MockTransport.java
+++ b/clients/java/signalr/src/test/java/com/microsoft/aspnet/signalr/MockTransport.java
@@ -5,11 +5,13 @@ package com.microsoft.aspnet.signalr;
 
 import java.util.ArrayList;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
 
 class MockTransport implements Transport {
     private OnReceiveCallBack onReceiveCallBack;
     private ArrayList<String> sentMessages = new ArrayList<>();
     private String url;
+    private Consumer<String> onClose;
 
     @Override
     public CompletableFuture start(String url) {
@@ -34,8 +36,18 @@ class MockTransport implements Transport {
     }
 
     @Override
+    public void setOnClose(Consumer<String> onCloseCallback) {
+        this.onClose = onCloseCallback;
+    }
+
+    @Override
     public CompletableFuture stop() {
+        onClose.accept(null);
         return CompletableFuture.completedFuture(null);
+    }
+
+    public void stopWithError(String errorMessage) {
+        onClose.accept(errorMessage);
     }
 
     public void receiveMessage(String message) throws Exception {

--- a/clients/java/signalr/src/test/java/com/microsoft/aspnet/signalr/WebSocketTransportUrlFormatTest.java
+++ b/clients/java/signalr/src/test/java/com/microsoft/aspnet/signalr/WebSocketTransportUrlFormatTest.java
@@ -5,7 +5,6 @@ package com.microsoft.aspnet.signalr;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.stream.Stream;
 


### PR DESCRIPTION
If there's an issue with the transport and it closes, the HubConnection should transition into the disconnected state. The stop/onClose logic in Websockets and HubConnection is now a lot closer to what we have in the TS client.
Issue:https://github.com/aspnet/SignalR/issues/3038