### PR TITLE
Lay/server invoke

### DIFF
--- a/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnectionExtensions.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Client.Core/HubConnectionExtensions.cs
@@ -242,5 +242,14 @@ namespace Microsoft.AspNetCore.SignalR.Client
                 return currentHandler(parameters);
             }, handler);
         }
+
+        public static IDisposable On<TResult>(this HubConnection hubConnection, string methodName, Func<Task<TResult>> handler)
+        {
+            return hubConnection.On(methodName, Type.EmptyTypes, typeof(TResult), async (parameters, state) =>
+            {
+                var currentHandler = (Func<Task<TResult>>) state;
+                return Task.FromResult<object>(await currentHandler());
+            }, handler);
+        }
     }
 }

--- a/src/Microsoft.AspNetCore.SignalR.Core/AllHubMethods.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/AllHubMethods.cs
@@ -26,7 +26,7 @@ namespace Microsoft.AspNetCore.SignalR
                 return _methods[hubType];
             }
 
-            var hubMethods = new Dictionary<string, HubMethodDescriptor>();
+            var hubMethods = new Dictionary<string, HubMethodDescriptor>(StringComparer.OrdinalIgnoreCase);
 
             var hubTypeInfo = hubType.GetTypeInfo();
             var hubName = hubType.Name;

--- a/src/Microsoft.AspNetCore.SignalR.Core/AllHubMethods.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/AllHubMethods.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.SignalR.Internal;
+using Microsoft.Extensions.Internal;
+
+namespace Microsoft.AspNetCore.SignalR
+{
+    public class AllHubMethods
+    {
+        private static readonly Dictionary<Type, Dictionary<string, HubMethodDescriptor>> _methods = new Dictionary<Type, Dictionary<string, HubMethodDescriptor>>();
+
+        internal static Dictionary<string, HubMethodDescriptor> DiscoverHubMethods<THub>()
+        {
+            var hubType = typeof(THub);
+
+            return DiscoverHubMethods(hubType);
+        }
+
+        internal static Dictionary<string, HubMethodDescriptor> DiscoverHubMethods(Type hubType)
+        {
+            if (_methods.ContainsKey(hubType))
+            {
+                return _methods[hubType];
+            }
+
+            var hubMethods = new Dictionary<string, HubMethodDescriptor>();
+
+            var hubTypeInfo = hubType.GetTypeInfo();
+            var hubName = hubType.Name;
+
+            foreach (var methodInfo in HubReflectionHelper.GetHubMethods(hubType))
+            {
+                var methodName =
+                    methodInfo.GetCustomAttribute<HubMethodNameAttribute>()?.Name ??
+                    methodInfo.Name;
+
+                if (hubMethods.ContainsKey(methodName))
+                {
+                    throw new NotSupportedException($"Duplicate definitions of '{methodName}'. Overloading is not supported.");
+                }
+
+                var executor = ObjectMethodExecutor.Create(methodInfo, hubTypeInfo);
+                var authorizeAttributes = methodInfo.GetCustomAttributes<AuthorizeAttribute>(inherit: true);
+                hubMethods[methodName] = new HubMethodDescriptor(executor, authorizeAttributes);
+            }
+            _methods.Add(hubType, hubMethods);
+
+            return hubMethods;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.SignalR.Core/DefaultHubLifetimeManager.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/DefaultHubLifetimeManager.cs
@@ -4,9 +4,11 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.SignalR.Internal;
 using Microsoft.AspNetCore.SignalR.Protocol;
 using Microsoft.Extensions.Logging;
@@ -177,7 +179,7 @@ namespace Microsoft.AspNetCore.SignalR
 
             return connection.WriteAsync(message).AsTask();
         }
-
+       
         /// <inheritdoc />
         public override Task SendGroupAsync(string groupName, string methodName, object[] args, CancellationToken cancellationToken = default)
         {
@@ -306,5 +308,23 @@ namespace Microsoft.AspNetCore.SignalR
         {
             return SendToAllConnections(methodName, args, connection => userIds.Contains(connection.UserIdentifier));
         }
+
+        public override async Task<object> InvokeConnectionAsync(string connectionId, string method, Type returnType, object[] args, CancellationToken cancellationToken)
+        {
+            if (connectionId == null)
+            {
+                throw new ArgumentNullException(nameof(connectionId));
+            }
+
+            var connection = _connections[connectionId];
+
+            if (connection == null)
+            {
+                return null;
+            }
+
+            return await connection.InvokeAsync(method, returnType, args, cancellationToken);
+        }
+
     }
 }

--- a/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionHandler.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/HubConnectionHandler.cs
@@ -81,6 +81,7 @@ namespace Microsoft.AspNetCore.SignalR
             Log.ConnectedStarting(_logger);
 
             var connectionContext = new HubConnectionContext(connection, keepAlive, _loggerFactory, clientTimeout);
+            connectionContext.ConnectionState = new ConnectionState(connectionContext, typeof(THub));
 
             var resolvedSupportedProtocols = (supportedProtocols as IReadOnlyList<string>) ?? supportedProtocols.ToList();
             if (!await connectionContext.HandshakeAsync(handshakeTimeout, resolvedSupportedProtocols, _protocolResolver, _userIdProvider, _enableDetailedErrors))
@@ -186,6 +187,7 @@ namespace Microsoft.AspNetCore.SignalR
         {
             var input = connection.Input;
             var protocol = connection.Protocol;
+            var builder = connection.ConnectionState;
             while (true)
             {
                 var result = await input.ReadAsync();
@@ -202,7 +204,7 @@ namespace Microsoft.AspNetCore.SignalR
                     {
                         connection.ResetClientTimeout();
 
-                        while (protocol.TryParseMessage(ref buffer, _dispatcher, out var message))
+                        while (protocol.TryParseMessage(ref buffer, builder, out var message))
                         {
                             await _dispatcher.DispatchMessageAsync(connection, message);
                         }

--- a/src/Microsoft.AspNetCore.SignalR.Core/HubLifetimeManager.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/HubLifetimeManager.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -66,6 +67,8 @@ namespace Microsoft.AspNetCore.SignalR
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None" />.</param>
         /// <returns>A <see cref="Task"/> that represents the asynchronous send.</returns>
         public abstract Task SendConnectionsAsync(IReadOnlyList<string> connectionIds, string methodName, object[] args, CancellationToken cancellationToken = default);
+
+        public abstract Task<object> InvokeConnectionAsync(string connectionId, string method, Type returnType, object[] args, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Sends an invocation message to the specified group.
@@ -135,5 +138,7 @@ namespace Microsoft.AspNetCore.SignalR
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None" />.</param>
         /// <returns>A <see cref="Task"/> that represents the asynchronous remove.</returns>
         public abstract Task RemoveFromGroupAsync(string connectionId, string groupName, CancellationToken cancellationToken = default);
+
+        
     }
 }

--- a/src/Microsoft.AspNetCore.SignalR.Core/IClientProxy.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/IClientProxy.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -24,5 +25,18 @@ namespace Microsoft.AspNetCore.SignalR
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None" />.</param>
         /// <returns>A <see cref="Task"/> that represents the asynchronous invoke.</returns>
         Task SendCoreAsync(string method, object[] args, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Invokes a method on the connection(s) represented by the <see cref="IClientProxy"/> instance.
+        /// Does not wait for a response from the receiver.
+        /// </summary>
+        /// <param name="method">Name of the method to invoke.</param>
+        /// <param name="args">A collection of arguments to pass to the client.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None" />.</param>
+        /// <returns>
+        /// A <see cref="Task{TResult}"/> that represents the asynchronous invoke.
+        /// The <see cref="Task{TResult}.Result"/> property returns an <see cref="object"/> for the client method return value.
+        /// </returns>
+        Task<TResult> InvokeCoreAsync<TResult>(string method, object[] args, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Microsoft.AspNetCore.SignalR.Core/Internal/DefaultHubDispatcher.Log.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/Internal/DefaultHubDispatcher.Log.cs
@@ -57,6 +57,16 @@ namespace Microsoft.AspNetCore.SignalR.Internal
             private static readonly Action<ILogger, string, Exception> _invalidReturnValueFromStreamingMethod =
                 LoggerMessage.Define<string>(LogLevel.Error, new EventId(15, "InvalidReturnValueFromStreamingMethod"), "A streaming method returned a value that cannot be used to build enumerator {HubMethod}.");
 
+            private static readonly Action<ILogger, string, Exception> _droppedCompletionMessage =
+                LoggerMessage.Define<string>(LogLevel.Warning, new EventId(9, "DroppedCompletionMessage"), "Dropped unsolicited Completion message for invocation '{InvocationId}'.");
+
+            private static readonly Action<ILogger, string, Exception> _receivedInvocationCompletion =
+                LoggerMessage.Define<string>(LogLevel.Trace, new EventId(18, "ReceivedInvocationCompletion"), "Received Completion for Invocation {InvocationId}.");
+
+            private static readonly Action<ILogger, string, Exception> _cancelingInvocationCompletion =
+                LoggerMessage.Define<string>(LogLevel.Trace, new EventId(19, "CancelingInvocationCompletion"), "Canceling dispatch of Completion message for Invocation {InvocationId}. The invocation was canceled.");
+
+
             public static void ReceivedHubInvocation(ILogger logger, InvocationMessage invocationMessage)
             {
                 _receivedHubInvocation(logger, invocationMessage, null);
@@ -132,6 +142,21 @@ namespace Microsoft.AspNetCore.SignalR.Internal
             public static void InvalidReturnValueFromStreamingMethod(ILogger logger, string hubMethod)
             {
                 _invalidReturnValueFromStreamingMethod(logger, hubMethod, null);
+            }
+
+            public static void DroppedCompletionMessage(ILogger<HubDispatcher<THub>> logger, string invocationId)
+            {
+                _droppedCompletionMessage(logger, invocationId, null);
+            }
+
+            public static void ReceivedInvocationCompletion(ILogger logger, string invocationId)
+            {
+                _receivedInvocationCompletion(logger, invocationId, null);
+            }
+
+            public static void CancelingInvocationCompletion(ILogger logger, string invocationId)
+            {
+                _cancelingInvocationCompletion(logger, invocationId, null);
             }
         }
     }

--- a/src/Microsoft.AspNetCore.SignalR.Core/Internal/Proxies.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/Internal/Proxies.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -22,6 +23,11 @@ namespace Microsoft.AspNetCore.SignalR.Internal
         {
             return _lifetimeManager.SendUserAsync(_userId, method, args, cancellationToken);
         }
+
+        public Task<TResult> InvokeCoreAsync<TResult>(string method, object[] args, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
     }
 
     internal class MultipleUserProxy<THub> : IClientProxy where THub : Hub
@@ -38,6 +44,11 @@ namespace Microsoft.AspNetCore.SignalR.Internal
         public Task SendCoreAsync(string method, object[] args, CancellationToken cancellationToken = default)
         {
             return _lifetimeManager.SendUsersAsync(_userIds, method, args, cancellationToken);
+        }
+
+        public Task<TResult> InvokeCoreAsync<TResult>(string method, object[] args, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
         }
     }
 
@@ -56,6 +67,11 @@ namespace Microsoft.AspNetCore.SignalR.Internal
         {
             return _lifetimeManager.SendGroupAsync(_groupName, method, args, cancellationToken);
         }
+
+        public Task<TResult> InvokeCoreAsync<TResult>(string method, object[] args, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
     }
 
     internal class MultipleGroupProxy<THub> : IClientProxy where THub : Hub
@@ -72,6 +88,11 @@ namespace Microsoft.AspNetCore.SignalR.Internal
         public Task SendCoreAsync(string method, object[] args, CancellationToken cancellationToken = default)
         {
             return _lifetimeManager.SendGroupsAsync(_groupNames, method, args, cancellationToken);
+        }
+
+        public Task<TResult> InvokeCoreAsync<TResult>(string method, object[] args, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
         }
     }
 
@@ -92,6 +113,11 @@ namespace Microsoft.AspNetCore.SignalR.Internal
         {
             return _lifetimeManager.SendGroupExceptAsync(_groupName, method, args, _excludedConnectionIds, cancellationToken);
         }
+
+        public Task<TResult> InvokeCoreAsync<TResult>(string method, object[] args, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
     }
 
     internal class AllClientProxy<THub> : IClientProxy where THub : Hub
@@ -106,6 +132,11 @@ namespace Microsoft.AspNetCore.SignalR.Internal
         public Task SendCoreAsync(string method, object[] args, CancellationToken cancellationToken = default)
         {
             return _lifetimeManager.SendAllAsync(method, args);
+        }
+
+        public Task<TResult> InvokeCoreAsync<TResult>(string method, object[] args, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
         }
     }
 
@@ -124,6 +155,11 @@ namespace Microsoft.AspNetCore.SignalR.Internal
         {
             return _lifetimeManager.SendAllExceptAsync(method, args, _excludedConnectionIds, cancellationToken);
         }
+
+        public Task<TResult> InvokeCoreAsync<TResult>(string method, object[] args, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
     }
 
     internal class SingleClientProxy<THub> : IClientProxy where THub : Hub
@@ -141,6 +177,11 @@ namespace Microsoft.AspNetCore.SignalR.Internal
         {
             return _lifetimeManager.SendConnectionAsync(_connectionId, method, args, cancellationToken);
         }
+
+        public async Task<TResult> InvokeCoreAsync<TResult>(string method, object[] args, CancellationToken cancellationToken = default)
+        {
+            return (TResult)await _lifetimeManager.InvokeConnectionAsync(_connectionId, method, typeof(TResult), args, cancellationToken);
+        }
     }
 
     internal class MultipleClientProxy<THub> : IClientProxy where THub : Hub
@@ -157,6 +198,11 @@ namespace Microsoft.AspNetCore.SignalR.Internal
         public Task SendCoreAsync(string method, object[] args, CancellationToken cancellationToken = default)
         {
             return _lifetimeManager.SendConnectionsAsync(_connectionIds, method, args, cancellationToken);
+        }
+
+        public Task<TResult> InvokeCoreAsync<TResult>(string method, object[] args, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/Microsoft.AspNetCore.SignalR.Core/InvocationRequest.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/InvocationRequest.cs
@@ -1,0 +1,234 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.SignalR.Protocol;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.SignalR.Internal
+{
+    public abstract class InvocationRequest : IDisposable
+    {
+        private readonly CancellationTokenRegistration _cancellationTokenRegistration;
+
+        protected ILogger Logger { get; }
+
+        public Type ResultType { get; }
+        public CancellationToken CancellationToken { get; }
+        public string InvocationId { get; }
+        public HubConnectionContext HubConnection { get; private set; }
+
+        protected InvocationRequest(CancellationToken cancellationToken, Type resultType, string invocationId, ILogger logger, HubConnectionContext hubConnection)
+        {
+            _cancellationTokenRegistration = cancellationToken.Register(self => ((InvocationRequest)self).Cancel(), this);
+
+            InvocationId = invocationId;
+            CancellationToken = cancellationToken;
+            ResultType = resultType;
+            Logger = logger;
+            HubConnection = hubConnection;
+
+            Log.InvocationCreated(Logger, InvocationId);
+        }
+
+        public static InvocationRequest Invoke(CancellationToken cancellationToken, Type resultType, string invocationId, ILogger logger, HubConnectionContext hubConnection, out Task<object> result)
+        {
+            var req = new NonStreaming(cancellationToken, resultType, invocationId, logger, hubConnection);
+            result = req.Result;
+            return req;
+        }
+
+        public static InvocationRequest Stream(CancellationToken cancellationToken, Type resultType, string invocationId,
+            ILogger logger, HubConnectionContext hubConnection, out ChannelReader<object> result)
+        {
+            var req = new Streaming(cancellationToken, resultType, invocationId, logger, hubConnection);
+            result = req.Result;
+            return req;
+        }
+
+        public abstract void Fail(Exception exception);
+        public abstract void Complete(CompletionMessage message);
+        public abstract ValueTask<bool> StreamItem(object item);
+
+        protected abstract void Cancel();
+
+        public virtual void Dispose()
+        {
+            Log.InvocationDisposed(Logger, InvocationId);
+
+            // Just in case it hasn't already been completed
+            Cancel();
+
+            _cancellationTokenRegistration.Dispose();
+        }
+
+        private class Streaming : InvocationRequest
+        {
+            private readonly Channel<object> _channel = Channel.CreateUnbounded<object>();
+
+            public Streaming(CancellationToken cancellationToken, Type resultType, string invocationId, ILogger logger, HubConnectionContext hubConnection)
+                : base(cancellationToken, resultType, invocationId, logger, hubConnection)
+            {
+            }
+
+            public ChannelReader<object> Result => _channel.Reader;
+
+            public override void Complete(CompletionMessage completionMessage)
+            {
+                Log.InvocationCompleted(Logger, InvocationId);
+                if (completionMessage.Result != null)
+                {
+                    Log.ReceivedUnexpectedComplete(Logger, InvocationId);
+                    _channel.Writer.TryComplete(new InvalidOperationException("Server provided a result in a completion response to a streamed invocation."));
+                }
+
+                if (!string.IsNullOrEmpty(completionMessage.Error))
+                {
+                    Fail(new HubException(completionMessage.Error));
+                    return;
+                }
+
+                _channel.Writer.TryComplete();
+            }
+
+            public override void Fail(Exception exception)
+            {
+                Log.InvocationFailed(Logger, InvocationId);
+                _channel.Writer.TryComplete(exception);
+            }
+
+            public override async ValueTask<bool> StreamItem(object item)
+            {
+                try
+                {
+                    while (!_channel.Writer.TryWrite(item))
+                    {
+                        if (!await _channel.Writer.WaitToWriteAsync())
+                        {
+                            return false;
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Log.ErrorWritingStreamItem(Logger, InvocationId, ex);
+                }
+                return true;
+            }
+
+            protected override void Cancel()
+            {
+                _channel.Writer.TryComplete(new OperationCanceledException());
+            }
+        }
+
+        private class NonStreaming : InvocationRequest
+        {
+            private readonly TaskCompletionSource<object> _completionSource = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            public NonStreaming(CancellationToken cancellationToken, Type resultType, string invocationId, ILogger logger, HubConnectionContext hubConnection)
+                : base(cancellationToken, resultType, invocationId, logger, hubConnection)
+            {
+            }
+
+            public Task<object> Result => _completionSource.Task;
+
+            public override void Complete(CompletionMessage completionMessage)
+            {
+                if (!string.IsNullOrEmpty(completionMessage.Error))
+                {
+                    Fail(new HubException(completionMessage.Error));
+                    return;
+                }
+
+                Log.InvocationCompleted(Logger, InvocationId);
+                _completionSource.TrySetResult(completionMessage.Result);
+            }
+
+            public override void Fail(Exception exception)
+            {
+                Log.InvocationFailed(Logger, InvocationId);
+                _completionSource.TrySetException(exception);
+            }
+
+            public override ValueTask<bool> StreamItem(object item)
+            {
+                Log.StreamItemOnNonStreamInvocation(Logger, InvocationId);
+                _completionSource.TrySetException(new InvalidOperationException($"Streaming hub methods must be invoked with the '{nameof(HubConnection)}.HubConnectionExtensions.StreamAsChannelAsync' method."));
+
+                // We "delivered" the stream item successfully as far as the caller cares
+                return new ValueTask<bool>(true);
+            }
+
+            protected override void Cancel()
+            {
+                _completionSource.TrySetCanceled();
+            }
+        }
+
+        private static class Log
+        {
+            // Category: Streaming and NonStreaming
+            private static readonly Action<ILogger, string, Exception> _invocationCreated =
+                LoggerMessage.Define<string>(LogLevel.Trace, new EventId(1, "InvocationCreated"), "Invocation {InvocationId} created.");
+
+            private static readonly Action<ILogger, string, Exception> _invocationDisposed =
+                LoggerMessage.Define<string>(LogLevel.Trace, new EventId(2, "InvocationDisposed"), "Invocation {InvocationId} disposed.");
+
+            private static readonly Action<ILogger, string, Exception> _invocationCompleted =
+                LoggerMessage.Define<string>(LogLevel.Trace, new EventId(3, "InvocationCompleted"), "Invocation {InvocationId} marked as completed.");
+
+            private static readonly Action<ILogger, string, Exception> _invocationFailed =
+                LoggerMessage.Define<string>(LogLevel.Trace, new EventId(4, "InvocationFailed"), "Invocation {InvocationId} marked as failed.");
+
+            // Category: Streaming
+            private static readonly Action<ILogger, string, Exception> _errorWritingStreamItem =
+                LoggerMessage.Define<string>(LogLevel.Error, new EventId(5, "ErrorWritingStreamItem"), "Invocation {InvocationId} caused an error trying to write a stream item.");
+
+            private static readonly Action<ILogger, string, Exception> _receivedUnexpectedComplete =
+                LoggerMessage.Define<string>(LogLevel.Error, new EventId(6, "ReceivedUnexpectedComplete"), "Invocation {InvocationId} received a completion result, but was invoked as a streaming invocation.");
+
+            // Category: NonStreaming
+            private static readonly Action<ILogger, string, Exception> _streamItemOnNonStreamInvocation =
+                LoggerMessage.Define<string>(LogLevel.Error, new EventId(5, "StreamItemOnNonStreamInvocation"), "Invocation {InvocationId} received stream item but was invoked as a non-streamed invocation.");
+
+            public static void InvocationCreated(ILogger logger, string invocationId)
+            {
+                _invocationCreated(logger, invocationId, null);
+            }
+
+            public static void InvocationDisposed(ILogger logger, string invocationId)
+            {
+                _invocationDisposed(logger, invocationId, null);
+            }
+
+            public static void InvocationCompleted(ILogger logger, string invocationId)
+            {
+                _invocationCompleted(logger, invocationId, null);
+            }
+
+            public static void InvocationFailed(ILogger logger, string invocationId)
+            {
+                _invocationFailed(logger, invocationId, null);
+            }
+
+            public static void ErrorWritingStreamItem(ILogger logger, string invocationId, Exception exception)
+            {
+                _errorWritingStreamItem(logger, invocationId, exception);
+            }
+
+            public static void ReceivedUnexpectedComplete(ILogger logger, string invocationId)
+            {
+                _receivedUnexpectedComplete(logger, invocationId, null);
+            }
+
+            public static void StreamItemOnNonStreamInvocation(ILogger logger, string invocationId)
+            {
+                _streamItemOnNonStreamInvocation(logger, invocationId, null);
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.SignalR.Redis/RedisHubLifetimeManager.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Redis/RedisHubLifetimeManager.cs
@@ -204,6 +204,12 @@ namespace Microsoft.AspNetCore.SignalR.Redis
             return SendGroupActionAndWaitForAck(connectionId, groupName, GroupAction.Remove);
         }
 
+        public override Task<object> InvokeConnectionAsync(string connectionId, string method, Type returnType, object[] args,
+            CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+
         public override Task SendConnectionsAsync(IReadOnlyList<string> connectionIds, string methodName, object[] args, CancellationToken cancellationToken = default)
         {
             if (connectionIds == null)

--- a/test/Microsoft.AspNetCore.SignalR.Tests/AddSignalRTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/AddSignalRTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright(c) .NET Foundation.All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -166,6 +167,12 @@ namespace Microsoft.AspNetCore.SignalR.Tests
         public override Task SendConnectionsAsync(IReadOnlyList<string> connectionIds, string methodName, object[] args, CancellationToken cancellationToken = default)
         {
             throw new System.NotImplementedException();
+        }
+
+        public override Task<object> InvokeConnectionAsync(string connectionId, string method, Type returnType, object[] args,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
         }
 
         public override Task SendGroupAsync(string groupName, string methodName, object[] args, CancellationToken cancellationToken = default)

--- a/test/Microsoft.AspNetCore.SignalR.Tests/ClientProxyTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/ClientProxyTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading;
@@ -181,6 +182,31 @@ namespace Microsoft.AspNetCore.SignalR.Tests
 
             Assert.NotNull(resultArgs);
             var arg = (byte[])Assert.Single(resultArgs);
+
+            Assert.Same(data, arg);
+        }
+
+        [Fact]
+        public async Task SingleClientProxy_InvokeAsync_ArrayArgumentNotExpanded()
+        {
+            object[] resultArgs = null;
+            object returnResult = "method call result";
+
+            var o = new Mock<HubLifetimeManager<FakeHub>>();
+            o.Setup(m => m.InvokeConnectionAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Type>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+                .Callback<string, string, object[], CancellationToken>((connectionId, methodName, args, _) => { resultArgs = args; })
+                .Returns(Task.FromResult(returnResult));
+
+            var proxy = new SingleClientProxy<FakeHub>(o.Object, string.Empty);
+
+            var data = Encoding.UTF8.GetBytes("Hello world");
+            //await proxy.SendAsync("Method", data);
+            var result = await proxy.InvokeCoreAsync<object>("ReturnMethod", new object[] {data});
+
+            Assert.NotNull(resultArgs);
+            var arg = (byte[])Assert.Single(resultArgs);
+
+            Assert.Same(returnResult, result);
 
             Assert.Same(data, arg);
         }

--- a/test/Microsoft.AspNetCore.SignalR.Tests/ClientProxyTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/ClientProxyTests.cs
@@ -194,7 +194,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
 
             var o = new Mock<HubLifetimeManager<FakeHub>>();
             o.Setup(m => m.InvokeConnectionAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Type>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
-                .Callback<string, string, object[], CancellationToken>((connectionId, methodName, args, _) => { resultArgs = args; })
+                .Callback<string, string, Type, object[], CancellationToken>((connectionId, returnType, methodName, args, _) => { resultArgs = args; })
                 .Returns(Task.FromResult(returnResult));
 
             var proxy = new SingleClientProxy<FakeHub>(o.Object, string.Empty);

--- a/test/Microsoft.AspNetCore.SignalR.Tests/Internal/TypedClientBuilderTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Tests/Internal/TypedClientBuilderTests.cs
@@ -201,6 +201,15 @@ namespace Microsoft.AspNetCore.SignalR.Tests.Internal
 
                 return tcs.Task;
             }
+
+            public Task<TResult> InvokeCoreAsync<TResult>(string method, object[] args, CancellationToken cancellationToken = default)
+            {
+                var tcs = new TaskCompletionSource<object>();
+
+                Sends.Add(new SendContext(method, args, cancellationToken, tcs));
+
+                return Task.FromResult((TResult)tcs.Task.Result);
+            }
         }
 
         private struct SendContext


### PR DESCRIPTION
Add server side invoke single client and wait for a result. #3045 

For client side: 
1、Make InvocatonHandler can return an object.
2、Send a CompetionMessage to server when an invocation hava non-null result.

For server side:
1、Add a state to HubConnectionContext which can store invocations.
2、Add CompetionMessage process to HubDispatcher.