### PR TITLE
Committing changes required to have SignalR depend on the centralized Microsoft BOM file for Java libraries

### DIFF
--- a/clients/java/signalr/build.gradle
+++ b/clients/java/signalr/build.gradle
@@ -25,15 +25,22 @@ sourceCompatibility = 1.8
 
 repositories {
     mavenCentral()
+    // add sonatype repository (temporary, due to java-8-parent being a snapshot)
+    maven {
+        url 'https://oss.sonatype.org/content/repositories/snapshots/'
+    }
 }
 
 dependencies {
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.3.1'
-    testCompile 'org.junit.jupiter:junit-jupiter-params:5.3.1'
-    testRuntime 'org.junit.jupiter:junit-jupiter-engine:5.3.1'
-    implementation 'com.google.code.gson:gson:2.8.5'
-    implementation 'com.squareup.okhttp3:okhttp:3.11.0'
-    implementation 'io.reactivex.rxjava2:rxjava:2.2.2'
+    implementation 'com.microsoft.maven:java-8-parent:8.0.0-SNAPSHOT'
+
+    // dependency versions imported from java-8-parent POM imported above
+    testImplementation 'org.junit.jupiter:junit-jupiter-api'
+    testCompile 'org.junit.jupiter:junit-jupiter-params'
+    testRuntime 'org.junit.jupiter:junit-jupiter-engine'
+    implementation 'com.google.code.gson:gson'
+    implementation 'com.squareup.okhttp3:okhttp'
+    implementation 'io.reactivex.rxjava2:rxjava'
 }
 
 spotless {

--- a/clients/java/signalr/settings.gradle
+++ b/clients/java/signalr/settings.gradle
@@ -1,3 +1,6 @@
 rootProject.name = 'signalr'
 include 'main'
 
+// This is required for Gradle 4.6+ to support importing BOMs, like we do for the Microsoft super pom.
+// See here: https://docs.gradle.org/4.6/release-notes.html?_ga=2.220409368.162752831.1539212384-1601231980.1538950297#bom-import
+enableFeaturePreview('IMPROVED_POM_SUPPORT')


### PR DESCRIPTION
For discussion with the Java client engineering team, @anurse @BrennanConroy @mikaelm12 @davidfowl. This is a proposal to externalise your dependency **version** management to an external POM. We are gradually rolling this out to all Java SDKs, and I am keen to hear your thoughts, feedback, concerns, or whatever else may be running through your mind 😄 

All versions that have been removed from your Gradle file are now represented in the Maven parent POM file, and as your dependencies have not yet been encountered (and were therefore not included up to now), I have taken the exact same version numbers as you use. There will therefore be no functional difference.