### PR TITLE
Skip flaky java test

### DIFF
--- a/clients/java/signalr/src/test/java/com/microsoft/signalr/WebSocketTransportTest.java
+++ b/clients/java/signalr/src/test/java/com/microsoft/signalr/WebSocketTransportTest.java
@@ -16,7 +16,7 @@ import io.reactivex.Completable;
 import io.reactivex.Single;
 
 class WebSocketTransportTest {
-    @Test
+    // @Test Skipping until we add functional test support
     public void WebSocketThrowsIfItCantConnect() {
         Transport transport = new WebSocketTransport(new HashMap<>(), new DefaultHttpClient());
         RuntimeException exception = assertThrows(RuntimeException.class, () -> transport.start("http://url.fake.example").blockingAwait(1, TimeUnit.SECONDS));


### PR DESCRIPTION
@anurse and I agree this should be skipped until we add functional tests since the test is flaky right now.

@muratg Test only 2.2 change.