### PR TITLE
Don't set Redis timeout

### DIFF
--- a/test/Microsoft.AspNetCore.SignalR.Redis.Tests/RedisEndToEnd.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Redis.Tests/RedisEndToEnd.cs
@@ -92,7 +92,7 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
             }
         }
 
-        [ConditionalTheory(Skip= "https://github.com/aspnet/SignalR/issues/3058")]
+        [ConditionalTheory]
         [SkipIfDockerNotPresent]
         [MemberData(nameof(TransportTypesAndProtocolTypes))]
         public async Task CanSendAndReceiveUserMessagesFromMultipleConnectionsWithSameUser(HttpTransportType transportType, string protocolName)

--- a/test/Microsoft.AspNetCore.SignalR.Redis.Tests/Startup.cs
+++ b/test/Microsoft.AspNetCore.SignalR.Redis.Tests/Startup.cs
@@ -20,8 +20,6 @@ namespace Microsoft.AspNetCore.SignalR.Redis.Tests
                 .AddMessagePackProtocol()
                 .AddRedis(options =>
                 {
-                    // We start the servers before starting redis so we want to time them out ASAP
-                    options.Configuration.ConnectTimeout = 1;
                     options.Configuration.EndPoints.Add(Environment.GetEnvironmentVariable("REDIS_CONNECTION-PREV"));
                 });
 

--- a/test/Microsoft.AspNetCore.SignalR.StackExchangeRedis.Tests/RedisEndToEnd.cs
+++ b/test/Microsoft.AspNetCore.SignalR.StackExchangeRedis.Tests/RedisEndToEnd.cs
@@ -92,7 +92,7 @@ namespace Microsoft.AspNetCore.SignalR.StackExchangeRedis.Tests
             }
         }
 
-        [ConditionalTheory(Skip= "https://github.com/aspnet/SignalR/issues/3058")]
+        [ConditionalTheory]
         [SkipIfDockerNotPresent]
         [MemberData(nameof(TransportTypesAndProtocolTypes))]
         public async Task CanSendAndReceiveUserMessagesFromMultipleConnectionsWithSameUser(HttpTransportType transportType, string protocolName)

--- a/test/Microsoft.AspNetCore.SignalR.StackExchangeRedis.Tests/Startup.cs
+++ b/test/Microsoft.AspNetCore.SignalR.StackExchangeRedis.Tests/Startup.cs
@@ -20,8 +20,6 @@ namespace Microsoft.AspNetCore.SignalR.StackExchangeRedis.Tests
                 .AddMessagePackProtocol()
                 .AddStackExchangeRedis(options =>
                 {
-                    // We start the servers before starting redis so we want to time them out ASAP
-                    options.Configuration.ConnectTimeout = 1;
                     options.Configuration.EndPoints.Add(Environment.GetEnvironmentVariable("REDIS_CONNECTION"));
                 });
 


### PR DESCRIPTION
We don't need ConnectTimeout anymore since we start Redis first. I'm not sure if this was causing issues, but I was hitting a similar-ish problem locally when connecting to Azure Redis with a low timeout value, and no issues when removing the timeout.