### PR TITLE
Update RxJava dependency

### DIFF
--- a/clients/java/signalr/build.gradle
+++ b/clients/java/signalr/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     testCompile 'org.slf4j:slf4j-jdk14:1.7.25'
     implementation 'com.google.code.gson:gson:2.8.5'
     implementation 'com.squareup.okhttp3:okhttp:3.11.0'
-    api 'io.reactivex.rxjava2:rxjava:2.2.2'
+    api 'io.reactivex.rxjava2:rxjava:2.2.3'
     implementation 'org.slf4j:slf4j-api:1.7.25'
 }
 


### PR DESCRIPTION
RxJava 2.2.3 was released recently. Generally a good idea to keep our dependencies up to date.
[Release notes](https://github.com/ReactiveX/RxJava/releases/tag/v2.2.3)