### PR TITLE
Fix NullPointerException when unboxing null to int.

### DIFF
--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/WebSocketTransport.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/WebSocketTransport.java
@@ -86,7 +86,7 @@ class WebSocketTransport implements Transport {
         return webSocketClient.stop().doOnEvent(t -> logger.info("WebSocket connection stopped."));
     }
 
-    void onClose(int code, String reason) {
+    void onClose(Integer code, String reason) {
         logger.info("WebSocket connection stopping with " +
                 "code {} and reason '{}'.", code, reason);
         if (code != 1000) {


### PR DESCRIPTION
Change int to Integer to allow use null as code used [here](https://github.com/aspnet/SignalR/blob/e1b602a7c5331e0c20efe4a087d73eb63441fd9c/clients/java/signalr/src/main/java/com/microsoft/signalr/OkHttpWebSocketWrapper.java#L103). I think using null as code is legal. just fixed the bug.