### PR TITLE
Remove withTransport and withHttpClient

### DIFF
--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/HttpHubConnectionBuilder.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/HttpHubConnectionBuilder.java
@@ -22,12 +22,12 @@ public class HttpHubConnectionBuilder {
         this.url = url;
     }
 
-    public HttpHubConnectionBuilder withTransport(Transport transport) {
+    HttpHubConnectionBuilder withTransport(Transport transport) {
         this.transport = transport;
         return this;
     }
 
-    public HttpHubConnectionBuilder withHttpClient(HttpClient httpClient) {
+    HttpHubConnectionBuilder withHttpClient(HttpClient httpClient) {
         this.httpClient = httpClient;
         return this;
     }


### PR DESCRIPTION
Removing `withTransport `and `withHttpClient `in the release/2.2 branch.