### PR TITLE
Update npm readme with Node info

### DIFF
--- a/clients/ts/signalr-protocol-msgpack/README.md
+++ b/clients/ts/signalr-protocol-msgpack/README.md
@@ -14,6 +14,9 @@ See the [SignalR Documentation](https://docs.microsoft.com/en-us/aspnet/core/sig
 
 To use the client in a browser, copy `*.js` files from the `dist/browser` folder to your script folder include on your page using the `<script>` tag.
 
+### NodeJS
+
+To use the client in a NodeJS application, install the package to your `node_modules` folder and use `require('@aspnet/signalr-protocol-msgpack')` to load the module. The object returned by `require('@aspnet/signalr-protocol-msgpack')` has the same members as the global `signalR.protocols.msgpack` object (when used in a browser).
 
 ### Example (Browser)
 

--- a/clients/ts/signalr/README.md
+++ b/clients/ts/signalr/README.md
@@ -16,10 +16,7 @@ To use the client in a browser, copy `*.js` files from the `dist/browser` folder
 
 ### Node.js
 
-The following polyfills are required to use the client in Node.js applications:
-- `XmlHttpRequest` - always
-- `WebSockets` - to use the WebSockets transport
-- `EventSource` - to use the ServerSentEvents transport
+To use the client in a NodeJS application, install the package to your `node_modules` folder and use `require('@aspnet/signalr')` to load the module. The object returned by `require('@aspnet/signalr')` has the same members as the global `signalR` object (when used in a browser).
 
 ### Example (Browser)
 


### PR DESCRIPTION
I noticed that these READMEs are out of date now that we have "official" node support.