### PR TITLE
Check if HubConnection stopped normally in Chat sample

### DIFF
--- a/clients/java/signalr/src/test/java/com/microsoft/signalr/sample/Chat.java
+++ b/clients/java/signalr/src/test/java/com/microsoft/signalr/sample/Chat.java
@@ -24,7 +24,7 @@ public class Chat {
         }, String.class, String.class);
 
         hubConnection.onClosed((ex) -> {
-            if (ex.getMessage() != null) {
+            if (ex != null) {
                 System.out.printf("There was an error: %s", ex.getMessage());
             }
         });


### PR DESCRIPTION
*This isn't a product issue*
The `OnClosed ` callbacks get an optional exception parameter which gets passed in when the `HubConnection ` stops with an error. If the `HubConnection ` stops normally the exception is null and the chat sample we have null refs as the application closes. 