### PR TITLE
[Java] Change StreamItem to have items instead of results

### DIFF
--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/InvocationRequest.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/InvocationRequest.java
@@ -30,8 +30,8 @@ class InvocationRequest {
     }
 
     public void addItem(StreamItem streamItem) {
-        if (streamItem.getResult() != null) {
-            pendingCall.onNext(streamItem.getResult());
+        if (streamItem.getItem() != null) {
+            pendingCall.onNext(streamItem.getItem());
         }
     }
 

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/JsonHubProtocol.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/JsonHubProtocol.java
@@ -73,14 +73,12 @@ class JsonHubProtocol implements HubProtocol {
                             error = reader.nextString();
                             break;
                         case "result":
+                        case "item":
                             if (invocationId == null || binder.getReturnType(invocationId) == null) {
                                 resultToken = jsonParser.parse(reader);
                             } else {
                                 result = gson.fromJson(reader, binder.getReturnType(invocationId));
                             }
-                            break;
-                        case "item":
-                            reader.skipValue();
                             break;
                         case "arguments":
                             if (target != null) {

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/StreamItem.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/StreamItem.java
@@ -6,19 +6,19 @@ package com.microsoft.signalr;
 final class StreamItem extends HubMessage {
     private final int type = HubMessageType.STREAM_ITEM.value;
     private final String invocationId;
-    private final Object result;
+    private final Object item;
 
-    public StreamItem(String invocationId, Object result) {
+    public StreamItem(String invocationId, Object item) {
         this.invocationId = invocationId;
-        this.result = result;
+        this.item = item;
     }
 
     public String getInvocationId() {
         return invocationId;
     }
 
-    public Object getResult() {
-        return result;
+    public Object getItem() {
+        return item;
     }
 
     @Override

--- a/clients/java/signalr/src/test/java/com/microsoft/signalr/HubConnectionTest.java
+++ b/clients/java/signalr/src/test/java/com/microsoft/signalr/HubConnectionTest.java
@@ -388,7 +388,7 @@ class HubConnectionTest {
         assertFalse(completed.get());
         assertFalse(onNextCalled.get());
 
-        mockTransport.receiveMessage("{\"type\":2,\"invocationId\":\"1\",\"result\":\"First\"}" + RECORD_SEPARATOR);
+        mockTransport.receiveMessage("{\"type\":2,\"invocationId\":\"1\",\"item\":\"First\"}" + RECORD_SEPARATOR);
 
         assertTrue(onNextCalled.get());
 
@@ -416,7 +416,7 @@ class HubConnectionTest {
         assertFalse(completed.get());
         assertFalse(onNextCalled.get());
 
-        mockTransport.receiveMessage("{\"type\":2,\"invocationId\":\"1\",\"result\":\"First\"}" + RECORD_SEPARATOR);
+        mockTransport.receiveMessage("{\"type\":2,\"invocationId\":\"1\",\"item\":\"First\"}" + RECORD_SEPARATOR);
 
         assertTrue(onNextCalled.get());
 
@@ -446,7 +446,7 @@ class HubConnectionTest {
         assertFalse(onErrorCalled.get());
         assertFalse(onNextCalled.get());
 
-        mockTransport.receiveMessage("{\"type\":2,\"invocationId\":\"1\",\"result\":\"First\"}" + RECORD_SEPARATOR);
+        mockTransport.receiveMessage("{\"type\":2,\"invocationId\":\"1\",\"item\":\"First\"}" + RECORD_SEPARATOR);
 
         assertTrue(onNextCalled.get());
 
@@ -474,8 +474,8 @@ class HubConnectionTest {
         assertEquals("{\"type\":4,\"invocationId\":\"1\",\"target\":\"echo\",\"arguments\":[\"message\"]}" + RECORD_SEPARATOR, mockTransport.getSentMessages()[1]);
         assertFalse(completed.get());
 
-        mockTransport.receiveMessage("{\"type\":2,\"invocationId\":\"1\",\"result\":\"First\"}" + RECORD_SEPARATOR);
-        mockTransport.receiveMessage("{\"type\":2,\"invocationId\":\"1\",\"result\":\"Second\"}" + RECORD_SEPARATOR);
+        mockTransport.receiveMessage("{\"type\":2,\"invocationId\":\"1\",\"item\":\"First\"}" + RECORD_SEPARATOR);
+        mockTransport.receiveMessage("{\"type\":2,\"invocationId\":\"1\",\"item\":\"Second\"}" + RECORD_SEPARATOR);
         mockTransport.receiveMessage("{\"type\":3,\"invocationId\":\"1\",\"result\":\"null\"}" + RECORD_SEPARATOR);
 
         Iterator<String> resultIterator = result.timeout(1000, TimeUnit.MILLISECONDS).blockingIterable().iterator();
@@ -545,10 +545,10 @@ class HubConnectionTest {
 
         assertEquals("{\"type\":4,\"invocationId\":\"1\",\"target\":\"echo\",\"arguments\":[\"message\"]}" + RECORD_SEPARATOR, mockTransport.getSentMessages()[1]);
 
-        mockTransport.receiveMessage("{\"type\":2,\"invocationId\":\"1\",\"result\":\"First\"}" + RECORD_SEPARATOR);
+        mockTransport.receiveMessage("{\"type\":2,\"invocationId\":\"1\",\"item\":\"First\"}" + RECORD_SEPARATOR);
 
         subscription.dispose();
-        mockTransport.receiveMessage("{\"type\":2,\"invocationId\":\"1\",\"result\":\"Second\"}" + RECORD_SEPARATOR);
+        mockTransport.receiveMessage("{\"type\":2,\"invocationId\":\"1\",\"item\":\"Second\"}" + RECORD_SEPARATOR);
 
         assertEquals("First", result.timeout(1000, TimeUnit.MILLISECONDS).blockingLast());
     }
@@ -573,10 +573,10 @@ class HubConnectionTest {
         assertEquals("{\"type\":4,\"invocationId\":\"1\",\"target\":\"echo\",\"arguments\":[\"message\"]}" + RECORD_SEPARATOR, mockTransport.getSentMessages()[1]);
         assertFalse(completed.get());
 
-        mockTransport.receiveMessage("{\"type\":2,\"invocationId\":\"1\",\"result\":\"First\"}" + RECORD_SEPARATOR);
+        mockTransport.receiveMessage("{\"type\":2,\"invocationId\":\"1\",\"item\":\"First\"}" + RECORD_SEPARATOR);
 
         subscription.dispose();
-        mockTransport.receiveMessage("{\"type\":2,\"invocationId\":\"1\",\"result\":\"Second\"}" + RECORD_SEPARATOR);
+        mockTransport.receiveMessage("{\"type\":2,\"invocationId\":\"1\",\"item\":\"Second\"}" + RECORD_SEPARATOR);
 
         mockTransport.receiveMessage("{\"type\":3,\"invocationId\":\"1\"}" + RECORD_SEPARATOR);
         assertTrue(completed.get());

--- a/clients/java/signalr/src/test/java/com/microsoft/signalr/sample/Chat.java
+++ b/clients/java/signalr/src/test/java/com/microsoft/signalr/sample/Chat.java
@@ -7,6 +7,7 @@ import java.util.Scanner;
 
 import com.microsoft.signalr.HubConnection;
 import com.microsoft.signalr.HubConnectionBuilder;
+
 import io.reactivex.Observable;
 
 public class Chat {

--- a/clients/java/signalr/src/test/java/com/microsoft/signalr/sample/Chat.java
+++ b/clients/java/signalr/src/test/java/com/microsoft/signalr/sample/Chat.java
@@ -8,7 +8,6 @@ import java.util.Scanner;
 import com.microsoft.signalr.HubConnection;
 import com.microsoft.signalr.HubConnectionBuilder;
 
-import io.reactivex.Observable;
 
 public class Chat {
     public static void main(String[] args) {
@@ -39,10 +38,6 @@ public class Chat {
             // Scans the next token of the input as an int.
             message = reader.nextLine();
             hubConnection.send("Send", enteredName, message);
-            Observable<Integer> result = hubConnection.stream(Integer.class,"ObservableCounter", 10, 100);
-            result.subscribe((item) -> {
-                System.out.println(item);
-            });
         }
 
         hubConnection.stop();

--- a/clients/java/signalr/src/test/java/com/microsoft/signalr/sample/Chat.java
+++ b/clients/java/signalr/src/test/java/com/microsoft/signalr/sample/Chat.java
@@ -7,6 +7,7 @@ import java.util.Scanner;
 
 import com.microsoft.signalr.HubConnection;
 import com.microsoft.signalr.HubConnectionBuilder;
+import io.reactivex.Observable;
 
 public class Chat {
     public static void main(String[] args) {
@@ -37,6 +38,10 @@ public class Chat {
             // Scans the next token of the input as an int.
             message = reader.nextLine();
             hubConnection.send("Send", enteredName, message);
+            Observable<Integer> result = hubConnection.stream(Integer.class,"ObservableCounter", 10, 100);
+            result.subscribe((item) -> {
+                System.out.println(item);
+            });
         }
 
         hubConnection.stop();


### PR DESCRIPTION
The payload on `StreamItem` should be an "item" instead of a "result". This has serialization/deserialization implications when reading json payloads. 
https://github.com/aspnet/SignalR/issues/3316