### PR TITLE
fix #3144 by failing tests on CI if no browsers

### DIFF
--- a/.vsts-pipelines/builds/ci-public.yml
+++ b/.vsts-pipelines/builds/ci-public.yml
@@ -14,6 +14,8 @@ resources:
 jobs:
 - template: .azure/templates/project-ci.yml@buildtools
   parameters:
+    variables:
+      ASPNETCORE_SIGNALR_TEST_ALL_BROWSERS: true
     beforeBuild:
     - task: NodeTool@0
       displayName: Use Node 8.x

--- a/clients/ts/FunctionalTests/scripts/karma.local.conf.js
+++ b/clients/ts/FunctionalTests/scripts/karma.local.conf.js
@@ -46,9 +46,11 @@ try {
 
     // We need to receive an argument from the caller, but globals don't seem to work, so we use an environment variable.
     if (process.env.ASPNETCORE_SIGNALR_TEST_ALL_BROWSERS === "true") {
-      tryAddBrowser("Edge", new EdgeBrowser(() => { }, { create() { } }));
-      tryAddBrowser("IE", new IEBrowser(() => { }, { create() { } }, {}));
-      tryAddBrowser("Safari", new SafariBrowser(() => { }, {}));
+        if (!process.env.CI) {
+            tryAddBrowser("Edge", new EdgeBrowser(() => { }, { create() { } }));
+        }
+        tryAddBrowser("IE", new IEBrowser(() => { }, { create() { } }, {}));
+        tryAddBrowser("Safari", new SafariBrowser(() => { }, {}));
     }
 
     module.exports = createKarmaConfig({

--- a/clients/ts/FunctionalTests/scripts/run-tests.ts
+++ b/clients/ts/FunctionalTests/scripts/run-tests.ts
@@ -126,7 +126,9 @@ const configFile = sauce ?
 debug(`Loading Karma config file: ${configFile}`);
 
 // Gross but it works
-process.env.ASPNETCORE_SIGNALR_TEST_ALL_BROWSERS = allBrowsers ? "true" : null;
+if (allBrowsers) {
+    process.env.ASPNETCORE_SIGNALR_TEST_ALL_BROWSERS = "true";
+}
 const config = (karma as any).config.parseConfig(configFile);
 
 if (sauce) {


### PR DESCRIPTION
fixes #3144

If there are no browsers available, our functional tests simply no-op. However, on the CI we want the tests to fail so we ensure we get some browser test coverage in CI.