### PR TITLE
Add package-info file for docs

### DIFF
--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/package-info.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/package-info.java
@@ -1,0 +1,4 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+package com.microsoft.signalr;

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/package-info.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/package-info.java
@@ -1,4 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+/**
+ * This package contains the classes for SignalR Java client.
+ * SignalR Java client.
+ */
 package com.microsoft.signalr;

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/package-info.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/package-info.java
@@ -3,6 +3,5 @@
 
 /**
  * This package contains the classes for SignalR Java client.
- * SignalR Java client.
  */
 package com.microsoft.signalr;


### PR DESCRIPTION
Adding a package-info file to get the high level class summaries on the docs page. 
Does this look right to you @dend ? 