### PR TITLE
Remove Duration API from Java Client

### DIFF
--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/HttpHubConnectionBuilder.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/HttpHubConnectionBuilder.java
@@ -17,7 +17,7 @@ public class HttpHubConnectionBuilder {
     private HttpClient httpClient;
     private boolean skipNegotiate;
     private Single<String> accessTokenProvider;
-    private long  handshakeResponseTimeout = 0;
+    private long handshakeResponseTimeout = 0;
     private Map<String, String> headers;
 
     HttpHubConnectionBuilder(String url) {
@@ -72,7 +72,7 @@ public class HttpHubConnectionBuilder {
     /**
      * Sets the duration the {@link HubConnection} should wait for a Handshake Response from the server.
      *
-      * @param timeoutInMilliseconds The duration (specified in milliseconds) that the {@link HubConnection} should wait for a Handshake Response from the server.
+     * @param timeoutInMilliseconds The duration (specified in milliseconds) that the {@link HubConnection} should wait for a Handshake Response from the server.
      * @return This instance of the HttpHubConnectionBuilder.
      */
     public HttpHubConnectionBuilder withHandshakeResponseTimeout(long timeoutInMilliseconds) {

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/HttpHubConnectionBuilder.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/HttpHubConnectionBuilder.java
@@ -18,7 +18,7 @@ public class HttpHubConnectionBuilder {
     private HttpClient httpClient;
     private boolean skipNegotiate;
     private Single<String> accessTokenProvider;
-    private Duration handshakeResponseTimeout;
+    private long  handshakeResponseTimeout = 0;
     private Map<String, String> headers;
 
     HttpHubConnectionBuilder(String url) {
@@ -76,7 +76,7 @@ public class HttpHubConnectionBuilder {
      * @param timeout The duration that the {@link HubConnection} should wait for a Handshake Response from the server.
      * @return This instance of the HttpHubConnectionBuilder.
      */
-    public HttpHubConnectionBuilder withHandshakeResponseTimeout(Duration timeout) {
+    public HttpHubConnectionBuilder withHandshakeResponseTimeout(long timeout) {
         this.handshakeResponseTimeout = timeout;
         return this;
     }

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/HttpHubConnectionBuilder.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/HttpHubConnectionBuilder.java
@@ -3,7 +3,6 @@
 
 package com.microsoft.signalr;
 
-import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/HttpHubConnectionBuilder.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/HttpHubConnectionBuilder.java
@@ -72,11 +72,11 @@ public class HttpHubConnectionBuilder {
     /**
      * Sets the duration the {@link HubConnection} should wait for a Handshake Response from the server.
      *
-      * @param timeout The duration (specified in milliseconds) that the {@link HubConnection} should wait for a Handshake Response from the server.
+      * @param timeoutInMilliseconds The duration (specified in milliseconds) that the {@link HubConnection} should wait for a Handshake Response from the server.
      * @return This instance of the HttpHubConnectionBuilder.
      */
     public HttpHubConnectionBuilder withHandshakeResponseTimeout(long timeoutInMilliseconds) {
-        this.handshakeResponseTimeout = timeout;
+        this.handshakeResponseTimeout = timeoutInMilliseconds;
         return this;
     }
 

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
@@ -248,7 +248,7 @@ public class HubConnection {
 
     /**
      * Starts a connection to the server.
-     * 
+     *
      * @return A Completable that completes when the connection has been established.
      */
     public Completable start() {

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
@@ -120,7 +120,7 @@ public class HubConnection {
             this.transport = transport;
         }
 
-        if (handshakeResponseTimeout != 0) {
+        if (handshakeResponseTimeout > 0) {
             this.handshakeResponseTimeout = handshakeResponseTimeout;
         }
 

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
@@ -57,7 +57,7 @@ public class HubConnection {
     /**
      * Sets the server timeout interval for the connection.
      *
-      * @param serverTimeoutInMilliseconds The server timeout duration (specified in milliseconds).
+     * @param serverTimeoutInMilliseconds The server timeout duration (specified in milliseconds).
      */
     public void setServerTimeout(long serverTimeoutInMilliseconds) {
         this.serverTimeout = serverTimeoutInMilliseconds;
@@ -248,6 +248,7 @@ public class HubConnection {
 
     /**
      * Starts a connection to the server.
+     * 
      * @return A Completable that completes when the connection has been established.
      */
     public Completable start() {

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
@@ -57,10 +57,10 @@ public class HubConnection {
     /**
      * Sets the server timeout interval for the connection.
      *
-      * @param serverTimeout The server timeout duration (specified in milliseconds).
+      * @param serverTimeoutInMilliseconds The server timeout duration (specified in milliseconds).
      */
     public void setServerTimeout(long serverTimeoutInMilliseconds) {
-        this.serverTimeout = serverTimeout;
+        this.serverTimeout = serverTimeoutInMilliseconds;
     }
 
     /**
@@ -75,10 +75,10 @@ public class HubConnection {
     /**
      * Sets the keep alive interval duration.
      *
-     * @param keepAliveInterval The interval (specified in milliseconds) at which the connection should send keep alive messages.
+     * @param keepAliveIntervalInMilliseconds The interval (specified in milliseconds) at which the connection should send keep alive messages.
      */
     public void setKeepAliveInterval(long keepAliveIntervalInMilliseconds) {
-        this.keepAliveInterval = keepAliveInterval;
+        this.keepAliveInterval = keepAliveIntervalInMilliseconds;
     }
 
     /**
@@ -92,7 +92,7 @@ public class HubConnection {
 
     // For testing purposes
     void setTickRate(long tickRateInMilliseconds) {
-        this.tickRate = tickRate;
+        this.tickRate = tickRateInMilliseconds;
     }
 
     HubConnection(String url, Transport transport, boolean skipNegotiate, HttpClient httpClient,

--- a/clients/java/signalr/src/test/java/com/microsoft/signalr/HubConnectionTest.java
+++ b/clients/java/signalr/src/test/java/com/microsoft/signalr/HubConnectionTest.java
@@ -68,7 +68,7 @@ class HubConnectionTest {
                 .withTransport(mockTransport)
                 .withHttpClient(new TestHttpClient())
                 .shouldSkipNegotiate(true)
-                .withHandshakeResponseTimeout(Duration.ofMillis(100))
+                .withHandshakeResponseTimeout(100)
                 .build();
         Throwable exception = assertThrows(RuntimeException.class, () -> hubConnection.start().blockingAwait(1000, TimeUnit.MILLISECONDS));
         assertEquals(ExecutionException.class, exception.getCause().getClass());
@@ -1066,8 +1066,8 @@ class HubConnectionTest {
     @Test
     public void connectionTimesOutIfServerDoesNotSendMessage() throws InterruptedException, ExecutionException, TimeoutException {
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com");
-        hubConnection.setServerTimeout(Duration.ofMillis(1));
-        hubConnection.setTickRate(Duration.ofMillis(1));
+        hubConnection.setServerTimeout(1);
+        hubConnection.setTickRate(1);
         CompletableFuture<Exception> closedFuture = new CompletableFuture<>();
         hubConnection.onClosed((e) -> {
             closedFuture.complete(e);
@@ -1082,8 +1082,8 @@ class HubConnectionTest {
     public void connectionSendsPingsRegularly() throws InterruptedException {
         MockTransport mockTransport = new MockTransport(true, false);
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport);
-        hubConnection.setKeepAliveInterval(Duration.ofMillis(1));
-        hubConnection.setTickRate(Duration.ofMillis(1));
+        hubConnection.setKeepAliveInterval(1);
+        hubConnection.setTickRate(1);
 
         hubConnection.start().blockingAwait(1000, TimeUnit.MILLISECONDS);
 

--- a/clients/java/signalr/src/test/java/com/microsoft/signalr/HubConnectionTest.java
+++ b/clients/java/signalr/src/test/java/com/microsoft/signalr/HubConnectionTest.java
@@ -5,7 +5,6 @@ package com.microsoft.signalr;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;


### PR DESCRIPTION
Removing the Duration API from the Java Client so we can target Android APIs lower than 26.
Issue: https://github.com/aspnet/SignalR/issues/3141