### PR TITLE
Remove Dependency on java.util.Function

### DIFF
--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
@@ -15,7 +15,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
-import java.util.function.Consumer;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,7 +37,7 @@ public class HubConnection {
     private Boolean handshakeReceived = false;
     private HubConnectionState hubConnectionState = HubConnectionState.DISCONNECTED;
     private final Lock hubConnectionStateLock = new ReentrantLock();
-    private List<Consumer<Exception>> onClosedCallbackList;
+    private List<OnClosedCallback> onClosedCallbackList;
     private final boolean skipNegotiate;
     private Single<String> accessTokenProvider;
     private final Map<String, String> headers = new HashMap<>();
@@ -432,8 +431,8 @@ public class HubConnection {
 
         // Do not run these callbacks inside the hubConnectionStateLock
         if (onClosedCallbackList != null) {
-            for (Consumer<Exception> callback : onClosedCallbackList) {
-                callback.accept(exception);
+            for (OnClosedCallback callback : onClosedCallbackList) {
+                callback.invoke(exception);
             }
         }
     }
@@ -526,7 +525,7 @@ public class HubConnection {
      *
      * @param callback A callback to run when the connection closes.
      */
-    public void onClosed(Consumer<Exception> callback) {
+    public void onClosed(OnClosedCallback callback) {
         if (onClosedCallbackList == null) {
             onClosedCallbackList = new ArrayList<>();
         }

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/OkHttpWebSocketWrapper.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/OkHttpWebSocketWrapper.java
@@ -4,7 +4,6 @@
 package com.microsoft.signalr;
 
 import java.util.Map;
-import java.util.function.BiConsumer;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -24,7 +23,7 @@ class OkHttpWebSocketWrapper extends WebSocketWrapper {
     private Map<String, String> headers;
     private OkHttpClient client;
     private OnReceiveCallBack onReceive;
-    private BiConsumer<Integer, String> onClose;
+    private WebsocketWrapperOnClosed onClose;
     private CompletableSubject startSubject = CompletableSubject.create();
     private CompletableSubject closeSubject = CompletableSubject.create();
 
@@ -70,7 +69,7 @@ class OkHttpWebSocketWrapper extends WebSocketWrapper {
     }
 
     @Override
-    public void setOnClose(BiConsumer<Integer, String> onClose) {
+    public void setOnClose(WebsocketWrapperOnClosed onClose) {
         this.onClose = onClose;
     }
 
@@ -92,7 +91,7 @@ class OkHttpWebSocketWrapper extends WebSocketWrapper {
 
         @Override
         public void onClosing(WebSocket webSocket, int code, String reason) {
-            onClose.accept(code, reason);
+            onClose.invoke(code, reason);
             closeSubject.onComplete();
             checkStartFailure();
         }
@@ -101,7 +100,7 @@ class OkHttpWebSocketWrapper extends WebSocketWrapper {
         public void onFailure(WebSocket webSocket, Throwable t, Response response) {
             logger.error("Websocket closed from an error: {}.", t.getMessage());
             closeSubject.onError(new RuntimeException(t));
-            onClose.accept(null, t.getMessage());
+            onClose.invoke(null, t.getMessage());
             checkStartFailure();
         }
 

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/OkHttpWebSocketWrapper.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/OkHttpWebSocketWrapper.java
@@ -23,7 +23,7 @@ class OkHttpWebSocketWrapper extends WebSocketWrapper {
     private Map<String, String> headers;
     private OkHttpClient client;
     private OnReceiveCallBack onReceive;
-    private WebsocketWrapperOnClosed onClose;
+    private WebSocketOnClosedCallback onClose;
     private CompletableSubject startSubject = CompletableSubject.create();
     private CompletableSubject closeSubject = CompletableSubject.create();
 
@@ -69,7 +69,7 @@ class OkHttpWebSocketWrapper extends WebSocketWrapper {
     }
 
     @Override
-    public void setOnClose(WebsocketWrapperOnClosed onClose) {
+    public void setOnClose(WebSocketOnClosedCallback onClose) {
         this.onClose = onClose;
     }
 

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/OnClosedCallback.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/OnClosedCallback.java
@@ -4,5 +4,5 @@
 package com.microsoft.signalr;
 
 public interface OnClosedCallback {
-    void invoke(Exception param1);
+    void invoke(Exception exception);
 }

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/OnClosedCallback.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/OnClosedCallback.java
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 package com.microsoft.signalr;
 
 public interface OnClosedCallback {

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/OnClosedCallback.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/OnClosedCallback.java
@@ -1,0 +1,5 @@
+package com.microsoft.signalr;
+
+public interface OnClosedCallback {
+    void invoke(Exception param1);
+}

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/OnClosedCallback.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/OnClosedCallback.java
@@ -3,6 +3,9 @@
 
 package com.microsoft.signalr;
 
+/**
+ * A callback to create and register on a HubConnections OnClosed method.
+ */
 public interface OnClosedCallback {
     void invoke(Exception exception);
 }

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/Transport.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/Transport.java
@@ -3,8 +3,6 @@
 
 package com.microsoft.signalr;
 
-import java.util.function.Consumer;
-
 import io.reactivex.Completable;
 
 interface Transport {
@@ -12,6 +10,6 @@ interface Transport {
     Completable send(String message);
     void setOnReceive(OnReceiveCallBack callback);
     void onReceive(String message);
-    void setOnClose(Consumer<String> onCloseCallback);
+    void setOnClose(TransportOnClosedCallback onCloseCallback);
     Completable stop();
 }

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/TransportOnClosedCallback.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/TransportOnClosedCallback.java
@@ -1,0 +1,5 @@
+package com.microsoft.signalr;
+
+interface TransportOnClosedCallback {
+    void invoke(String reason);
+}

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/TransportOnClosedCallback.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/TransportOnClosedCallback.java
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 package com.microsoft.signalr;
 
 interface TransportOnClosedCallback {

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/WebSocketTransport.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/WebSocketTransport.java
@@ -4,7 +4,6 @@
 package com.microsoft.signalr;
 
 import java.util.Map;
-import java.util.function.Consumer;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/WebSocketTransport.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/WebSocketTransport.java
@@ -14,7 +14,7 @@ import io.reactivex.Completable;
 class WebSocketTransport implements Transport {
     private WebSocketWrapper webSocketClient;
     private OnReceiveCallBack onReceiveCallBack;
-    private Consumer<String> onClose;
+    private TransportOnClosedCallback onClose;
     private String url;
     private final HttpClient client;
     private final Map<String, String> headers;
@@ -78,7 +78,7 @@ class WebSocketTransport implements Transport {
     }
 
     @Override
-    public void setOnClose(Consumer<String> onCloseCallback) {
+    public void setOnClose(TransportOnClosedCallback onCloseCallback) {
         this.onClose = onCloseCallback;
     }
 
@@ -91,10 +91,10 @@ class WebSocketTransport implements Transport {
         logger.info("WebSocket connection stopping with " +
                 "code {} and reason '{}'.", code, reason);
         if (code != 1000) {
-            onClose.accept(reason);
+            onClose.invoke(reason);
         }
         else {
-            onClose.accept(null);
+            onClose.invoke(null);
         }
     }
 }

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/WebSocketWrapper.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/WebSocketWrapper.java
@@ -14,5 +14,5 @@ abstract class WebSocketWrapper {
 
     public abstract void setOnReceive(OnReceiveCallBack onReceive);
 
-    public abstract void setOnClose(WebsocketWrapperOnClosed onClose);
+    public abstract void setOnClose(WebSocketOnClosedCallback onClose);
 }

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/WebSocketWrapper.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/WebSocketWrapper.java
@@ -3,8 +3,6 @@
 
 package com.microsoft.signalr;
 
-import java.util.function.BiConsumer;
-
 import io.reactivex.Completable;
 
 abstract class WebSocketWrapper {
@@ -16,5 +14,5 @@ abstract class WebSocketWrapper {
 
     public abstract void setOnReceive(OnReceiveCallBack onReceive);
 
-    public abstract void setOnClose(BiConsumer<Integer, String> onClose);
+    public abstract void setOnClose(WebsocketWrapperOnClosed onClose);
 }

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/WebsocketWrapperOnClosed.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/WebsocketWrapperOnClosed.java
@@ -3,6 +3,6 @@
 
 package com.microsoft.signalr;
 
-interface WebsocketWrapperOnClosed {
+interface WebSocketOnClosedCallback {
     void invoke(Integer code, String reason);
 }

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/WebsocketWrapperOnClosed.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/WebsocketWrapperOnClosed.java
@@ -1,0 +1,5 @@
+package com.microsoft.signalr;
+
+interface WebsocketWrapperOnClosed {
+    void invoke(Integer code, String string);
+}

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/WebsocketWrapperOnClosed.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/WebsocketWrapperOnClosed.java
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 package com.microsoft.signalr;
 
 interface WebsocketWrapperOnClosed {

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/WebsocketWrapperOnClosed.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/WebsocketWrapperOnClosed.java
@@ -4,5 +4,5 @@
 package com.microsoft.signalr;
 
 interface WebsocketWrapperOnClosed {
-    void invoke(Integer code, String string);
+    void invoke(Integer code, String reason);
 }

--- a/clients/java/signalr/src/test/java/com/microsoft/signalr/MockTransport.java
+++ b/clients/java/signalr/src/test/java/com/microsoft/signalr/MockTransport.java
@@ -4,7 +4,6 @@
 package com.microsoft.signalr;
 
 import java.util.ArrayList;
-import java.util.function.Consumer;
 
 import io.reactivex.Completable;
 import io.reactivex.subjects.CompletableSubject;

--- a/clients/java/signalr/src/test/java/com/microsoft/signalr/MockTransport.java
+++ b/clients/java/signalr/src/test/java/com/microsoft/signalr/MockTransport.java
@@ -13,7 +13,7 @@ class MockTransport implements Transport {
     private OnReceiveCallBack onReceiveCallBack;
     private ArrayList<String> sentMessages = new ArrayList<>();
     private String url;
-    private Consumer<String> onClose;
+    private TransportOnClosedCallback onClose;
     final private boolean ignorePings;
     final private boolean autoHandshake;
     final private CompletableSubject startSubject = CompletableSubject.create();
@@ -67,19 +67,19 @@ class MockTransport implements Transport {
     }
 
     @Override
-    public void setOnClose(Consumer<String> onCloseCallback) {
+    public void setOnClose(TransportOnClosedCallback onCloseCallback) {
         this.onClose = onCloseCallback;
     }
 
     @Override
     public Completable stop() {
-        onClose.accept(null);
+        onClose.invoke(null);
         stopSubject.onComplete();
         return stopSubject;
     }
 
     public void stopWithError(String errorMessage) {
-        onClose.accept(errorMessage);
+        onClose.invoke(errorMessage);
     }
 
     public void receiveMessage(String message) {

--- a/clients/java/signalr/src/test/java/com/microsoft/signalr/TestHttpClient.java
+++ b/clients/java/signalr/src/test/java/com/microsoft/signalr/TestHttpClient.java
@@ -10,7 +10,7 @@ import java.util.Map;
 import io.reactivex.Single;
 
 class TestHttpClient extends HttpClient {
-    private TestHttpClientHandler handler;
+    private TestHttpRequestHandler handler;
     private List<HttpRequest> sentRequests;
 
     public TestHttpClient() {
@@ -30,13 +30,13 @@ class TestHttpClient extends HttpClient {
         return sentRequests;
     }
 
-    public TestHttpClient on(TestHttpClientHandler handler) {
+    public TestHttpClient on(TestHttpRequestHandler handler) {
         this.handler = (req) -> handler.invoke(req);
         return this;
     }
 
-    public TestHttpClient on(String method, TestHttpClientHandler handler) {
-        TestHttpClientHandler oldHandler = this.handler;
+    public TestHttpClient on(String method, TestHttpRequestHandler handler) {
+        TestHttpRequestHandler oldHandler = this.handler;
         this.handler = (req) -> {
             if (req.getMethod().equals(method)) {
                 return handler.invoke(req);
@@ -48,8 +48,8 @@ class TestHttpClient extends HttpClient {
         return this;
     }
 
-    public TestHttpClient on(String method, String url, TestHttpClientHandler handler) {
-        TestHttpClientHandler oldHandler = this.handler;
+    public TestHttpClient on(String method, String url, TestHttpRequestHandler handler) {
+        TestHttpRequestHandler oldHandler = this.handler;
         this.handler = (req) -> {
             if (req.getMethod().equals(method) && req.getUrl().equals(url)) {
                 return handler.invoke(req);
@@ -66,7 +66,7 @@ class TestHttpClient extends HttpClient {
         throw new RuntimeException("WebSockets isn't supported in testing currently.");
     }
 
-    interface TestHttpClientHandler {
+    interface TestHttpRequestHandler {
         Single<HttpResponse> invoke(HttpRequest request);
     }
 }

--- a/clients/java/signalr/src/test/java/com/microsoft/signalr/TestHttpClient.java
+++ b/clients/java/signalr/src/test/java/com/microsoft/signalr/TestHttpClient.java
@@ -6,12 +6,11 @@ package com.microsoft.signalr;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
 
 import io.reactivex.Single;
 
 class TestHttpClient extends HttpClient {
-    private Function<HttpRequest, Single<HttpResponse>> handler;
+    private TestHttpClientHandler handler;
     private List<HttpRequest> sentRequests;
 
     public TestHttpClient() {
@@ -24,39 +23,39 @@ class TestHttpClient extends HttpClient {
     @Override
     public Single<HttpResponse> send(HttpRequest request) {
         this.sentRequests.add(request);
-        return this.handler.apply(request);
+        return this.handler.invoke(request);
     }
 
     public List<HttpRequest> getSentRequests() {
         return sentRequests;
     }
 
-    public TestHttpClient on(Function<HttpRequest, Single<HttpResponse>> handler) {
-        this.handler = (req) -> handler.apply(req);
+    public TestHttpClient on(TestHttpClientHandler handler) {
+        this.handler = (req) -> handler.invoke(req);
         return this;
     }
 
-    public TestHttpClient on(String method, Function<HttpRequest, Single<HttpResponse>> handler) {
-        Function<HttpRequest, Single<HttpResponse>> oldHandler = this.handler;
+    public TestHttpClient on(String method, TestHttpClientHandler handler) {
+        TestHttpClientHandler oldHandler = this.handler;
         this.handler = (req) -> {
             if (req.getMethod().equals(method)) {
-                return handler.apply(req);
+                return handler.invoke(req);
             }
 
-            return oldHandler.apply(req);
+            return oldHandler.invoke(req);
         };
 
         return this;
     }
 
-    public TestHttpClient on(String method, String url, Function<HttpRequest, Single<HttpResponse>> handler) {
-        Function<HttpRequest, Single<HttpResponse>> oldHandler = this.handler;
+    public TestHttpClient on(String method, String url, TestHttpClientHandler handler) {
+        TestHttpClientHandler oldHandler = this.handler;
         this.handler = (req) -> {
             if (req.getMethod().equals(method) && req.getUrl().equals(url)) {
-                return handler.apply(req);
+                return handler.invoke(req);
             }
 
-            return oldHandler.apply(req);
+            return oldHandler.invoke(req);
         };
 
         return this;
@@ -65,5 +64,9 @@ class TestHttpClient extends HttpClient {
     @Override
     public WebSocketWrapper createWebSocket(String url, Map<String, String> headers) {
         throw new RuntimeException("WebSockets isn't supported in testing currently.");
+    }
+
+    interface TestHttpClientHandler {
+        Single<HttpResponse> invoke(HttpRequest request);
     }
 }


### PR DESCRIPTION
Removing our uses of Consumer,BiConsumer etc and replacing them with our own interfaces. Moving towards being able to target Android API level 23.
The other half of issue: https://github.com/aspnet/SignalR/issues/3164