### PR TITLE
Make the ActionBase type internal

### DIFF
--- a/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/ActionBase.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/aspnet/signalr/ActionBase.java
@@ -4,6 +4,6 @@
 package com.microsoft.aspnet.signalr;
 
 @FunctionalInterface
-public interface ActionBase {
+interface ActionBase {
     void invoke(Object ... params);
 }


### PR DESCRIPTION
Making the `ActionBase` type internal