### PR TITLE
Add options to disable Xhr requests using 'withCredentials'

### DIFF
--- a/clients/ts/signalr/src/DefaultHttpClient.ts
+++ b/clients/ts/signalr/src/DefaultHttpClient.ts
@@ -3,9 +3,9 @@
 
 import { AbortError } from "./Errors";
 import { HttpClient, HttpRequest, HttpResponse } from "./HttpClient";
+import { IHttpClientOptions } from "./IHttpClientOptions";
 import { ILogger } from "./ILogger";
 import { XhrHttpClient } from "./XhrHttpClient";
-import { IHttpClientOptions } from "./IHttpClientOptions";
 
 let nodeHttpClientModule: any;
 if (typeof XMLHttpRequest === "undefined") {

--- a/clients/ts/signalr/src/DefaultHttpClient.ts
+++ b/clients/ts/signalr/src/DefaultHttpClient.ts
@@ -5,6 +5,7 @@ import { AbortError } from "./Errors";
 import { HttpClient, HttpRequest, HttpResponse } from "./HttpClient";
 import { ILogger } from "./ILogger";
 import { XhrHttpClient } from "./XhrHttpClient";
+import { IHttpClientOptions } from "./IHttpClientOptions";
 
 let nodeHttpClientModule: any;
 if (typeof XMLHttpRequest === "undefined") {
@@ -17,11 +18,13 @@ export class DefaultHttpClient extends HttpClient {
     private readonly httpClient: HttpClient;
 
     /** Creates a new instance of the {@link @aspnet/signalr.DefaultHttpClient}, using the provided {@link @aspnet/signalr.ILogger} to log messages. */
-    public constructor(logger: ILogger) {
+    public constructor(logger: ILogger, options: IHttpClientOptions) {
         super();
 
+        options = options || {};
+
         if (typeof XMLHttpRequest !== "undefined") {
-            this.httpClient = new XhrHttpClient(logger);
+            this.httpClient = new XhrHttpClient(logger, options);
         } else if (typeof nodeHttpClientModule !== "undefined") {
             this.httpClient = new nodeHttpClientModule.NodeHttpClient(logger);
         } else {

--- a/clients/ts/signalr/src/HttpConnection.ts
+++ b/clients/ts/signalr/src/HttpConnection.ts
@@ -87,7 +87,7 @@ export class HttpConnection implements IConnection {
             }
         }
 
-        this.httpClient = options.httpClient || new DefaultHttpClient(this.logger);
+        this.httpClient = options.httpClient || new DefaultHttpClient(this.logger, { disableXhrWithCredentials: options.disableXhrWithCredentials });
         this.connectionState = ConnectionState.Disconnected;
         this.options = options;
         this.onreceive = null;

--- a/clients/ts/signalr/src/IHttpClientOptions.ts
+++ b/clients/ts/signalr/src/IHttpClientOptions.ts
@@ -1,5 +1,5 @@
 /** Options provided to {@link @aspnet/signalr.DefaultHttpClient} and {@link @aspnet/signalr.XhrHttpClient} to configure options for the HTTP-based transports. */
 export interface IHttpClientOptions {
     /** Disable withCredentials for the default {@link @aspnet/signalr.HttpClient} */
-    disableXhrWithCredentials?: boolean,
+    disableXhrWithCredentials?: boolean;
 }

--- a/clients/ts/signalr/src/IHttpClientOptions.ts
+++ b/clients/ts/signalr/src/IHttpClientOptions.ts
@@ -1,0 +1,5 @@
+/** Options provided to {@link @aspnet/signalr.DefaultHttpClient} and {@link @aspnet/signalr.XhrHttpClient} to configure options for the HTTP-based transports. */
+export interface IHttpClientOptions {
+    /** Disable withCredentials for the default {@link @aspnet/signalr.HttpClient} */
+    disableXhrWithCredentials?: boolean,
+}

--- a/clients/ts/signalr/src/IHttpConnectionOptions.ts
+++ b/clients/ts/signalr/src/IHttpConnectionOptions.ts
@@ -12,7 +12,7 @@ export interface IHttpConnectionOptions {
     httpClient?: HttpClient;
 
     /** Disable withCredentials for the default {@link @aspnet/signalr.HttpClient} */
-    disableXhrWithCredentials?: boolean,
+    disableXhrWithCredentials?: boolean;
 
     /** An {@link @aspnet/signalr.HttpTransportType} value specifying the transport to use for the connection. */
     transport?: HttpTransportType | ITransport;

--- a/clients/ts/signalr/src/IHttpConnectionOptions.ts
+++ b/clients/ts/signalr/src/IHttpConnectionOptions.ts
@@ -11,6 +11,9 @@ export interface IHttpConnectionOptions {
     /** An {@link @aspnet/signalr.HttpClient} that will be used to make HTTP requests. */
     httpClient?: HttpClient;
 
+    /** Disable withCredentials for the default {@link @aspnet/signalr.HttpClient} */
+    disableXhrWithCredentials?: boolean,
+
     /** An {@link @aspnet/signalr.HttpTransportType} value specifying the transport to use for the connection. */
     transport?: HttpTransportType | ITransport;
 

--- a/clients/ts/signalr/src/XhrHttpClient.ts
+++ b/clients/ts/signalr/src/XhrHttpClient.ts
@@ -3,8 +3,8 @@
 
 import { AbortError, HttpError, TimeoutError } from "./Errors";
 import { HttpClient, HttpRequest, HttpResponse } from "./HttpClient";
-import { ILogger, LogLevel } from "./ILogger";
 import { IHttpClientOptions } from "./IHttpClientOptions";
+import { ILogger, LogLevel } from "./ILogger";
 
 export class XhrHttpClient extends HttpClient {
     private readonly logger: ILogger;

--- a/clients/ts/signalr/src/XhrHttpClient.ts
+++ b/clients/ts/signalr/src/XhrHttpClient.ts
@@ -4,13 +4,16 @@
 import { AbortError, HttpError, TimeoutError } from "./Errors";
 import { HttpClient, HttpRequest, HttpResponse } from "./HttpClient";
 import { ILogger, LogLevel } from "./ILogger";
+import { IHttpClientOptions } from "./IHttpClientOptions";
 
 export class XhrHttpClient extends HttpClient {
     private readonly logger: ILogger;
+    public readonly options: IHttpClientOptions;
 
-    public constructor(logger: ILogger) {
+    public constructor(logger: ILogger, options: IHttpClientOptions) {
         super();
         this.logger = logger;
+        this.options = options || {};
     }
 
     /** @inheritDoc */
@@ -31,7 +34,7 @@ export class XhrHttpClient extends HttpClient {
             const xhr = new XMLHttpRequest();
 
             xhr.open(request.method!, request.url!, true);
-            xhr.withCredentials = true;
+            xhr.withCredentials = !this.options.disableXhrWithCredentials;
             xhr.setRequestHeader("X-Requested-With", "XMLHttpRequest");
             // Explicitly setting the Content-Type header for React Native on Android platform.
             xhr.setRequestHeader("Content-Type", "text/plain;charset=UTF-8");


### PR DESCRIPTION
Add options to disable Xhr requests using 'withCredentials'
 - Options class `IHttpClientOptions` added
 - Used only in XhrHttpClient
