### PR TITLE
Remove functional interfaces

### DIFF
--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/Action.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/Action.java
@@ -7,5 +7,7 @@ package com.microsoft.signalr;
  * A callback that takes no parameters.
  */
 public interface Action {
+    // We can't use @FunctionalInterface because it's only
+    // available on Android API Level 24 and above.
     void invoke();
 }

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/Action.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/Action.java
@@ -7,7 +7,7 @@ package com.microsoft.signalr;
  * A callback that takes no parameters.
  */
 public interface Action {
-    // We can't use @FunctionalInterface because it's only
+    // We can't use the @FunctionalInterface annotation because it's only
     // available on Android API Level 24 and above.
     void invoke();
 }

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/Action.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/Action.java
@@ -6,7 +6,6 @@ package com.microsoft.signalr;
 /**
  * A callback that takes no parameters.
  */
-@FunctionalInterface
 public interface Action {
     void invoke();
 }

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/Action1.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/Action1.java
@@ -9,5 +9,7 @@ package com.microsoft.signalr;
  * @param <T1> The type of the first parameter to the callback.
  */
 public interface Action1<T1> {
+    // We can't use @FunctionalInterface because it's only
+    // available on Android API Level 24 and above.
     void invoke(T1 param1);
 }

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/Action1.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/Action1.java
@@ -8,7 +8,6 @@ package com.microsoft.signalr;
  *
  * @param <T1> The type of the first parameter to the callback.
  */
-@FunctionalInterface
 public interface Action1<T1> {
     void invoke(T1 param1);
 }

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/Action1.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/Action1.java
@@ -9,7 +9,7 @@ package com.microsoft.signalr;
  * @param <T1> The type of the first parameter to the callback.
  */
 public interface Action1<T1> {
-    // We can't use @FunctionalInterface because it's only
+    // We can't use the @FunctionalInterface annotation because it's only
     // available on Android API Level 24 and above.
     void invoke(T1 param1);
 }

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/Action2.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/Action2.java
@@ -9,7 +9,6 @@ package com.microsoft.signalr;
  * @param <T1> The type of the first parameter to the callback.
  * @param <T2> The type of the second parameter to the callback.
  */
-@FunctionalInterface
 public interface Action2<T1, T2> {
     void invoke(T1 param1, T2 param2);
 }

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/Action2.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/Action2.java
@@ -10,7 +10,7 @@ package com.microsoft.signalr;
  * @param <T2> The type of the second parameter to the callback.
  */
 public interface Action2<T1, T2> {
-    // We can't use @FunctionalInterface because it's only
+    // We can't use the @FunctionalInterface annotation because it's only
     // available on Android API Level 24 and above.
     void invoke(T1 param1, T2 param2);
 }

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/Action2.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/Action2.java
@@ -10,5 +10,7 @@ package com.microsoft.signalr;
  * @param <T2> The type of the second parameter to the callback.
  */
 public interface Action2<T1, T2> {
+    // We can't use @FunctionalInterface because it's only
+    // available on Android API Level 24 and above.
     void invoke(T1 param1, T2 param2);
 }

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/Action3.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/Action3.java
@@ -11,5 +11,7 @@ package com.microsoft.signalr;
  * @param <T3> The type of the third parameter to the callback.
  */
 public interface Action3<T1, T2, T3> {
+    // We can't use @FunctionalInterface because it's only
+    // available on Android API Level 24 and above.
     void invoke(T1 param1, T2 param2, T3 param3);
 }

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/Action3.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/Action3.java
@@ -11,7 +11,7 @@ package com.microsoft.signalr;
  * @param <T3> The type of the third parameter to the callback.
  */
 public interface Action3<T1, T2, T3> {
-    // We can't use @FunctionalInterface because it's only
+    // We can't use the @FunctionalInterface annotation because it's only
     // available on Android API Level 24 and above.
     void invoke(T1 param1, T2 param2, T3 param3);
 }

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/Action3.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/Action3.java
@@ -10,7 +10,6 @@ package com.microsoft.signalr;
  * @param <T2> The type of the second parameter to the callback.
  * @param <T3> The type of the third parameter to the callback.
  */
-@FunctionalInterface
 public interface Action3<T1, T2, T3> {
     void invoke(T1 param1, T2 param2, T3 param3);
 }

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/Action4.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/Action4.java
@@ -11,7 +11,6 @@ package com.microsoft.signalr;
  * @param <T3> The type of the third parameter to the callback.
  * @param <T4> The type of the fourth parameter to the callback.
  */
-@FunctionalInterface
 public interface Action4<T1, T2, T3, T4> {
     void invoke(T1 param1, T2 param2, T3 param3, T4 param4);
 }

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/Action4.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/Action4.java
@@ -12,5 +12,7 @@ package com.microsoft.signalr;
  * @param <T4> The type of the fourth parameter to the callback.
  */
 public interface Action4<T1, T2, T3, T4> {
+    // We can't use @FunctionalInterface because it's only
+    // available on Android API Level 24 and above.
     void invoke(T1 param1, T2 param2, T3 param3, T4 param4);
 }

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/Action4.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/Action4.java
@@ -12,7 +12,7 @@ package com.microsoft.signalr;
  * @param <T4> The type of the fourth parameter to the callback.
  */
 public interface Action4<T1, T2, T3, T4> {
-    // We can't use @FunctionalInterface because it's only
+    // We can't use the @FunctionalInterface annotation because it's only
     // available on Android API Level 24 and above.
     void invoke(T1 param1, T2 param2, T3 param3, T4 param4);
 }

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/Action5.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/Action5.java
@@ -12,7 +12,6 @@ package com.microsoft.signalr;
  * @param <T4> The type of the fourth parameter to the callback.
  * @param <T5> The type of the fifth parameter to the callback.
  */
-@FunctionalInterface
 public interface Action5<T1, T2, T3, T4, T5> {
     void invoke(T1 param1, T2 param2, T3 param3, T4 param4, T5 param5);
 }

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/Action5.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/Action5.java
@@ -13,5 +13,7 @@ package com.microsoft.signalr;
  * @param <T5> The type of the fifth parameter to the callback.
  */
 public interface Action5<T1, T2, T3, T4, T5> {
+    // We can't use @FunctionalInterface because it's only
+    // available on Android API Level 24 and above.
     void invoke(T1 param1, T2 param2, T3 param3, T4 param4, T5 param5);
 }

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/Action5.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/Action5.java
@@ -13,7 +13,7 @@ package com.microsoft.signalr;
  * @param <T5> The type of the fifth parameter to the callback.
  */
 public interface Action5<T1, T2, T3, T4, T5> {
-    // We can't use @FunctionalInterface because it's only
+    // We can't use the @FunctionalInterface annotation because it's only
     // available on Android API Level 24 and above.
     void invoke(T1 param1, T2 param2, T3 param3, T4 param4, T5 param5);
 }

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/Action6.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/Action6.java
@@ -14,5 +14,7 @@ package com.microsoft.signalr;
  * @param <T6> The type of the sixth parameter to the callback.
  */
 public interface Action6<T1, T2, T3, T4, T5, T6> {
+    // We can't use @FunctionalInterface because it's only
+    // available on Android API Level 24 and above.
     void invoke(T1 param1, T2 param2, T3 param3, T4 param4, T5 param5, T6 param6);
 }

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/Action6.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/Action6.java
@@ -13,7 +13,6 @@ package com.microsoft.signalr;
  * @param <T5> The type of the fifth parameter to the callback.
  * @param <T6> The type of the sixth parameter to the callback.
  */
-@FunctionalInterface
 public interface Action6<T1, T2, T3, T4, T5, T6> {
     void invoke(T1 param1, T2 param2, T3 param3, T4 param4, T5 param5, T6 param6);
 }

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/Action6.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/Action6.java
@@ -14,7 +14,7 @@ package com.microsoft.signalr;
  * @param <T6> The type of the sixth parameter to the callback.
  */
 public interface Action6<T1, T2, T3, T4, T5, T6> {
-    // We can't use @FunctionalInterface because it's only
+    // We can't use the @FunctionalInterface annotation because it's only
     // available on Android API Level 24 and above.
     void invoke(T1 param1, T2 param2, T3 param3, T4 param4, T5 param5, T6 param6);
 }

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/Action7.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/Action7.java
@@ -15,7 +15,7 @@ package com.microsoft.signalr;
  * @param <T7> The type of the seventh parameter to the callback.
  */
 public interface Action7<T1, T2, T3, T4, T5, T6, T7> {
-    // We can't use @FunctionalInterface because it's only
+    // We can't use the @FunctionalInterface annotation because it's only
     // available on Android API Level 24 and above.
     void invoke(T1 param1, T2 param2, T3 param3, T4 param4, T5 param5, T6 param6, T7 param7);
 }

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/Action7.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/Action7.java
@@ -15,5 +15,7 @@ package com.microsoft.signalr;
  * @param <T7> The type of the seventh parameter to the callback.
  */
 public interface Action7<T1, T2, T3, T4, T5, T6, T7> {
+    // We can't use @FunctionalInterface because it's only
+    // available on Android API Level 24 and above.
     void invoke(T1 param1, T2 param2, T3 param3, T4 param4, T5 param5, T6 param6, T7 param7);
 }

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/Action7.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/Action7.java
@@ -14,7 +14,6 @@ package com.microsoft.signalr;
  * @param <T6> The type of the sixth parameter to the callback.
  * @param <T7> The type of the seventh parameter to the callback.
  */
-@FunctionalInterface
 public interface Action7<T1, T2, T3, T4, T5, T6, T7> {
     void invoke(T1 param1, T2 param2, T3 param3, T4 param4, T5 param5, T6 param6, T7 param7);
 }

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/Action8.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/Action8.java
@@ -16,5 +16,7 @@ package com.microsoft.signalr;
  * @param <T8> The type of the eighth parameter to the callback.
  */
 public interface Action8<T1, T2, T3, T4, T5, T6, T7, T8> {
+    // We can't use @FunctionalInterface because it's only
+    // available on Android API Level 24 and above.
     void invoke(T1 param1, T2 param2, T3 param3, T4 param4, T5 param5, T6 param6, T7 param7, T8 param8);
 }

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/Action8.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/Action8.java
@@ -15,7 +15,6 @@ package com.microsoft.signalr;
  * @param <T7> The type of the seventh parameter to the callback.
  * @param <T8> The type of the eighth parameter to the callback.
  */
-@FunctionalInterface
 public interface Action8<T1, T2, T3, T4, T5, T6, T7, T8> {
     void invoke(T1 param1, T2 param2, T3 param3, T4 param4, T5 param5, T6 param6, T7 param7, T8 param8);
 }

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/Action8.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/Action8.java
@@ -16,7 +16,7 @@ package com.microsoft.signalr;
  * @param <T8> The type of the eighth parameter to the callback.
  */
 public interface Action8<T1, T2, T3, T4, T5, T6, T7, T8> {
-    // We can't use @FunctionalInterface because it's only
+    // We can't use the @FunctionalInterface annotation because it's only
     // available on Android API Level 24 and above.
     void invoke(T1 param1, T2 param2, T3 param3, T4 param4, T5 param5, T6 param6, T7 param7, T8 param8);
 }

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/ActionBase.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/ActionBase.java
@@ -4,5 +4,7 @@
 package com.microsoft.signalr;
 
 interface ActionBase {
+    // We can't use @FunctionalInterface because it's only
+    // available on Android API Level 24 and above.
     void invoke(Object ... params);
 }

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/ActionBase.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/ActionBase.java
@@ -4,7 +4,7 @@
 package com.microsoft.signalr;
 
 interface ActionBase {
-    // We can't use @FunctionalInterface because it's only
+    // We can't use the @FunctionalInterface annotation because it's only
     // available on Android API Level 24 and above.
     void invoke(Object ... params);
 }

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/ActionBase.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/ActionBase.java
@@ -3,7 +3,6 @@
 
 package com.microsoft.signalr;
 
-@FunctionalInterface
 interface ActionBase {
     void invoke(Object ... params);
 }


### PR DESCRIPTION
Part of the Java Android API level reduction work. Functional interfaces are only available in API levels 24 and above. This just removes the functional interface tags.
Issues: https://github.com/aspnet/SignalR/issues/3164 and https://github.com/aspnet/SignalR/issues/3143