### PR TITLE
[JAVA] Added read locks for hub connection states

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,5 @@ ipch/
 *.opendb
 *.db
 coverage/
+
+clients/java/signalr/local\.properties

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
@@ -17,7 +17,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock.ReadLock;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,7 +40,7 @@ public class HubConnection {
     private final CallbackMap handlers = new CallbackMap();
     private HubProtocol protocol;
     private Boolean handshakeReceived = false;
-    private volatile HubConnectionState hubConnectionState = HubConnectionState.DISCONNECTED;
+    private HubConnectionState hubConnectionState = HubConnectionState.DISCONNECTED;
     private final ReentrantReadWriteLock hubConnectionStateLock = new ReentrantReadWriteLock();
     private List<OnClosedCallback> onClosedCallbackList;
     private final boolean skipNegotiate;

--- a/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
+++ b/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
@@ -39,7 +39,7 @@ public class HubConnection {
     private final CallbackMap handlers = new CallbackMap();
     private HubProtocol protocol;
     private Boolean handshakeReceived = false;
-    private HubConnectionState hubConnectionState = HubConnectionState.DISCONNECTED;
+    private volatile HubConnectionState hubConnectionState = HubConnectionState.DISCONNECTED;
     private final Lock hubConnectionStateLock = new ReentrantLock();
     private List<OnClosedCallback> onClosedCallbackList;
     private final boolean skipNegotiate;


### PR DESCRIPTION
As mentioned in Issue #3329, reads of the connection state weren't synchronized. This PR adds a `ReentrantReadWriteLock` to `HubConnection.java`