### PR TITLE
Use Node https module for https requests

### DIFF
--- a/clients/ts/signalr/src/NodeHttpClient.ts
+++ b/clients/ts/signalr/src/NodeHttpClient.ts
@@ -34,6 +34,9 @@ export class NodeHttpClient extends HttpClient {
                 port: url.port,
             };
 
+            // "any" is used here because require() can't be correctly resolved by the compiler
+            // when httpOrHttps is typeof http | typeof https. Change to http when editing to get
+            // intellisense.
             const httpOrHttps: any = url.protocol === "https" ? https : http;
 
             const req = httpOrHttps.request(options, (res: http.IncomingMessage) => {

--- a/clients/ts/signalr/src/NodeHttpClient.ts
+++ b/clients/ts/signalr/src/NodeHttpClient.ts
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 import * as http from "http";
+import * as https from "http";
 import { URL } from "url";
 
 import { AbortError, HttpError, TimeoutError } from "./Errors";
@@ -33,7 +34,15 @@ export class NodeHttpClient extends HttpClient {
                 port: url.port,
             };
 
-            const req = http.request(options, (res: http.IncomingMessage) => {
+            let httpOrHttps = http;
+            if (request.url) {
+                // poor man's "startsWith()"
+                if (request.url.lastIndexOf("https", 0) === 0) {
+                    httpOrHttps = https;
+                }
+            }
+
+            const req = httpOrHttps.request(options, (res: http.IncomingMessage) => {
                 const data: Buffer[] = [];
                 let dataLength = 0;
                 res.on("data", (chunk: any) => {

--- a/clients/ts/signalr/src/NodeHttpClient.ts
+++ b/clients/ts/signalr/src/NodeHttpClient.ts
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 import * as http from "http";
-import * as https from "http";
+import * as https from "https";
 import { URL } from "url";
 
 import { AbortError, HttpError, TimeoutError } from "./Errors";
@@ -34,13 +34,7 @@ export class NodeHttpClient extends HttpClient {
                 port: url.port,
             };
 
-            let httpOrHttps = http;
-            if (request.url) {
-                // poor man's "startsWith()"
-                if (request.url.lastIndexOf("https", 0) === 0) {
-                    httpOrHttps = https;
-                }
-            }
+            const httpOrHttps: any = url.protocol === "https" ? https : http;
 
             const req = httpOrHttps.request(options, (res: http.IncomingMessage) => {
                 const data: Buffer[] = [];
@@ -85,7 +79,7 @@ export class NodeHttpClient extends HttpClient {
                 });
             }
 
-            req.on("error", (e) => {
+            req.on("error", (e: Error) => {
                 this.logger.log(LogLevel.Warning, `Error from HTTP request. ${e}`);
                 reject(e);
             });


### PR DESCRIPTION
Fixes https://github.com/aspnet/SignalR/issues/3168

I'll see if I can get a test certificate on our functional tests server so we can run https tests. But I want this in ASAP