### PR TITLE
Remove BiFunction Ref

### DIFF
--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/CallbackMap.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/CallbackMap.java
@@ -4,27 +4,44 @@
 package com.microsoft.signalr;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
 
 class CallbackMap {
-    private final Map<String, List<InvocationHandler>> handlers = new ConcurrentHashMap<>();
+    private final Map<String, List<InvocationHandler>> handlers = new HashMap<>();
+    private final ReentrantLock lock = new ReentrantLock();
 
     public InvocationHandler put(String target, ActionBase action, Class<?>... classes) {
-        InvocationHandler handler = new InvocationHandler(action, classes);
-        if (!handlers.containsKey(target)){
-            handlers.put(target, new ArrayList<>());
+        try {
+            lock.lock();
+            InvocationHandler handler = new InvocationHandler(action, classes);
+            if (!handlers.containsKey(target)) {
+                handlers.put(target, new ArrayList<>());
+            }
+            handlers.get(target).add(handler);
+            return handler;
+        } finally {
+            lock.unlock();
         }
-        handlers.get(target).add(handler);
-        return handler;
     }
 
     public List<InvocationHandler> get(String key) {
-        return handlers.get(key);
+        try {
+            lock.lock();
+            return handlers.get(key);
+        } finally {
+            lock.unlock();
+        }
     }
 
     public void remove(String key) {
-        handlers.remove(key);
+        try {
+            lock.lock();
+            handlers.remove(key);
+        } finally {
+            lock.unlock();
+        }
     }
 }

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/CallbackMap.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/CallbackMap.java
@@ -3,7 +3,9 @@
 
 package com.microsoft.signalr;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 class CallbackMap {
@@ -11,13 +13,10 @@ class CallbackMap {
 
     public InvocationHandler put(String target, ActionBase action, Class<?>... classes) {
         InvocationHandler handler = new InvocationHandler(action, classes);
-        handlers.compute(target, (key, value) -> {
-            if (value == null) {
-                value = new ArrayList<>();
-            }
-            value.add(handler);
-            return value;
-        });
+        if (!handlers.containsKey(target)){
+            handlers.put(target, new ArrayList<>());
+        }
+        handlers.get(target).add(handler);
         return handler;
     }
 


### PR DESCRIPTION
Was doing Android API Version verification and found a sneaky `BiFunction` reference that was hidden though inlining and a reference to `java.util.*` 