### PR TITLE
Enable logging in chat sample

### DIFF
--- a/clients/java/signalr/build.gradle
+++ b/clients/java/signalr/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
     testCompile 'org.junit.jupiter:junit-jupiter-params'
     testRuntime 'org.junit.jupiter:junit-jupiter-engine'
+    testCompile 'org.slf4j:slf4j-jdk14:1.7.25'
     implementation 'com.google.code.gson:gson'
     implementation 'com.squareup.okhttp3:okhttp'
     implementation 'io.reactivex.rxjava2:rxjava'


### PR DESCRIPTION
Issue: https://github.com/aspnet/SignalR/issues/3121
Updating the Chat sample to use java console logging through the SLF4J APIs. We have to take another dependency on the bridging jar between slf4j and java.util.logging