### PR TITLE
Dispose WebSocket if StartAsync fails

### DIFF
--- a/src/Microsoft.AspNetCore.Http.Connections.Client/Internal/WebSocketsTransport.cs
+++ b/src/Microsoft.AspNetCore.Http.Connections.Client/Internal/WebSocketsTransport.cs
@@ -119,7 +119,15 @@ namespace Microsoft.AspNetCore.Http.Connections.Client.Internal
 
             Log.StartTransport(_logger, transferFormat, resolvedUrl);
 
-            await _webSocket.ConnectAsync(resolvedUrl, CancellationToken.None);
+            try
+            {
+                await _webSocket.ConnectAsync(resolvedUrl, CancellationToken.None);
+            }
+            catch
+            {
+                _webSocket.Dispose();
+                throw;
+            }
 
             Log.StartedTransport(_logger);
 


### PR DESCRIPTION
Fixes #3127 

Don't think we can test this since `_webSocket` is entirely internal and there is no way to check if it's disposed or not.