### PR TITLE
Remove hidden BiConsumer reference

### DIFF
--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/DefaultHttpClient.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/DefaultHttpClient.java
@@ -99,7 +99,7 @@ final class DefaultHttpClient extends HttpClient {
         if (httpRequest.getHeaders() != null) {
             httpRequest.getHeaders().forEach(requestBuilder::addHeader);
             Collection<String> keys = httpRequest.getHeaders().keySet();
-            for (String key: keys) {
+            for (String key : keys) {
                 requestBuilder.addHeader(key, httpRequest.getHeaders().get(key));
             }
         }

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/DefaultHttpClient.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/DefaultHttpClient.java
@@ -5,6 +5,7 @@ package com.microsoft.signalr;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.locks.Lock;
@@ -97,6 +98,10 @@ final class DefaultHttpClient extends HttpClient {
 
         if (httpRequest.getHeaders() != null) {
             httpRequest.getHeaders().forEach(requestBuilder::addHeader);
+            Collection<String> keys = httpRequest.getHeaders().keySet();
+            for (String key: keys) {
+                requestBuilder.addHeader(key, httpRequest.getHeaders().get(key));
+            }
         }
 
         Request request = requestBuilder.build();

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/DefaultHttpClient.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/DefaultHttpClient.java
@@ -97,7 +97,6 @@ final class DefaultHttpClient extends HttpClient {
         }
 
         if (httpRequest.getHeaders() != null) {
-            httpRequest.getHeaders().forEach(requestBuilder::addHeader);
             Collection<String> keys = httpRequest.getHeaders().keySet();
             for (String key : keys) {
                 requestBuilder.addHeader(key, httpRequest.getHeaders().get(key));


### PR DESCRIPTION
Map's forEach method takes a BiConsumer. Removing it for Android API compatibility.