### PR TITLE
Wrap log in enabled check

### DIFF
--- a/src/Microsoft.AspNetCore.SignalR.Core/Internal/DefaultHubDispatcher.Log.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Core/Internal/DefaultHubDispatcher.Log.cs
@@ -90,8 +90,11 @@ namespace Microsoft.AspNetCore.SignalR.Internal
 
             public static void SendingResult(ILogger logger, string invocationId, ObjectMethodExecutor objectMethodExecutor)
             {
-                var resultType = objectMethodExecutor.AsyncResultType == null ? objectMethodExecutor.MethodReturnType : objectMethodExecutor.AsyncResultType;
-                _sendingResult(logger, invocationId, resultType.FullName, null);
+                if (logger.IsEnabled(LogLevel.Trace))
+                {
+                    var resultType = objectMethodExecutor.AsyncResultType == null ? objectMethodExecutor.MethodReturnType : objectMethodExecutor.AsyncResultType;
+                    _sendingResult(logger, invocationId, resultType.FullName, null);
+                }
             }
 
             public static void FailedInvokingHubMethod(ILogger logger, string hubMethod, Exception exception)


### PR DESCRIPTION
DotTrace showed this log took 1.5% of SignalR's runtime (not the apps runtime) with logging turned off.